### PR TITLE
Rudimentary support for iterative trace

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -23,6 +23,7 @@ type GlobalConf struct {
 	Retries             int
 	AlexaFormat         bool
 	IterativeResolution bool
+	Trace               bool
 	MaxDepth            int
 	CacheSize           int
 	GoMaxProcs          int

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -76,7 +76,7 @@ type Trace struct {
 	DnsClass   uint16 `json:"class"`
 	Name       string `json:"name"`
 	NameServer string `json:"name_server"`
-	Depth      int    `json:"cached"`
+	Depth      int    `json:"depth"`
 	Layer      string `json:"layer"`
 	Cached     bool   `json:"cached"`
 }

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -67,6 +67,18 @@ type Result struct {
 	Authorities []interface{} `json:"authorities"`
 	Protocol    string        `json:"protocol"`
 	Flags       DNSFlags      `json:"flags"`
+	Trace       []Trace       `json:"trace,omitempty"`
+}
+
+type Trace struct {
+	Result     Result `json:"results"`
+	DnsType    uint16 `json:"type"`
+	DnsClass   uint16 `json:"class"`
+	Name       string `json:"name"`
+	NameServer string `json:"name_server"`
+	Depth      int    `json:"cached"`
+	Layer      string `json:"layer"`
+	Cached     bool   `json:"cached"`
 }
 
 type TimedAnswer struct {
@@ -322,6 +334,7 @@ type RoutineLookupFactory struct {
 	Timeout             time.Duration
 	IterativeTimeout    time.Duration
 	IterativeResolution bool
+	Trace               bool
 	DNSType             uint16
 	DNSClass            uint16
 	ThreadID            int
@@ -345,6 +358,7 @@ func (s *RoutineLookupFactory) Initialize(c *zdns.GlobalConf) {
 	s.Retries = c.Retries
 	s.MaxDepth = c.MaxDepth
 	s.IterativeResolution = c.IterativeResolution
+	s.Trace = c.Trace
 
 	s.DNSClass = c.Class
 }
@@ -510,17 +524,19 @@ func (s *Lookup) retryingLookup(dnsType uint16, dnsClass uint16, name string, na
 	panic("loop must return")
 }
 
-func (s *Lookup) cachedRetryingLookup(dnsType uint16, dnsClass uint16, name string, nameServer string, layer string, depth int) (Result, zdns.Status, error) {
+func (s *Lookup) cachedRetryingLookup(dnsType uint16, dnsClass uint16, name string, nameServer string, layer string, depth int) (Result, zdns.Status, error, bool) {
+	isCached := false
 	s.VerboseLog(depth+1, "Cached retrying lookup. Name: ", name, ", Layer: ", layer, ", Nameserver: ", nameServer)
 	if s.IterativeStop.Before(time.Now()) {
 		s.VerboseLog(depth+2, "ITERATIVE_TIMEOUT ", name, ", Layer: ", layer, ", Nameserver: ", nameServer)
 		var r Result
-		return r, zdns.STATUS_ITER_TIMEOUT, nil
+		return r, zdns.STATUS_ITER_TIMEOUT, nil, isCached
 	}
 	// First, we check the answer
 	cachedResult, ok := s.Factory.Factory.GetCachedResult(name, dnsType, dnsType, depth+1, s.Factory.ThreadID)
 	if ok {
-		return cachedResult, zdns.STATUS_NOERROR, nil
+		isCached = true
+		return cachedResult, zdns.STATUS_NOERROR, nil, isCached
 	}
 	// Now, we check the authoritative:
 	name = strings.ToLower(name)
@@ -530,12 +546,12 @@ func (s *Lookup) cachedRetryingLookup(dnsType uint16, dnsClass uint16, name stri
 		if authName == "" {
 			s.VerboseLog(depth+2, "Can't parse name to authority properly. name: ", name, ", layer: ", layer)
 			var r Result
-			return r, zdns.STATUS_AUTHFAIL, nil
+			return r, zdns.STATUS_AUTHFAIL, nil, isCached
 		}
 		s.VerboseLog(depth+2, "Cache auth check for ", authName)
 		cachedResult, ok = s.Factory.Factory.GetCachedResult(authName, dns.TypeNS, dnsType, depth+2, s.Factory.ThreadID)
 		if ok {
-			return cachedResult, zdns.STATUS_NOERROR, nil
+			return cachedResult, zdns.STATUS_NOERROR, nil, isCached
 		}
 	}
 
@@ -544,7 +560,7 @@ func (s *Lookup) cachedRetryingLookup(dnsType uint16, dnsClass uint16, name stri
 	result, status, err := s.retryingLookup(dnsType, dnsClass, name, nameServer, false)
 
 	s.cacheUpdate(layer, result, depth+2)
-	return result, status, err
+	return result, status, err, isCached
 }
 
 func nameIsBeneath(name string, layer string) (bool, string) {
@@ -596,18 +612,18 @@ func (s *Lookup) checkGlue(server string, depth int, result Result) (Result, zdn
 	return r, zdns.STATUS_SERVFAIL
 }
 
-func (s *Lookup) extractAuthority(authority interface{}, layer string, depth int, result Result) (string, zdns.Status, string) {
+func (s *Lookup) extractAuthority(authority interface{}, layer string, depth int, result Result, trace []Trace) (string, zdns.Status, string, []Trace) {
 
 	// Is it an answer
 	ans, ok := authority.(Answer)
 	if !ok {
-		return "", zdns.STATUS_SERVFAIL, layer
+		return "", zdns.STATUS_SERVFAIL, layer, trace
 	}
 
 	// Is the layering correct
 	ok, layer = nameIsBeneath(ans.Name, layer)
 	if !ok {
-		return "", zdns.STATUS_AUTHFAIL, layer
+		return "", zdns.STATUS_AUTHFAIL, layer, trace
 	}
 
 	server := strings.TrimSuffix(ans.Answer, ".")
@@ -618,10 +634,10 @@ func (s *Lookup) extractAuthority(authority interface{}, layer string, depth int
 	res, status := s.checkGlue(server, depth, result)
 	if status != zdns.STATUS_NOERROR {
 		// Fall through to normal query
-		res, status, _ = s.iterativeLookup(dns.TypeA, dns.ClassINET, server, s.NameServer, depth+1, ".")
+		res, status, _, trace = s.iterativeLookup(dns.TypeA, dns.ClassINET, server, s.NameServer, depth+1, ".", trace)
 	}
 	if status == zdns.STATUS_ITER_TIMEOUT {
-		return "", status, ""
+		return "", status, "", trace
 	}
 	if status == zdns.STATUS_NOERROR {
 		// XXX we don't actually check the question here
@@ -632,11 +648,11 @@ func (s *Lookup) extractAuthority(authority interface{}, layer string, depth int
 			}
 			if inner_ans.Type == "A" {
 				server := strings.TrimSuffix(inner_ans.Answer, ".") + ":53"
-				return server, zdns.STATUS_NOERROR, layer
+				return server, zdns.STATUS_NOERROR, layer, trace
 			}
 		}
 	}
-	return "", zdns.STATUS_SERVFAIL, layer
+	return "", zdns.STATUS_SERVFAIL, layer, trace
 }
 
 func debugReverseLookup(name string) string {
@@ -648,41 +664,41 @@ func debugReverseLookup(name string) string {
 	return "unknown"
 }
 
-func (s *Lookup) iterateOnAuthorities(dnsType uint16, dnsClass uint16, name string, depth int, result Result, layer string) (Result, zdns.Status, error) {
+func (s *Lookup) iterateOnAuthorities(dnsType uint16, dnsClass uint16, name string, depth int, result Result, layer string, trace []Trace) (Result, zdns.Status, error, []Trace) {
 	if len(result.Authorities) == 0 {
 		var r Result
-		return r, zdns.STATUS_SERVFAIL, nil
+		return r, zdns.STATUS_SERVFAIL, nil, trace
 	}
 	for _, elem := range result.Authorities {
 		s.VerboseLog(depth+1, "Trying Authority: ", elem)
-		ns, ns_status, layer := s.extractAuthority(elem, layer, depth, result)
+		ns, ns_status, layer, trace := s.extractAuthority(elem, layer, depth, result, trace)
 		s.VerboseLog((depth + 1), "Output from extract authorities: ", ns)
 		if ns_status == zdns.STATUS_ITER_TIMEOUT {
 			var r Result
 			s.VerboseLog((depth + 2), "--> Hit iterative timeout: ")
-			return r, ns_status, nil
+			return r, ns_status, nil, trace
 		}
 		if ns_status != zdns.STATUS_NOERROR {
 			s.VerboseLog((depth + 2), "--> Auth find Failed: ", ns_status)
 			continue
 		}
-		r, status, err := s.iterativeLookup(dnsType, dnsClass, name, ns, depth+1, layer)
+		r, status, err, trace := s.iterativeLookup(dnsType, dnsClass, name, ns, depth+1, layer, trace)
 		if status == zdns.STATUS_ITER_TIMEOUT {
-			return r, status, err
+			return r, status, err, trace
 		}
 		if status != zdns.STATUS_NOERROR {
 			s.VerboseLog((depth + 2), "--> Auth resolution of ", ns, " Failed: ", status)
 			continue
 		}
 		s.VerboseLog((depth + 1), "--> Auth Resolution success: ", status)
-		return r, status, err
+		return r, status, err, trace
 	}
 	s.VerboseLog((depth + 1), "Unable to find authoritative name server")
 	var r Result
-	return r, zdns.STATUS_ERROR, errors.New("could not find authoritative name server")
+	return r, zdns.STATUS_ERROR, errors.New("could not find authoritative name server"), trace
 }
 
-func (s *Lookup) iterativeLookup(dnsType uint16, dnsClass uint16, name string, nameServer string, depth int, layer string) (Result, zdns.Status, error) {
+func (s *Lookup) iterativeLookup(dnsType uint16, dnsClass uint16, name string, nameServer string, depth int, layer string, trace []Trace) (Result, zdns.Status, error, []Trace) {
 	if log.GetLevel() == log.DebugLevel {
 		//s.VerboseLog((depth), "iterative lookup for ", name, " (", dnsType, ") against ", nameServer, " (", debugReverseLookup(nameServer), ") layer ", layer)
 		s.VerboseLog((depth), "iterative lookup for ", name, " (", dnsType, ") against ", nameServer, " layer ", layer)
@@ -690,12 +706,25 @@ func (s *Lookup) iterativeLookup(dnsType uint16, dnsClass uint16, name string, n
 	if depth > s.Factory.MaxDepth {
 		var r Result
 		s.VerboseLog((depth + 1), "-> Max recursion depth reached")
-		return r, zdns.STATUS_ERROR, errors.New("Max recursion depth reached")
+		return r, zdns.STATUS_ERROR, errors.New("Max recursion depth reached"), trace
 	}
-	result, status, err := s.cachedRetryingLookup(dnsType, dnsClass, name, nameServer, layer, depth)
+	result, status, err, isCached := s.cachedRetryingLookup(dnsType, dnsClass, name, nameServer, layer, depth)
+	if s.Factory.Trace && status == zdns.STATUS_NOERROR {
+		var t Trace
+		t.Result = result
+		t.DnsType = dnsType
+		t.DnsClass = dnsClass
+		t.Name = name
+		t.NameServer = nameServer
+		t.Layer = layer
+		t.Depth = depth
+		t.Cached = isCached
+		trace = append(trace, t)
+
+	}
 	if status != zdns.STATUS_NOERROR {
 		s.VerboseLog((depth + 1), "-> error occurred during lookup")
-		return result, status, err
+		return result, status, err, trace
 	} else if len(result.Answers) != 0 || result.Flags.Authoritative == true {
 		if len(result.Answers) != 0 {
 			s.VerboseLog((depth + 1), "-> answers found")
@@ -710,13 +739,13 @@ func (s *Lookup) iterativeLookup(dnsType uint16, dnsClass uint16, name string, n
 		} else {
 			s.VerboseLog((depth + 1), "-> authoritative response found")
 		}
-		return result, status, err
+		return result, status, err, trace
 	} else if len(result.Authorities) != 0 {
 		s.VerboseLog((depth + 1), "-> Authority found, iterating")
-		return s.iterateOnAuthorities(dnsType, dnsClass, name, depth, result, layer)
+		return s.iterateOnAuthorities(dnsType, dnsClass, name, depth, result, layer, trace)
 	} else {
 		s.VerboseLog((depth + 1), "-> No Authority found, error")
-		return result, zdns.STATUS_ERROR, errors.New("NOERROR record without any answers or authorities")
+		return result, zdns.STATUS_ERROR, errors.New("NOERROR record without any answers or authorities"), trace
 	}
 }
 
@@ -724,8 +753,11 @@ func (s *Lookup) DoMiekgLookup(name string) (interface{}, zdns.Status, error) {
 	if s.Factory.IterativeResolution {
 		s.VerboseLog(0, "MIEKG-IN: iterative lookup for ", name, " (", s.DNSType, ")")
 		s.IterativeStop = time.Now().Add(time.Duration(s.Factory.IterativeTimeout))
-		result, status, err := s.iterativeLookup(s.DNSType, s.DNSClass, name, s.NameServer, 1, ".")
+		result, status, err, trace := s.iterativeLookup(s.DNSType, s.DNSClass, name, s.NameServer, 1, ".", make([]Trace, 0))
 		s.VerboseLog(0, "MIEKG-OUT: iterative lookup for ", name, " (", s.DNSType, "): status: ", status, " , err: ", err)
+		if s.Factory.Trace {
+			result.Trace = trace
+		}
 		return result, status, err
 
 	} else {
@@ -737,8 +769,11 @@ func (s *Lookup) DoMiekgLookupForClass(name string, dnsClass uint16) (interface{
 	if s.Factory.IterativeResolution {
 		s.VerboseLog(0, "MIEKG-IN: iterative lookup for ", name, " (", s.DNSType, ") in class ", dnsClass)
 		s.IterativeStop = time.Now().Add(time.Duration(s.Factory.IterativeTimeout))
-		result, status, err := s.iterativeLookup(s.DNSType, s.DNSClass, name, s.NameServer, 1, ".")
+		result, status, err, trace := s.iterativeLookup(s.DNSType, s.DNSClass, name, s.NameServer, 1, ".", make([]Trace, 0))
 		s.VerboseLog(0, "MIEKG-OUT: iterative lookup for ", name, " (", s.DNSType, "): status: ", status, " , err: ", err)
+		if s.Factory.Trace {
+			result.Trace = trace
+		}
 		return result, status, err
 
 	} else {
@@ -753,8 +788,11 @@ func (s *Lookup) DoTypedMiekgLookup(name string, dnsType uint16) (interface{}, z
 	if s.Factory.IterativeResolution {
 		s.VerboseLog(0, "MIEKG-IN: iterative lookup for ", name, " (", dnsType, ")")
 		s.IterativeStop = time.Now().Add(time.Duration(s.Factory.IterativeTimeout))
-		result, status, err := s.iterativeLookup(dnsType, s.DNSClass, name, s.NameServer, 1, ".")
+		result, status, err, trace := s.iterativeLookup(dnsType, s.DNSClass, name, s.NameServer, 1, ".", make([]Trace, 0))
 		s.VerboseLog(0, "MIEKG-OUT: iterative lookup for ", name, " (", dnsType, "): status: ", status, " , err: ", err)
+		if s.Factory.Trace {
+			result.Trace = trace
+		}
 		return result, status, err
 	} else {
 		return s.retryingLookup(dnsType, s.DNSClass, name, s.NameServer, true)
@@ -768,8 +806,11 @@ func (s *Lookup) DoTypedMiekgLookupInClass(name string, dnsType uint16, dnsClass
 	if s.Factory.IterativeResolution {
 		s.VerboseLog(0, "MIEKG-IN: iterative lookup for ", name, " (", dnsType, ") in class ", dnsClass)
 		s.IterativeStop = time.Now().Add(time.Duration(s.Factory.IterativeTimeout))
-		result, status, err := s.iterativeLookup(dnsType, dnsClass, name, s.NameServer, 1, ".")
+		result, status, err, trace := s.iterativeLookup(dnsType, dnsClass, name, s.NameServer, 1, ".", make([]Trace, 0))
 		s.VerboseLog(0, "MIEKG-OUT: iterative lookup for ", name, " (", dnsType, "): status: ", status, " , err: ", err)
+		if s.Factory.Trace {
+			result.Trace = trace
+		}
 		return result, status, err
 	} else {
 		return s.retryingLookup(dnsType, dnsClass, name, s.NameServer, true)

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -43,6 +43,7 @@ func main() {
 	flags.StringVar(&gc.NamePrefix, "prefix", "", "name to be prepended to what's passed in (e.g., www.)")
 	flags.BoolVar(&gc.AlexaFormat, "alexa", false, "is input file from Alexa Top Million download")
 	flags.BoolVar(&gc.IterativeResolution, "iterative", false, "Perform own iteration instead of relying on recursive resolver")
+	flags.BoolVar(&gc.Trace, "trace", false, "Output a trace of individual steps for iterative resolutions")
 	flags.StringVar(&gc.InputFilePath, "input-file", "-", "names to read")
 	flags.StringVar(&gc.OutputFilePath, "output-file", "-", "where should JSON output be saved")
 	flags.StringVar(&gc.MetadataFilePath, "metadata-file", "", "where should JSON metadata be saved")


### PR DESCRIPTION
Provides intermediate queries and results involved for iterative lookups as the .data.trace field (list). Sample below

```json
{
  "data": {
    "trace": [
      {
        "cached": false,
        "layer": ".",
        "depth": 1,
        "name_server": "202.12.27.33:53",
        "name": "www.example.com",
        "class": 1,
        "type": 1,
        "results": {
          "flags": {
            "error_code": 0,
            "response": true,
            "opcode": 0,
            "authoritative": false,
            "truncated": false,
            "recursion_desired": false,
            "recursion_available": false,
            "authenticated": false,
            "checking_disabled": false
          },
          "protocol": "udp",
          "authorities": [
            {
              "answer": "l.gtld-servers.net",
              "name": "com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            },
            {
              "answer": "k.gtld-servers.net",
              "name": "com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            },
            {
              "answer": "c.gtld-servers.net",
              "name": "com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            },
            {
              "answer": "d.gtld-servers.net",
              "name": "com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            },
            {
              "answer": "m.gtld-servers.net",
              "name": "com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            },
            {
              "answer": "g.gtld-servers.net",
              "name": "com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            },
            {
              "answer": "h.gtld-servers.net",
              "name": "com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            },
            {
              "answer": "f.gtld-servers.net",
              "name": "com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            },
            {
              "answer": "a.gtld-servers.net",
              "name": "com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            },
            {
              "answer": "b.gtld-servers.net",
              "name": "com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            },
            {
              "answer": "e.gtld-servers.net",
              "name": "com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            },
            {
              "answer": "i.gtld-servers.net",
              "name": "com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            },
            {
              "answer": "j.gtld-servers.net",
              "name": "com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            }
          ],
          "additionals": [
            {
              "answer": "192.5.6.30",
              "name": "a.gtld-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "192.33.14.30",
              "name": "b.gtld-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "192.26.92.30",
              "name": "c.gtld-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "192.31.80.30",
              "name": "d.gtld-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "192.12.94.30",
              "name": "e.gtld-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "192.35.51.30",
              "name": "f.gtld-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "192.42.93.30",
              "name": "g.gtld-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "192.54.112.30",
              "name": "h.gtld-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "192.43.172.30",
              "name": "i.gtld-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "192.48.79.30",
              "name": "j.gtld-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "192.52.178.30",
              "name": "k.gtld-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "192.41.162.30",
              "name": "l.gtld-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "192.55.83.30",
              "name": "m.gtld-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "2001:503:a83e::2:30",
              "name": "a.gtld-servers.net",
              "class": "IN",
              "type": "AAAA",
              "ttl": 172800
            }
          ],
          "answers": []
        }
      },
      {
        "cached": false,
        "layer": "com",
        "depth": 2,
        "name_server": "192.41.162.30:53",
        "name": "www.example.com",
        "class": 1,
        "type": 1,
        "results": {
          "flags": {
            "error_code": 0,
            "response": true,
            "opcode": 0,
            "authoritative": false,
            "truncated": false,
            "recursion_desired": false,
            "recursion_available": false,
            "authenticated": false,
            "checking_disabled": false
          },
          "protocol": "udp",
          "authorities": [
            {
              "answer": "a.iana-servers.net",
              "name": "example.com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            },
            {
              "answer": "b.iana-servers.net",
              "name": "example.com",
              "class": "IN",
              "type": "NS",
              "ttl": 172800
            }
          ],
          "additionals": [
            {
              "answer": "199.43.135.53",
              "name": "a.iana-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "2001:500:8f::53",
              "name": "a.iana-servers.net",
              "class": "IN",
              "type": "AAAA",
              "ttl": 172800
            },
            {
              "answer": "199.43.133.53",
              "name": "b.iana-servers.net",
              "class": "IN",
              "type": "A",
              "ttl": 172800
            },
            {
              "answer": "2001:500:8d::53",
              "name": "b.iana-servers.net",
              "class": "IN",
              "type": "AAAA",
              "ttl": 172800
            }
          ],
          "answers": []
        }
      },
      {
        "cached": false,
        "layer": "example.com",
        "depth": 3,
        "name_server": "199.43.135.53:53",
        "name": "www.example.com",
        "class": 1,
        "type": 1,
        "results": {
          "flags": {
            "error_code": 0,
            "response": true,
            "opcode": 0,
            "authoritative": true,
            "truncated": false,
            "recursion_desired": false,
            "recursion_available": false,
            "authenticated": false,
            "checking_disabled": false
          },
          "protocol": "udp",
          "authorities": [
            {
              "answer": "a.iana-servers.net",
              "name": "example.com",
              "class": "IN",
              "type": "NS",
              "ttl": 86400
            },
            {
              "answer": "b.iana-servers.net",
              "name": "example.com",
              "class": "IN",
              "type": "NS",
              "ttl": 86400
            }
          ],
          "additionals": [],
          "answers": [
            {
              "answer": "93.184.216.34",
              "name": "www.example.com",
              "class": "IN",
              "type": "A",
              "ttl": 86400
            }
          ]
        }
      }
    ],
    "flags": {
      "error_code": 0,
      "response": true,
      "opcode": 0,
      "authoritative": true,
      "truncated": false,
      "recursion_desired": false,
      "recursion_available": false,
      "authenticated": false,
      "checking_disabled": false
    },
    "protocol": "udp",
    "authorities": [],
    "additionals": [],
    "answers": [
      {
        "answer": "93.184.216.34",
        "name": "www.example.com",
        "class": "IN",
        "type": "A",
        "ttl": 86400
      }
    ]
  },
  "timestamp": "2017-08-20T16:48:54-07:00",
  "status": "NOERROR",
  "class": "IN",
  "name": "www.example.com"
}
```
