### PR TITLE
Add the option of including a timestamp in every output json

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -51,7 +51,7 @@ type Result struct {
 	AlexaRank   int         `json:"alexa_rank,omitempty"`
 	Status      string      `json:"status,omitempty"`
 	Error       string      `json:"error,omitempty"`
-	Timestamp   time.Time   `json:"timestamp"`
+	Timestamp   string      `json:"timestamp,omitempty"`
 	Data        interface{} `json:"data,omitempty"`
 }
 

--- a/conf.go
+++ b/conf.go
@@ -17,12 +17,11 @@ package zdns
 import "time"
 
 type GlobalConf struct {
-	Threads      int
-	Timeout      time.Duration
-	AlexaFormat  bool
-	LogTimestamp bool
-	GoMaxProcs   int
-	Verbosity    int
+	Threads     int
+	Timeout     time.Duration
+	AlexaFormat bool
+	GoMaxProcs  int
+	Verbosity   int
 
 	NameServersSpecified bool
 	NameServers          []string
@@ -52,7 +51,7 @@ type Result struct {
 	AlexaRank   int         `json:"alexa_rank,omitempty"`
 	Status      string      `json:"status,omitempty"`
 	Error       string      `json:"error,omitempty"`
-	Timestamp   *time.Time  `json:"timestamp,omitempty"`
+	Timestamp   time.Time   `json:"timestamp"`
 	Data        interface{} `json:"data,omitempty"`
 }
 

--- a/conf.go
+++ b/conf.go
@@ -17,11 +17,12 @@ package zdns
 import "time"
 
 type GlobalConf struct {
-	Threads     int
-	Timeout     time.Duration
-	AlexaFormat bool
-	GoMaxProcs  int
-	Verbosity   int
+	Threads      int
+	Timeout      time.Duration
+	AlexaFormat  bool
+	LogTimestamp bool
+	GoMaxProcs   int
+	Verbosity    int
 
 	NameServersSpecified bool
 	NameServers          []string
@@ -51,6 +52,7 @@ type Result struct {
 	AlexaRank   int         `json:"alexa_rank,omitempty"`
 	Status      string      `json:"status,omitempty"`
 	Error       string      `json:"error,omitempty"`
+	Timestamp   *time.Time  `json:"timestamp,omitempty"`
 	Data        interface{} `json:"data,omitempty"`
 }
 

--- a/lookup.go
+++ b/lookup.go
@@ -111,6 +111,10 @@ func doLookup(g *GlobalLookupFactory, gc *GlobalConf, input <-chan interface{}, 
 			res.Name = rawName
 			innerRes, status, err = l.DoLookup(lookupName)
 		}
+		if gc.LogTimestamp {
+			now := time.Now()
+			res.Timestamp = &now
+		}
 		if status != STATUS_NO_OUTPUT {
 			res.Status = string(status)
 			res.Data = innerRes

--- a/lookup.go
+++ b/lookup.go
@@ -111,7 +111,7 @@ func doLookup(g *GlobalLookupFactory, gc *GlobalConf, input <-chan interface{}, 
 			res.Name = rawName
 			innerRes, status, err = l.DoLookup(lookupName)
 		}
-		res.Timestamp = time.Now()
+		res.Timestamp = time.Now().Format(time.RFC3339)
 		if status != STATUS_NO_OUTPUT {
 			res.Status = string(status)
 			res.Data = innerRes

--- a/lookup.go
+++ b/lookup.go
@@ -111,10 +111,7 @@ func doLookup(g *GlobalLookupFactory, gc *GlobalConf, input <-chan interface{}, 
 			res.Name = rawName
 			innerRes, status, err = l.DoLookup(lookupName)
 		}
-		if gc.LogTimestamp {
-			now := time.Now()
-			res.Timestamp = &now
-		}
+		res.Timestamp = time.Now()
 		if status != STATUS_NO_OUTPUT {
 			res.Status = string(status)
 			res.Data = innerRes

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -52,6 +52,7 @@ func main() {
 	flags.IntVar(&gc.GoMaxProcs, "go-processes", 0, "number of OS processes (GOMAXPROCS)")
 	flags.StringVar(&gc.NamePrefix, "prefix", "", "name to be prepended to what's passed in (e.g., www.)")
 	flags.BoolVar(&gc.AlexaFormat, "alexa", false, "is input file from Alexa Top Million download")
+	flags.BoolVar(&gc.LogTimestamp, "timestamp", false, "include a timestamp in each JSON output")
 	flags.StringVar(&gc.InputFilePath, "input-file", "-", "names to read")
 	flags.StringVar(&gc.OutputFilePath, "output-file", "-", "where should JSON output be saved")
 	flags.StringVar(&gc.MetadataFilePath, "metadata-file", "", "where should JSON metadata be saved")

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -52,7 +52,6 @@ func main() {
 	flags.IntVar(&gc.GoMaxProcs, "go-processes", 0, "number of OS processes (GOMAXPROCS)")
 	flags.StringVar(&gc.NamePrefix, "prefix", "", "name to be prepended to what's passed in (e.g., www.)")
 	flags.BoolVar(&gc.AlexaFormat, "alexa", false, "is input file from Alexa Top Million download")
-	flags.BoolVar(&gc.LogTimestamp, "timestamp", false, "include a timestamp in each JSON output")
 	flags.StringVar(&gc.InputFilePath, "input-file", "-", "names to read")
 	flags.StringVar(&gc.OutputFilePath, "output-file", "-", "where should JSON output be saved")
 	flags.StringVar(&gc.MetadataFilePath, "metadata-file", "", "where should JSON metadata be saved")


### PR DESCRIPTION
Adds `--timestamp` which will include a golang time.Time in every
output object. If ``--timestamp` is not set, the field is omitted.

Usage:
```
$ echo "example.com" | ./zdns A
{"name":"example.com","status":"NOERROR","data":{"answers":[{"ttl":49854,"type":"A","name":"example.com","answer":"93.184.216.34"}],"additionals":[],"authorities":[],"protocol":"udp"}}
```

```
$ echo "example.com" | ./zdns A --timestamp
{"name":"example.com","status":"NOERROR","timestamp":"2017-01-09T17:05:54.706439267-08:00","data":{"answers":[{"ttl":49626,"type":"A","name":"example.com","answer":"93.184.216.34"}],"additionals":[],"authorities":[],"protocol":"udp"}}
```

Let me answer some questions you're going to ask.

* Paul, why did you make `Timestamp` of type `*time.Time` instead of `time.Time`
  * Because `time.Time` can not be `empty`, meaning `omitempty` does not work right
* Paul, why do you create a variable and then take it's address (`now`) instead of just taking the address of `time.Now()`
  * Because that goes against the spec, despite the fact that `time.Now()` can't return `nil`
* Paul,  why are you doing this in doLookup() instead of miekg.DoLookup(), which would be closer to the wire time. 
  * Because the config information is not passed that deep into the depths of zdns.