### PR TITLE
Support IPv6 nameservers in resolv.conf & zone files

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -39,7 +39,7 @@ func GetDNSServers(path string) ([]string, error) {
 	}
 	var servers []string
 	for _, s := range c.Servers {
-		if strings.Contains(s, ":") {
+		if s[0:1] != "[" && strings.Contains(s, ":") {
 			s = "[" + s + "]"
 		}
 		full := strings.Join([]string{s, c.Port}, ":")

--- a/lookup.go
+++ b/lookup.go
@@ -39,6 +39,9 @@ func GetDNSServers(path string) ([]string, error) {
 	}
 	var servers []string
 	for _, s := range c.Servers {
+		if strings.Contains(s, ":") {
+			s = "[" + s + "]"
+		}
 		full := strings.Join([]string{s, c.Port}, ":")
 		servers = append(servers, full)
 	}

--- a/modules/zone/zone.go
+++ b/modules/zone/zone.go
@@ -78,6 +78,9 @@ func LookupHelper(domain string, nsIPs []string, lookup *alookup.Lookup) (interf
 	var status zdns.Status
 	var err error
 	for _, location := range nsIPs {
+		if location[0:1] != "[" && strings.Contains(location, ":") {
+			location = "[" + location + "]"
+		}
 		result, status, err = lookup.DoTargetedLookup(domain, location+":53")
 		if status == zdns.STATUS_NOERROR && err == nil {
 			return result, status, err


### PR DESCRIPTION
This fixes the following error when IPv6 nameservers are found in the resolv.conf file or zone files:
```
{"name":"example.com","status":"ERROR","error":"dial udp: too many colons in address 2001:4860:4860::8888:53"}
```

For command-line specification of IPv6 nameservers, these need to have the brackets applied manually, since otherwise it would difficult to disambiguate the address from the port:
```
-nameservers [2001:4860:4860::8888]:53
```