### PR TITLE
Properly handle all dns RR types returned by miekg

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ You can control the number of concurrent connections with the `--threads` and
 specified with `--name-servers`. ZDNS will rotate through these servers when
 making requests.
 
+Unsupported Types
+------------
+If zdns encounters a record type it does not support it will generate an output
+record with the `type` field set correctly and a representation of the
+underlying data structure in the `unparsed_rr` field. Do not rely on the
+presence or structure of this field. This field (and its existence) may change
+at any time as we expand support for additional record types. If you find
+yourself using this field, please consider submitting a pull-request adding
+parser support.
 
 License
 =======

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -123,11 +123,13 @@ func ParseAnswer(ans dns.RR) interface{} {
 			Expire:  soa.Expire,
 			Minttl:  soa.Minttl,
 		}
-	} else if any, ok := ans.(*dns.ANY); ok {
+	} else {
 		return struct {
-			Type string
+			Type string `json:"type"`
+			Unparsed dns.RR `json:"unparsed_rr"`
 		}{
-			Type: dns.Type(any.Hdr.Rrtype).String(),
+			Type: dns.Type(ans.Header().Rrtype).String(),
+			Unparsed: ans,
 		}
 	}
 	retv.Name = strings.TrimSuffix(retv.Name, ".")


### PR DESCRIPTION
Previously, types unsupported by zdns could be returned via:
-ANY requests
-Resolvers being jerks

If zdns encountered such a record, it would generate an empty answer
as  if..else if... clause lacked an else.

Example:
```
$ echo "example.com" | ./zdns ANY | jq "."
{
  "data": {
    "protocol": "tcp",
    "authorities": [],
    "additionals": [],
    "answers": [
      {
        "min_ttl": 3600,
        "expire": 1209600,
        "ttl": 3580,
        "type": "SOA",
        "name": "example.com.",
        "ns": "sns.dns.icann.org",
        "mbox": "noc.dns.icann.org.",
        "serial": 2016110728,
        "refresh": 7200,
        "retry": 3600
      },
      {},
      {},
      {},
      {
        "answer": "a.iana-servers.net.",
        "name": "example.com",
        "type": "NS",
        "ttl": 86380
      },
      {
        "answer": "b.iana-servers.net.",
        "name": "example.com",
        "type": "NS",
        "ttl": 86380
      },
      {},
      {
        "answer": "2606:2800:220:1:248:1893:25c8:1946",
        "name": "example.com",
        "type": "AAAA",
        "ttl": 86380
      },
      {},
      {
        "answer": "93.184.216.34",
        "name": "example.com",
        "type": "A",
        "ttl": 86380
      },
      {},
      {
        "answer": "v=spf1 -all",
        "name": "example.com",
        "type": "TXT",
        "ttl": 40
      },
      {
        "answer": "$Id: example.com 4415 2015-08-24 20:12:23Z davids $",
        "name": "example.com",
        "type": "TXT",
        "ttl": 40
      },
      {},
      {},
      {},
      {},
      {},
      {}
    ]
  },
  "status": "NOERROR",
  "name": "example.com"
}
```

All empty answers are types miekg understands that zdns does not.

This commit adds a new return struct with 2 fields, 'type' which conforms
to the type field used in the rest of zdns, as well as 'unparsed_rr' which is
the miekg represenation of the data.

The ANY clause was removed, as ANY is not a valid response type (it has no
data) and even if it was returned, it would now get caught by the new else
clause. Example new output:

```
$ echo "example.com" | ./zdns ANY | jq "."
{
  "data": {
    "protocol": "tcp",
    "authorities": [],
    "additionals": [],
    "answers": [
      {
        "min_ttl": 3600,
        "expire": 1209600,
        "ttl": 3543,
        "type": "SOA",
        "name": "example.com.",
        "ns": "sns.dns.icann.org",
        "mbox": "noc.dns.icann.org.",
        "serial": 2016110728,
        "refresh": 7200,
        "retry": 3600
      },
      {
        "unparsed_rr": {
          "Signature": "t+9IofuHl8EnnymaTAeeGNKFfe5Bv3zKT2QS43ZKyUCB46aiL5zr+Bb7MZqajQpAc232118+RzQY6ir6Z0e+92u9/FkN3epBKovsGtZsQj5EUb9KoG0Gs1b65Ni7HI0ftbL9/1tY8VlavNEWr3louE0iec5waWjbsKqF/9mD7Jw+KZA=",
          "SignerName": "example.com.",
          "Hdr": {
            "Rdlength": 162,
            "Ttl": 3543,
            "Class": 1,
            "Rrtype": 46,
            "Name": "example.com."
          },
          "TypeCovered": 47,
          "Algorithm": 8,
          "Labels": 2,
          "OrigTtl": 3600,
          "Expiration": 1484226120,
          "Inception": 1482420723,
          "KeyTag": 59901
        },
        "type": "RRSIG"
      },
      {
        "unparsed_rr": {
          "TypeBitMap": [
            1,
            2,
            6,
            16,
            28,
            46,
            47,
            48
          ],
          "NextDomain": "www.example.com.",
          "Hdr": {
            "Rdlength": 26,
            "Ttl": 3543,
            "Class": 1,
            "Rrtype": 47,
            "Name": "example.com."
          }
        },
        "type": "NSEC"
      },
      {
        "unparsed_rr": {
          "Signature": "XmofSizbD3epC0UXOhQetkbRYIp9PmRPmSEwvNxun50X1z9WCd30N+Hueu+pfz9kN6ywG2VXpPGyfplV1ApTdRq2FCY1NI9pn+fXWOomAjdqIQN2K7RvvoiIicmOOdYx2Lwx9QWOh8QKJWy5/n9qDWPlzq1tHgVngowbVXKNjITwiSM=",
          "SignerName": "example.com.",
          "Hdr": {
            "Rdlength": 162,
            "Ttl": 86343,
            "Class": 1,
            "Rrtype": 46,
            "Name": "example.com."
          },
          "TypeCovered": 2,
          "Algorithm": 8,
          "Labels": 2,
          "OrigTtl": 86400,
          "Expiration": 1484180042,
          "Inception": 1482377523,
          "KeyTag": 59901
        },
        "type": "RRSIG"
      },
      {
        "answer": "b.iana-servers.net.",
        "name": "example.com",
        "type": "NS",
        "ttl": 86343
      },
      {
        "answer": "a.iana-servers.net.",
        "name": "example.com",
        "type": "NS",
        "ttl": 86343
      },
      {
        "unparsed_rr": {
          "Signature": "peXGcZxTy1bDi9NUTl1nFYFUPV3o4vGNFzQMA2ED//IGrtX9DEhFRCk5il/1gAZerzt0hwd4r8PRrVB51JlhKZ82kU6Rx39j8Y9opqEnhvDe0Q28K9D/9C4UC+7gl9ucAKW28gQbYNpuExpD5max5+9d3S22rL5vaSwVUICbfWEoOFI=",
          "SignerName": "example.com.",
          "Hdr": {
            "Rdlength": 162,
            "Ttl": 86343,
            "Class": 1,
            "Rrtype": 46,
            "Name": "example.com."
          },
          "TypeCovered": 28,
          "Algorithm": 8,
          "Labels": 2,
          "OrigTtl": 86400,
          "Expiration": 1484328852,
          "Inception": 1482485523,
          "KeyTag": 59901
        },
        "type": "RRSIG"
      },
      {
        "answer": "2606:2800:220:1:248:1893:25c8:1946",
        "name": "example.com",
        "type": "AAAA",
        "ttl": 86343
      },
      {
        "unparsed_rr": {
          "Signature": "KZBOeiJPEd55HPdOBtUWcSt+nBgnPXyE2tZSJ+kh1q+00LJacat4juy/RZXhcVpsI8tQhKMr1YHtD21d9glt8SdjfKMxPcO1URLREeB/IPIgEoR7dO8r4gno8+sOxmz/FUhVcGSoU4egMlSKDJE0C4g3+TAnumP+gHn2j1LIG2rcIKc=",
          "SignerName": "example.com.",
          "Hdr": {
            "Rdlength": 162,
            "Ttl": 86343,
            "Class": 1,
            "Rrtype": 46,
            "Name": "example.com."
          },
          "TypeCovered": 1,
          "Algorithm": 8,
          "Labels": 2,
          "OrigTtl": 86400,
          "Expiration": 1484187438,
          "Inception": 1482355923,
          "KeyTag": 59901
        },
        "type": "RRSIG"
      },
      {
        "answer": "93.184.216.34",
        "name": "example.com",
        "type": "A",
        "ttl": 86343
      },
      {
        "unparsed_rr": {
          "Signature": "vMqxnOAG1MdxzSUqLtWX+hQmpCqElkjUcmmOa6E7SlvrFYganiKzkJW+7gFkJioBqvlJwels/4SvytiNGkQnbCriNmwDT3/Yl8rHIHLTXewoRCAPahOL5DOBLwORx5/aj6ZPoHXjpf4XVU89kVUSW+D+xrjxdrmupOM+jBoHllHXfa8=",
          "SignerName": "example.com.",
          "Hdr": {
            "Rdlength": 162,
            "Ttl": 3,
            "Class": 1,
            "Rrtype": 46,
            "Name": "example.com."
          },
          "TypeCovered": 16,
          "Algorithm": 8,
          "Labels": 2,
          "OrigTtl": 60,
          "Expiration": 1484314180,
          "Inception": 1482471123,
          "KeyTag": 59901
        },
        "type": "RRSIG"
      },
      {
        "answer": "$Id: example.com 4415 2015-08-24 20:12:23Z davids $",
        "name": "example.com",
        "type": "TXT",
        "ttl": 3
      },
      {
        "answer": "v=spf1 -all",
        "name": "example.com",
        "type": "TXT",
        "ttl": 3
      },
      {
        "unparsed_rr": {
          "Signature": "c8W9xAQmnKuEQ994gOPFz59aXhJgVHlvJ5rS9Eg/SrRfOCA+7HCqanneDZOjpL0uY7NxeB1IPcQptwaxUGANbVG08UnYziC1lgljAqxB0xpTQo9c6mqBomYj+hPVDBwEWXHzGwCcBjQyGEf4LvwPzSaCmsAgDZFPu3AC0QIxOkYFWD3ua3S1YF/6fh9pqVD0m9xBa1OaHSwdanWzr4lXcRj9sCu2OOrOcxiWYtklj3eaYPU1zSjZfK7Tlrbgd8K82i3+A6xJNuC+k6+0MkTWqzizL51k2BYpQkJx59uZGAFqEfsmVWdlFx/NAjiNFKMWapKtnLJ9oRlxUUCcJxAC2Q==",
          "SignerName": "example.com.",
          "Hdr": {
            "Rdlength": 287,
            "Ttl": 3543,
            "Class": 1,
            "Rrtype": 46,
            "Name": "example.com."
          },
          "TypeCovered": 48,
          "Algorithm": 8,
          "Labels": 2,
          "OrigTtl": 3600,
          "Expiration": 1484365631,
          "Inception": 1482550323,
          "KeyTag": 31406
        },
        "type": "RRSIG"
      },
      {
        "unparsed_rr": {
          "Signature": "ZaTmB0s8Tn9u6Y0x9KuGmk5G/wb5cBvMDmYldFkBvOlNBjaAj2+GaqOJhy05oVeX1yUUeLoMfr2Kbs/jKkv8M/nDfMKylzKNybCXELR5ZrIzvDO6C/r8yUPO4EKlxMCarlyAOQpmJMe+lA5zGpio+PFRVH/eUtj8/yVmPwpfhW5mqRNmbEnI+JsfXuUiMuc7K4dVZumyPAlNAlqpdyl2kO7Nm2rF19HORt4E/ueshrXThyv9QOUTCoH18o7zjlsDng3aXiU6Pld3ccgKwlGcBdlesIwHqnE+Bfau2cv+Vd+nhjtparw1MOM/EbWN9D3Lzs1TGXFpJQqcd2S8ZnqLmw==",
          "SignerName": "example.com.",
          "Hdr": {
            "Rdlength": 287,
            "Ttl": 3543,
            "Class": 1,
            "Rrtype": 46,
            "Name": "example.com."
          },
          "TypeCovered": 48,
          "Algorithm": 8,
          "Labels": 2,
          "OrigTtl": 3600,
          "Expiration": 1484365631,
          "Inception": 1482550323,
          "KeyTag": 45620
        },
        "type": "RRSIG"
      },
      {
        "unparsed_rr": {
          "PublicKey": "AwEAAZ0aqu1rJ6orJynrRfNpPmayJZoAx9Ic2/Rl9VQWLMHyjxxem3VUSoNUIFXERQbj0A9Ogp0zDM9YIccKLRd6LmWiDCt7UJQxVdD+heb5Ec4qlqGmyX9MDabkvX2NvMwsUecbYBq8oXeTT9LRmCUt9KUt/WOi6DKECxoG/bWTykrXyBR8elD+SQY43OAVjlWrVltHxgp4/rhBCvRbmdflunaPIgu27eE2U4myDSLT8a4A0rB5uHG4PkOa9dIRs9y00M2mWf4lyPee7vi5few2dbayHXmieGcaAHrx76NGAABeY393xjlmDNcUkF1gpNWUla4fWZbbaYQzA93mLdrng+M=",
          "Algorithm": 8,
          "Protocol": 3,
          "Flags": 257,
          "Hdr": {
            "Rdlength": 264,
            "Ttl": 3543,
            "Class": 1,
            "Rrtype": 48,
            "Name": "example.com."
          }
        },
        "type": "DNSKEY"
      },
      {
        "unparsed_rr": {
          "PublicKey": "AwEAAbOFAxl+Lkt0UMglZizKEC1AxUu8zlj65KYatR5wBWMrh18TYzK/ig6Y1t5YTWCO68bynorpNu9fqNFALX7bVl9/gybA0v0EhF+dgXmoUfRX7ksMGgBvtfa2/Y9a3klXNLqkTszIQ4PEMVCjtryl19Be9/PkFeC9ITjgMRQsQhmB39eyMYnal+f3bUxKk4fq7cuEU0dbRpue4H/N6jPucXWOwiMAkTJhghqgy+o9FfIp+tR/emKao94/wpVXDcPf5B18j7xz2SvTTxiuqCzCMtsxnikZHcoh1j4g+Y1B8zIMIvrEM+pZGhh/Yuf4RwCBgaYCi9hpiMWVvS4WBzx0/lU=",
          "Algorithm": 8,
          "Protocol": 3,
          "Flags": 257,
          "Hdr": {
            "Rdlength": 264,
            "Ttl": 3543,
            "Class": 1,
            "Rrtype": 48,
            "Name": "example.com."
          }
        },
        "type": "DNSKEY"
      },
      {
        "unparsed_rr": {
          "PublicKey": "AwEAAdCUv+suuM/Fb7we3JdnSW3c1WvZRKX876JJwlt26X/SRw+6HbglozqPpgcLcBafYvVhSkp3SGsowambFFgoxP7WekjRtVqHHxWkQ5l8lcGFFCuoiKGxgXallcWgjwd+OYv1pf5OTk1nFWnvzgsEj8TdCPMdDHuf74TX4VJowD10gxmb",
          "Algorithm": 8,
          "Protocol": 3,
          "Flags": 256,
          "Hdr": {
            "Rdlength": 139,
            "Ttl": 3543,
            "Class": 1,
            "Rrtype": 48,
            "Name": "example.com."
          }
        },
        "type": "DNSKEY"
      },
      {
        "unparsed_rr": {
          "Signature": "fuRKdRFVtEVBZIIrtxzX61nQ5olDDVITFjMOa8JUohr+j+sPsX91gZAJTzHE/+HGb5kPuHF87O88YQCqLvWhJfmTWDgixUoz+E+YYeNF23QcDnNZbwR3eTRUfvV8CoyzvmzAsqoeOd4DfXLYPyvqtRTUhrES+RY/EvBvMY5dzhcIb60=",
          "SignerName": "example.com.",
          "Hdr": {
            "Rdlength": 162,
            "Ttl": 3543,
            "Class": 1,
            "Rrtype": 46,
            "Name": "example.com."
          },
          "TypeCovered": 6,
          "Algorithm": 8,
          "Labels": 2,
          "OrigTtl": 3600,
          "Expiration": 1484326851,
          "Inception": 1482550323,
          "KeyTag": 59901
        },
        "type": "RRSIG"
      }
    ]
  },
  "status": "NOERROR",
  "name": "example.com"
}
```