### PR TITLE
Restore support for PTR queries

### DIFF
--- a/integration_tests.py
+++ b/integration_tests.py
@@ -104,7 +104,7 @@ class Tests(unittest.TestCase):
       }
     }
 
-    ALOOKUP_WWW_ZDNS_TESTING = {
+    A_LOOKUP_WWW_ZDNS_TESTING = {
       u"name": u"www.zdns-testing.com",
       u"status": u"NOERROR",
       u"data": {
@@ -120,6 +120,13 @@ class Tests(unittest.TestCase):
         ]
       }
     }
+
+    PTR_LOOKUP_GOOGLE_PUB = [{
+        "type":"PTR",
+        "name":"8.8.8.8.in-addr.arpa",
+        "answer":"google-public-dns-a.google.com."
+        }
+    ]
 
     CAA_RECORD = [
       {
@@ -237,15 +244,28 @@ class Tests(unittest.TestCase):
         name = u"www.zdns-testing.com"
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd)
-        self.assertEqualALookup(res, self.ALOOKUP_WWW_ZDNS_TESTING)
+        self.assertEqualALookup(res, self.A_LOOKUP_WWW_ZDNS_TESTING)
 
     def test_a_lookup_iterative(self):
         c = u"./zdns/zdns alookup --ipv4-lookup --ipv6-lookup --iterative"
         name = u"www.zdns-testing.com"
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd)
-        self.assertEqualALookup(res, self.ALOOKUP_WWW_ZDNS_TESTING)
+        self.assertEqualALookup(res, self.A_LOOKUP_WWW_ZDNS_TESTING)
 
+    def test_ptr(self):
+        c = u"./zdns/zdns PTR"
+        name = u"8.8.8.8"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd)
+        self.assertEqualAnswers(res, self.PTR_LOOKUP_GOOGLE_PUB, cmd)
+
+    def test_ptr_iterative(self):
+        c = u"./zdns/zdns PTR --iterative"
+        name = u"8.8.8.8"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd)
+        self.assertEqualAnswers(res, self.PTR_LOOKUP_GOOGLE_PUB, cmd)
 
 if __name__ == '__main__':
     unittest.main()

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -450,6 +450,17 @@ func (s *Lookup) cacheUpdate(layer string, result Result, depth int) {
 
 func (s *Lookup) retryingLookup(dnsType uint16, name string, nameServer string, recursive bool) (Result, zdns.Status, error) {
 	s.VerboseLog(1, "****WIRE LOOKUP***", name, " ", nameServer)
+
+	if dnsType == dns.TypePTR {
+		var err error
+		name, err = dns.ReverseAddr(name)
+		if err != nil {
+			var r Result
+			return r, zdns.STATUS_ILLEGAL_INPUT, err
+		}
+		name = name[:len(name)-1]
+	}
+
 	origTimeout := s.Factory.Client.Timeout
 	for i := 0; i < s.Factory.Retries; i++ {
 		result, status, err := s.doLookup(dnsType, name, nameServer, recursive)


### PR DESCRIPTION
1) Restores support for PTR queries. Yay.

2) Adds unit tests for PTR queries. Yay.

Turns out unit tests can't help you identify when support for an entire class of queries vanishes, if you also forget to write a unit test for that class of queries.