### PR TITLE
Allow 'zdns -h' to work even without a lookup module

### DIFF
--- a/zdns/main.go
+++ b/zdns/main.go
@@ -67,6 +67,7 @@ func main() {
 	gc.Module = strings.ToUpper(os.Args[1])
 	factory := zdns.GetLookup(gc.Module)
 	if factory == nil {
+		flags.Parse(os.Args[1:])
 		log.Fatal("Invalid lookup module specified. Valid modules: ", zdns.ValidlookupsString())
 	}
 	factory.AddFlags(flags)


### PR DESCRIPTION
This is a mild hack. What it does is it adds flag parsing on the failure
path when no valid module is found. The flag parsing will find the "-h"
and print the default usage, terminating the program before hitting
the log.Fatal(). If no -h is supplied it falls through the flag parse
and hits the log.Fatal() as it did previously.