### PR TITLE
Change default timeout value from 10s to 15s

### DIFF
--- a/zdns/main.go
+++ b/zdns/main.go
@@ -59,7 +59,7 @@ func main() {
 	flags.IntVar(&gc.Verbosity, "verbosity", 3, "log verbosity: 1 (lowest)--5 (highest)")
 	servers_string := flags.String("name-servers", "", "comma-delimited list of DNS servers to use")
 	config_file := flags.String("conf-file", "/etc/resolv.conf", "config file for DNS servers")
-	timeout := flags.Int("timeout", 10, "timeout for resolving an individual name")
+	timeout := flags.Int("timeout", 15, "timeout for resolving an individual name")
 	// allow module to initialize and add its own flags before we parse
 	if len(os.Args) < 2 {
 		log.Fatal("No lookup module specified. Valid modules: ", zdns.ValidlookupsString())


### PR DESCRIPTION
The BIND default timeout value is 10s. If zdns also uses a value
of 10s you get zdns timeouts when a few ms later BIND returns a
SERVFAIL. Depending on thread scheduling etc, authoritative
timeouts become a mix of TIMEOUT and SERVFAIL. This results
in overall sadness.