### PR TITLE
ZONE module

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -32,6 +32,8 @@ type GlobalConf struct {
 	MetadataFilePath string
 
 	NamePrefix string
+
+	Module string
 }
 
 type Metadata struct {

--- a/conf.go
+++ b/conf.go
@@ -54,8 +54,8 @@ type Result struct {
 }
 
 type TargetedDomain struct {
-	Domain     string `json:"domain"`
-	Nameserver string `json:"nameserver"`
+	Domain      string   `json:"domain"`
+	Nameservers []string `json:"nameservers"`
 }
 
 type Status string

--- a/conf.go
+++ b/conf.go
@@ -53,6 +53,11 @@ type Result struct {
 	Data        interface{} `json:"data,omitempty"`
 }
 
+type TargetedDomain struct {
+	Domain     string `json:"domain"`
+	Nameserver string `json:"nameserver"`
+}
+
 type Status string
 
 const (

--- a/lookup.go
+++ b/lookup.go
@@ -90,13 +90,14 @@ func doLookup(g *GlobalLookupFactory, gc *GlobalConf, input <-chan string, outpu
 				log.Fatal("Internal Error: %s", err)
 			}
 		} else {
+			var changed bool
 			if gc.AlexaFormat == true {
 				rawName, rank = parseAlexa(line)
 				res.AlexaRank = rank
 			} else {
 				rawName = line
 			}
-			lookupName, changed := makeName(rawName, gc.NamePrefix)
+			lookupName, changed = makeName(rawName, gc.NamePrefix)
 			if changed {
 				res.AlteredName = lookupName
 			}
@@ -169,7 +170,11 @@ func doInput(in chan<- string, path string, wg *sync.WaitGroup, moduleType strin
 				if strings.Count(t.RR.Header().Name, ".") < 2 {
 					continue
 				}
-				targeted := TargetedDomain{t.RR.Header().Name, record.Ns}
+				name := t.RR.Header().Name
+				if name[len(name)-1] == '.' {
+					name = name[0 : len(name)-1]
+				}
+				targeted := TargetedDomain{name, record.Ns}
 				query, err := json.Marshal(targeted)
 				if err != nil {
 					log.Fatal("Internal Error: %s", err)

--- a/lookup.go
+++ b/lookup.go
@@ -83,7 +83,6 @@ func doLookup(g *GlobalLookupFactory, gc *GlobalConf, input <-chan string, outpu
 				res.AlteredName = prefixedName
 				targeted.Domain = prefixedName
 			}
-
 			query, err := json.Marshal(targeted)
 			lookupName = string(query)
 			if err != nil {
@@ -159,6 +158,7 @@ func doInput(in chan<- string, path string, wg *sync.WaitGroup, moduleType strin
 			log.Fatal("unable to open output file:", err.Error())
 		}
 	}
+	//TK caching
 	if moduleType == "ZONE" {
 		tokens := dns.ParseZone(f, ".", path)
 		for t := range tokens {
@@ -174,7 +174,7 @@ func doInput(in chan<- string, path string, wg *sync.WaitGroup, moduleType strin
 				if name[len(name)-1] == '.' {
 					name = name[0 : len(name)-1]
 				}
-				targeted := TargetedDomain{name, record.Ns}
+				targeted := TargetedDomain{name, []string{record.Ns}}
 				query, err := json.Marshal(targeted)
 				if err != nil {
 					log.Fatal("Internal Error: %s", err)

--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -16,6 +16,7 @@ package alookup
 
 import (
 	"flag"
+	"strings"
 
 	"github.com/miekg/dns"
 	"github.com/zmap/zdns"
@@ -53,20 +54,20 @@ func (s *Lookup) DoTargetedLookup(name, nameServer string) (interface{}, zdns.St
 		if status != zdns.STATUS_SUCCESS || err != nil {
 			return nil, status, err
 		}
-		names := map[string]bool{name: true}
+		names := map[string]bool{strings.ToLower(name): true}
 		searchSet := []miekg.Answer{}
 		searchSet = append(searchSet, miekgResult.(miekg.Result).Additional...)
 		searchSet = append(searchSet, miekgResult.(miekg.Result).Answers...)
 		for _, add := range searchSet {
 			if add.Type == "CNAME" {
-				if _, ok := names[add.Name]; ok {
-					names[add.Answer] = true
+				if _, ok := names[strings.ToLower(add.Name)]; ok {
+					names[strings.ToLower(add.Answer)] = true
 				}
 			}
 		}
 		for _, add := range searchSet {
 			if add.Type == dns.Type(dnsType).String() {
-				if _, ok := names[add.Name]; ok {
+				if _, ok := names[strings.ToLower(add.Name)]; ok {
 					if add.Type == dns.Type(dns.TypeA).String() {
 						res.IPv4Addresses = append(res.IPv4Addresses, add.Answer)
 					}

--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -36,6 +36,10 @@ type Lookup struct {
 
 func (s *Lookup) DoLookup(name string) (interface{}, zdns.Status, error) {
 	nameServer := s.Factory.Factory.RandomNameServer()
+	return s.DoTargetedLookup(name, nameServer)
+}
+
+func (s *Lookup) DoTargetedLookup(name, nameServer string) (interface{}, zdns.Status, error) {
 	requests := []uint16{}
 	if s.Factory.Factory.IPv6Lookup {
 		requests = append(requests, dns.TypeAAAA)

--- a/modules/zone/zone.go
+++ b/modules/zone/zone.go
@@ -1,0 +1,133 @@
+/*
+ * ZDNS Copyright 2016 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package zone
+
+import (
+	"errors"
+	"flag"
+	"log"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/miekg/dns"
+	"github.com/zmap/zdns"
+	"github.com/zmap/zdns/modules/miekg"
+)
+
+type Domain struct {
+	Name          string   `json:"name"`
+	IPv4Addresses []string `json:"ipv4_addresses,omitempty"`
+	IPv6Addresses []string `json:"ipv6_addresses,omitempty"`
+}
+
+type Result struct {
+	Subdomains []Domain `json:"subdomains"`
+}
+
+// Per Connection Lookup ======================================================
+//
+type Lookup struct {
+	Factory *RoutineLookupFactory
+	miekg.Lookup
+}
+
+func (s *Lookup) DoLookup(name string) (interface{}, zdns.Status, error) {
+	return nil, zdns.STATUS_SUCCESS, nil
+}
+
+// Per GoRoutine Factory ======================================================
+//
+type RoutineLookupFactory struct {
+	miekg.RoutineLookupFactory
+	Factory *GlobalLookupFactory
+}
+
+func (s *RoutineLookupFactory) MakeLookup() (zdns.Lookup, error) {
+	a := Lookup{Factory: s}
+	return &a, nil
+}
+
+// Global Factory =============================================================
+//
+type GlobalLookupFactory struct {
+	zdns.BaseGlobalLookupFactory
+	IPv4Lookup      bool
+	IPv6Lookup      bool
+	Subdomains      []string
+	SubdomainString string
+	Glue            *map[string][]string
+	GlueLock        sync.Mutex
+}
+
+func (s *GlobalLookupFactory) AddFlags(f *flag.FlagSet) {
+	f.BoolVar(&s.IPv4Lookup, "ipv4-lookup", true, "perform A lookups for each server")
+	f.BoolVar(&s.IPv6Lookup, "ipv6-lookup", true, "perform AAAA record lookups for each server")
+	f.StringVar(&s.SubdomainString, "subdomains", ",www", "specify which subdomains to search for (default \"\" and \"www\")")
+}
+
+func (s *GlobalLookupFactory) Initialize(c *zdns.GlobalConf) error {
+	s.GlobalConf = c
+	s.Subdomains = strings.Split(s.SubdomainString, ",")
+	if c.InputFilePath == "-" {
+		return errors.New("Input to ZONELOOKUP must be a file, not STDIN")
+	}
+	return s.ParseGlue(c.InputFilePath)
+}
+
+func (s *GlobalLookupFactory) ParseGlue(glueFile string) error {
+	f, err := os.Open(glueFile)
+	if err != nil {
+		log.Fatal("unable to open output file:", err.Error())
+	}
+	glue := make(map[string][]string)
+	s.Glue = &glue
+	tokens := dns.ParseZone(f, ".", glueFile)
+	for t := range tokens {
+		if t.Error != nil {
+			continue
+		}
+		switch record := t.RR.(type) {
+		case *dns.AAAA:
+			(*s.Glue)[t.RR.Header().Name] = append((*s.Glue)[t.RR.Header().Name], record.AAAA.String())
+		case *dns.A:
+			(*s.Glue)[t.RR.Header().Name] = append((*s.Glue)[t.RR.Header().Name], record.A.String())
+		default:
+			continue
+		}
+	}
+
+	return nil
+}
+
+// Command-line Help Documentation. This is the descriptive text what is
+// returned when you run zdns module --help
+func (s *GlobalLookupFactory) Help() string {
+	return ""
+}
+
+func (s *GlobalLookupFactory) MakeRoutineFactory() (zdns.RoutineLookupFactory, error) {
+	r := new(RoutineLookupFactory)
+	r.Factory = s
+	r.Initialize(s.GlobalConf.Timeout)
+	return r, nil
+}
+
+// Global Registration ========================================================
+//
+func init() {
+	s := new(GlobalLookupFactory)
+	zdns.RegisterLookup("ZONE", s)
+}

--- a/modules/zone/zone.go
+++ b/modules/zone/zone.go
@@ -27,14 +27,9 @@ import (
 	"github.com/zmap/zdns/modules/miekg"
 )
 
-type Domain struct {
-	Name          string   `json:"name"`
+type Result struct {
 	IPv4Addresses []string `json:"ipv4_addresses,omitempty"`
 	IPv6Addresses []string `json:"ipv6_addresses,omitempty"`
-}
-
-type Result struct {
-	Subdomains []Domain `json:"subdomains"`
 }
 
 // Per Connection Lookup ======================================================
@@ -64,25 +59,21 @@ func (s *RoutineLookupFactory) MakeLookup() (zdns.Lookup, error) {
 //
 type GlobalLookupFactory struct {
 	zdns.BaseGlobalLookupFactory
-	IPv4Lookup      bool
-	IPv6Lookup      bool
-	Subdomains      []string
-	SubdomainString string
-	Glue            *map[string][]string
-	GlueLock        sync.Mutex
+	IPv4Lookup bool
+	IPv6Lookup bool
+	Glue       *map[string][]string
+	GlueLock   sync.Mutex
 }
 
 func (s *GlobalLookupFactory) AddFlags(f *flag.FlagSet) {
 	f.BoolVar(&s.IPv4Lookup, "ipv4-lookup", true, "perform A lookups for each server")
 	f.BoolVar(&s.IPv6Lookup, "ipv6-lookup", true, "perform AAAA record lookups for each server")
-	f.StringVar(&s.SubdomainString, "subdomains", ",www", "specify which subdomains to search for (default \"\" and \"www\")")
 }
 
 func (s *GlobalLookupFactory) Initialize(c *zdns.GlobalConf) error {
 	s.GlobalConf = c
-	s.Subdomains = strings.Split(s.SubdomainString, ",")
 	if c.InputFilePath == "-" {
-		return errors.New("Input to ZONELOOKUP must be a file, not STDIN")
+		return errors.New("Input to ZONE must be a file, not STDIN")
 	}
 	return s.ParseGlue(c.InputFilePath)
 }

--- a/modules/zone/zone.go
+++ b/modules/zone/zone.go
@@ -39,9 +39,8 @@ func (s *Lookup) DoLookup(name string) (interface{}, zdns.Status, error) {
 	lookup, _ := s.Factory.Subfactory.MakeLookup()
 	var targeted zdns.TargetedDomain
 	json.Unmarshal([]byte(name), &targeted)
-	//nameServer := s.Factory.Factory.RandomNameServer()
-	return lookup.DoLookup(targeted.Domain)
-	//return lookup.(*alookup.Lookup).DoTargetedLookup(targeted.Domain, nameServer)
+	nameServer := s.Factory.Factory.RandomNameServer()
+	return lookup.(*alookup.Lookup).DoTargetedLookup(targeted.Domain, nameServer)
 }
 
 // Per GoRoutine Factory ======================================================

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -56,7 +56,8 @@ func main() {
 	if len(os.Args) < 2 {
 		log.Fatal("No lookup module specified. Valid modules: ", zdns.ValidlookupsString())
 	}
-	factory := zdns.GetLookup(strings.ToUpper(os.Args[1]))
+	gc.Module = strings.ToUpper(os.Args[1])
+	factory := zdns.GetLookup(gc.Module)
 	if factory == nil {
 		log.Fatal("Invalid lookup module specified. Valid modules: ", zdns.ValidlookupsString())
 	}

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/zmap/zdns/modules/ns"
 	_ "github.com/zmap/zdns/modules/spf"
 	_ "github.com/zmap/zdns/modules/txt"
+	_ "github.com/zmap/zdns/modules/zone"
 )
 
 func main() {


### PR DESCRIPTION
Performs ALOOKUP on all domains in a root zone file. This attempts to skip the first hop where possible, not hitting local or root DNS servers. It instead uses glue records and NS information in the root zone file to connect directly to the nameserver.

This is not general, and currently only works with ALOOKUP.
