### PR TITLE
Add the SERVFAIL const.

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -64,6 +64,7 @@ type Status string
 const (
 	STATUS_NOERROR       Status = "NOERROR"
 	STATUS_ERROR         Status = "ERROR"
+	STATUS_SERVFAIL      Status = "SERVFAIL"
 	STATUS_NO_RECORD     Status = "NORECORD"
 	STATUS_BLACKLIST     Status = "BLACKLIST"
 	STATUS_NO_OUTPUT     Status = "NO_OUTPUT"


### PR DESCRIPTION
Although this is not used in the existing codebase, the SERVFAIL
const is frequenly returned via:
https://github.com/zmap/zdns/blob/master/modules/miekg/miekg.go#L179

Without this you have to do awkward things mix zdns.status... and strings