### PR TITLE
Support for trace across all queries (#111), fix lookups (#110)

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -54,16 +54,16 @@ type Metadata struct {
 }
 
 type Result struct {
-	AlteredName string      `json:"altered_name,omitempty"`
-	Name        string      `json:"name,omitempty"`
-	Nameserver  string      `json:"nameserver,omitempty"`
-	Class       string      `json:"class,omitempty"`
-	AlexaRank   int         `json:"alexa_rank,omitempty"`
-	Status      string      `json:"status,omitempty"`
-	Error       string      `json:"error,omitempty"`
-	Timestamp   string      `json:"timestamp,omitempty"`
-	Data        interface{} `json:"data,omitempty"`
-	Trace       interface{} `json:"trace,omitempty"`
+	AlteredName string        `json:"altered_name,omitempty"`
+	Name        string        `json:"name,omitempty"`
+	Nameserver  string        `json:"nameserver,omitempty"`
+	Class       string        `json:"class,omitempty"`
+	AlexaRank   int           `json:"alexa_rank,omitempty"`
+	Status      string        `json:"status,omitempty"`
+	Error       string        `json:"error,omitempty"`
+	Timestamp   string        `json:"timestamp,omitempty"`
+	Data        interface{}   `json:"data,omitempty"`
+	Trace       []interface{} `json:"trace,omitempty"`
 }
 
 type TargetedDomain struct {

--- a/conf.go
+++ b/conf.go
@@ -63,6 +63,7 @@ type Result struct {
 	Error       string      `json:"error,omitempty"`
 	Timestamp   string      `json:"timestamp,omitempty"`
 	Data        interface{} `json:"data,omitempty"`
+	Trace       interface{} `json:"trace,omitempty"`
 }
 
 type TargetedDomain struct {

--- a/conf.go
+++ b/conf.go
@@ -23,6 +23,7 @@ type GlobalConf struct {
 	Retries             int
 	AlexaFormat         bool
 	IterativeResolution bool
+	Trace               bool
 	MaxDepth            int
 	CacheSize           int
 	GoMaxProcs          int

--- a/interface.go
+++ b/interface.go
@@ -44,7 +44,7 @@ import (
 // one Lookup per IP/name/connection ==========================================
 //
 type Lookup interface {
-	DoLookup(name string) (interface{}, Status, error)
+	DoLookup(name string) (interface{}, interface{}, Status, error)
 	DoZonefileLookup(record *dns.Token) (interface{}, Status, error)
 }
 

--- a/interface.go
+++ b/interface.go
@@ -44,7 +44,7 @@ import (
 // one Lookup per IP/name/connection ==========================================
 //
 type Lookup interface {
-	DoLookup(name string) (interface{}, interface{}, Status, error)
+	DoLookup(name string) (interface{}, []interface{}, Status, error)
 	DoZonefileLookup(record *dns.Token) (interface{}, Status, error)
 }
 

--- a/lookup.go
+++ b/lookup.go
@@ -75,6 +75,7 @@ func doLookup(g *GlobalLookupFactory, gc *GlobalConf, input <-chan interface{}, 
 	for genericInput := range input {
 		var res Result
 		var innerRes interface{}
+		var trace interface{}
 		var status Status
 		var err error
 		l, err := f.MakeLookup()
@@ -111,12 +112,13 @@ func doLookup(g *GlobalLookupFactory, gc *GlobalConf, input <-chan interface{}, 
 			}
 			res.Name = rawName
 			res.Class = dns.Class(gc.Class).String()
-			innerRes, status, err = l.DoLookup(lookupName)
+			innerRes, trace, status, err = l.DoLookup(lookupName)
 		}
 		res.Timestamp = time.Now().Format(time.RFC3339)
 		if status != STATUS_NO_OUTPUT {
 			res.Status = string(status)
 			res.Data = innerRes
+			res.Trace = trace
 			if err != nil {
 				res.Error = err.Error()
 			}

--- a/lookup.go
+++ b/lookup.go
@@ -75,7 +75,7 @@ func doLookup(g *GlobalLookupFactory, gc *GlobalConf, input <-chan interface{}, 
 	for genericInput := range input {
 		var res Result
 		var innerRes interface{}
-		var trace interface{}
+		var trace []interface{}
 		var status Status
 		var err error
 		l, err := f.MakeLookup()

--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -36,25 +36,26 @@ type Lookup struct {
 	miekg.Lookup
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name string) (interface{}, interface{}, zdns.Status, error) {
 	nameServer := s.Factory.Factory.RandomNameServer()
 	return s.DoTargetedLookup(name, nameServer)
 }
 
-func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16, searchSet map[string][]miekg.Answer, origName string, depth int) ([]string, zdns.Status, error) {
+func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16, searchSet map[string][]miekg.Answer, origName string, depth int) ([]string, interface{}, zdns.Status, error) {
 	// avoid infinite loops
 	if name == origName && depth != 0 {
-		return nil, zdns.STATUS_ERROR, errors.New("Infinite redirection loop")
+		return nil, nil, zdns.STATUS_ERROR, errors.New("Infinite redirection loop")
 	}
 	if depth > 10 {
-		return nil, zdns.STATUS_ERROR, errors.New("Max recursion depth reached")
+		return nil, nil, zdns.STATUS_ERROR, errors.New("Max recursion depth reached")
 	}
 	// check if the record is already in our cache. if not, perform normal A lookup and
 	// see what comes back. Then iterate over results and if needed, perform further lookups
+	var trace interface{}
 	if _, ok := searchSet[name]; !ok {
-		miekgResult, status, err := s.DoTypedMiekgLookup(name, dnsType)
+		miekgResult, trace, status, err := s.DoTypedMiekgLookup(name, dnsType)
 		if status != zdns.STATUS_NOERROR || err != nil {
-			return nil, status, err
+			return nil, trace, status, err
 		}
 		for _, a := range miekgResult.(miekg.Result).Answers {
 			ans, ok := a.(miekg.Answer)
@@ -76,41 +77,61 @@ func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16
 	if !ok || len(res) == 0 {
 		// we have no data whatsoever about this name. return an empty recordset to the user
 		var ips []string
-		return ips, zdns.STATUS_NO_ANSWER, nil
+		return ips, trace, zdns.STATUS_NO_ANSWER, nil
 	} else if res[0].Type == dns.Type(dnsType).String() {
 		// we have IP addresses to hand back to the user. let's make an easy-to-use array of strings
 		var ips []string
 		for _, answer := range res {
 			ips = append(ips, answer.Answer)
 		}
-		return ips, zdns.STATUS_NOERROR, nil
+		return ips, trace, zdns.STATUS_NOERROR, nil
 	} else if res[0].Type == dns.Type(dns.TypeCNAME).String() {
 		// we have a CNAME and need to further recurse to find IPs
 		shortName := strings.ToLower(res[0].Answer[0 : len(res[0].Answer)-1])
-		return s.doLookupProtocol(shortName, nameServer, dnsType, searchSet, origName, depth+1)
+		res, secondTrace, status, err := s.doLookupProtocol(shortName, nameServer, dnsType, searchSet, origName, depth+1)
+		trace = append(trace.([]interface{}), secondTrace.([]interface{})...)
+		return res, trace, status, err
 	} else {
-		return nil, zdns.STATUS_ERROR, errors.New("Unexpected record type received")
+		return nil, trace, zdns.STATUS_ERROR, errors.New("Unexpected record type received")
 	}
 }
 
-func (s *Lookup) DoTargetedLookup(name string, nameServer string) (interface{}, zdns.Status, error) {
+func (s *Lookup) DoTargetedLookup(name string, nameServer string) (interface{}, interface{}, zdns.Status, error) {
 	res := Result{}
 	searchSet := map[string][]miekg.Answer{}
+	var ipv4 []string
+	var ipv6 []string
+	var ipv4Trace interface{}
+	var ipv6Trace interface{}
 	if s.Factory.Factory.IPv4Lookup {
-		ipv4, _, _ := s.doLookupProtocol(name, nameServer, dns.TypeA, searchSet, name, 0)
+		ipv4, ipv4Trace, _, _ = s.doLookupProtocol(name, nameServer, dns.TypeA, searchSet, name, 0)
 		res.IPv4Addresses = make([]string, len(ipv4))
 		copy(res.IPv4Addresses, ipv4)
 	}
 	searchSet = map[string][]miekg.Answer{}
 	if s.Factory.Factory.IPv6Lookup {
-		ipv6, _, _ := s.doLookupProtocol(name, nameServer, dns.TypeAAAA, searchSet, name, 0)
+		ipv6, ipv6Trace, _, _ = s.doLookupProtocol(name, nameServer, dns.TypeAAAA, searchSet, name, 0)
 		res.IPv6Addresses = make([]string, len(ipv6))
 		copy(res.IPv6Addresses, ipv6)
 	}
-	if len(res.IPv4Addresses) == 0 && len(res.IPv6Addresses) == 0 {
-		return nil, zdns.STATUS_NO_ANSWER, nil
+
+	var trace interface{}
+
+	if ipv4Trace != nil || ipv6Trace != nil {
+		if ipv4Trace != nil {
+			trace = ipv4Trace
+			if ipv6Trace != nil {
+				trace = append(trace.([]interface{}), ipv6Trace.([]interface{})...)
+			}
+		} else {
+			trace = ipv6Trace
+		}
 	}
-	return res, zdns.STATUS_NOERROR, nil
+
+	if len(res.IPv4Addresses) == 0 && len(res.IPv6Addresses) == 0 {
+		return nil, trace, zdns.STATUS_NO_ANSWER, nil
+	}
+	return res, trace, zdns.STATUS_NOERROR, nil
 }
 
 // Per GoRoutine Factory ======================================================

--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -103,7 +103,7 @@ func (s *Lookup) DoTargetedLookup(name string, nameServer string) (interface{}, 
 	var ipv6 []string
 	var ipv4Trace []interface{}
 	var ipv6Trace []interface{}
-	if s.Factory.Factory.IPv4Lookup {
+	if s.Factory.Factory.IPv4Lookup || !s.Factory.Factory.IPv6Lookup {
 		ipv4, ipv4Trace, _, _ = s.doLookupProtocol(name, nameServer, dns.TypeA, searchSet, name, 0)
 		res.IPv4Addresses = make([]string, len(ipv4))
 		copy(res.IPv4Addresses, ipv4)

--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -53,7 +53,10 @@ func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16
 	// see what comes back. Then iterate over results and if needed, perform further lookups
 	var trace []interface{}
 	if _, ok := searchSet[name]; !ok {
-		miekgResult, trace, status, err := s.DoTypedMiekgLookup(name, dnsType)
+		var miekgResult interface{}
+		var status zdns.Status
+		var err error
+		miekgResult, trace, status, err = s.DoTypedMiekgLookup(name, dnsType)
 		if status != zdns.STATUS_NOERROR || err != nil {
 			return nil, trace, status, err
 		}

--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -44,10 +44,10 @@ func (s *Lookup) DoLookup(name string) (interface{}, interface{}, zdns.Status, e
 func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16, searchSet map[string][]miekg.Answer, origName string, depth int) ([]string, interface{}, zdns.Status, error) {
 	// avoid infinite loops
 	if name == origName && depth != 0 {
-		return nil, nil, zdns.STATUS_ERROR, errors.New("Infinite redirection loop")
+		return nil, make([]interface{}, 0), zdns.STATUS_ERROR, errors.New("Infinite redirection loop")
 	}
 	if depth > 10 {
-		return nil, nil, zdns.STATUS_ERROR, errors.New("Max recursion depth reached")
+		return nil, make([]interface{}, 0), zdns.STATUS_ERROR, errors.New("Max recursion depth reached")
 	}
 	// check if the record is already in our cache. if not, perform normal A lookup and
 	// see what comes back. Then iterate over results and if needed, perform further lookups

--- a/modules/axfr/axfr.go
+++ b/modules/axfr/axfr.go
@@ -95,7 +95,7 @@ func (s *Lookup) DoAXFR(name string, server string) AXFRServerResult {
 	return retv
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name string) (interface{}, []interface{}, zdns.Status, error) {
 	parsedNS, trace, status, err := s.DoNSLookup(name, true, false)
 	if status != zdns.STATUS_NOERROR {
 		return nil, trace, status, err

--- a/modules/axfr/axfr.go
+++ b/modules/axfr/axfr.go
@@ -95,10 +95,10 @@ func (s *Lookup) DoAXFR(name string, server string) AXFRServerResult {
 	return retv
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, zdns.Status, error) {
-	parsedNS, status, err := s.DoNSLookup(name, true, false)
+func (s *Lookup) DoLookup(name string) (interface{}, interface{}, zdns.Status, error) {
+	parsedNS, trace, status, err := s.DoNSLookup(name, true, false)
 	if status != zdns.STATUS_NOERROR {
-		return nil, status, err
+		return nil, trace, status, err
 	}
 	var retv AXFRResult
 	for _, server := range parsedNS.Servers {
@@ -106,7 +106,7 @@ func (s *Lookup) DoLookup(name string) (interface{}, zdns.Status, error) {
 			retv.Servers = append(retv.Servers, s.DoAXFR(name, server.IPv4Addresses[0]))
 		}
 	}
-	return retv, zdns.STATUS_NOERROR, nil
+	return retv, trace, zdns.STATUS_NOERROR, nil
 }
 
 // Per GoRoutine Factory ======================================================

--- a/modules/dmarc/dmarc.go
+++ b/modules/dmarc/dmarc.go
@@ -32,14 +32,14 @@ type Lookup struct {
 	miekg.Lookup
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name string) (interface{}, interface{}, zdns.Status, error) {
 	var res Result
-	innerRes, status, err := s.DoTxtLookup(name)
+	innerRes, trace, status, err := s.DoTxtLookup(name)
 	if status != zdns.STATUS_NOERROR {
-		return res, status, err
+		return res, nil, status, err
 	}
 	res.Dmarc = innerRes
-	return res, zdns.STATUS_NOERROR, nil
+	return res, trace, zdns.STATUS_NOERROR, nil
 }
 
 // Per GoRoutine Factory ======================================================

--- a/modules/dmarc/dmarc.go
+++ b/modules/dmarc/dmarc.go
@@ -32,7 +32,7 @@ type Lookup struct {
 	miekg.Lookup
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name string) (interface{}, []interface{}, zdns.Status, error) {
 	var res Result
 	innerRes, trace, status, err := s.DoTxtLookup(name)
 	if status != zdns.STATUS_NOERROR {

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -504,7 +504,7 @@ func (s *Lookup) tracedRetryingLookup(dnsType uint16, dnsClass uint16, name stri
 
 	res, status, err := s.retryingLookup(dnsType, dnsClass, name, nameServer, recursive)
 
-	var trace Trace
+	trace := make([]TraceStep, 0)
 
 	if s.Factory.Trace {
 		var t TraceStep
@@ -516,7 +516,6 @@ func (s *Lookup) tracedRetryingLookup(dnsType uint16, dnsClass uint16, name stri
 		t.Layer = name
 		t.Depth = 1
 		t.Cached = false
-		trace = make([]TraceStep, 1)
 		trace = append(trace, t)
 	}
 
@@ -785,7 +784,7 @@ func (s *Lookup) DoMiekgLookup(name string) (interface{}, interface{}, zdns.Stat
 		if s.Factory.Trace {
 			return result, trace, status, err
 		}
-		return result, nil, status, err
+		return result, trace, status, err
 
 	} else {
 		return s.tracedRetryingLookup(s.DNSType, s.DNSClass, name, s.NameServer, true)
@@ -801,7 +800,7 @@ func (s *Lookup) DoMiekgLookupForClass(name string, dnsClass uint16) (interface{
 		if s.Factory.Trace {
 			return result, trace, status, err
 		}
-		return result, nil, status, err
+		return result, trace, status, err
 
 	} else {
 		return s.tracedRetryingLookup(s.DNSType, s.DNSClass, name, s.NameServer, true)
@@ -820,7 +819,7 @@ func (s *Lookup) DoTypedMiekgLookup(name string, dnsType uint16) (interface{}, i
 		if s.Factory.Trace {
 			return result, trace, status, err
 		}
-		return result, nil, status, err
+		return result, trace, status, err
 	} else {
 		return s.tracedRetryingLookup(dnsType, s.DNSClass, name, s.NameServer, true)
 	}
@@ -838,7 +837,7 @@ func (s *Lookup) DoTypedMiekgLookupInClass(name string, dnsType uint16, dnsClass
 		if s.Factory.Trace {
 			return result, trace, status, err
 		}
-		return result, nil, status, err
+		return result, trace, status, err
 	} else {
 		return s.tracedRetryingLookup(dnsType, dnsClass, name, s.NameServer, true)
 	}
@@ -847,7 +846,7 @@ func (s *Lookup) DoTypedMiekgLookupInClass(name string, dnsType uint16, dnsClass
 func (s *Lookup) DoTxtLookup(name string) (string, interface{}, zdns.Status, error) {
 	res, trace, status, err := s.DoMiekgLookup(name)
 	if status != zdns.STATUS_NOERROR {
-		return "", nil, status, err
+		return "", trace, status, err
 	}
 	if parsedResult, ok := res.(Result); ok {
 		for _, a := range parsedResult.Answers {
@@ -857,7 +856,7 @@ func (s *Lookup) DoTxtLookup(name string) (string, interface{}, zdns.Status, err
 			}
 		}
 	}
-	return "", nil, zdns.STATUS_NO_RECORD, nil
+	return "", trace, zdns.STATUS_NO_RECORD, nil
 }
 
 // allow miekg to be used as a ZDNS module

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -76,7 +76,7 @@ type Trace struct {
 	DnsClass   uint16 `json:"class"`
 	Name       string `json:"name"`
 	NameServer string `json:"name_server"`
-	Depth      int    `json:"cached"`
+	Depth      int    `json:"depth"`
 	Layer      string `json:"layer"`
 	Cached     bool   `json:"cached"`
 }

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -67,6 +67,18 @@ type Result struct {
 	Authorities []interface{} `json:"authorities"`
 	Protocol    string        `json:"protocol"`
 	Flags       DNSFlags      `json:"flags"`
+	Trace       []Trace       `json:"trace,omitempty"`
+}
+
+type Trace struct {
+	Result     Result `json:"results"`
+	DnsType    uint16 `json:"type"`
+	DnsClass   uint16 `json:"class"`
+	Name       string `json:"name"`
+	NameServer string `json:"name_server"`
+	Depth      int    `json:"cached"`
+	Layer      string `json:"layer"`
+	Cached     bool   `json:"cached"`
 }
 
 type TimedAnswer struct {
@@ -322,6 +334,7 @@ type RoutineLookupFactory struct {
 	Timeout             time.Duration
 	IterativeTimeout    time.Duration
 	IterativeResolution bool
+	Trace               bool
 	DNSType             uint16
 	DNSClass            uint16
 	ThreadID            int
@@ -345,6 +358,7 @@ func (s *RoutineLookupFactory) Initialize(c *zdns.GlobalConf) {
 	s.Retries = c.Retries
 	s.MaxDepth = c.MaxDepth
 	s.IterativeResolution = c.IterativeResolution
+	s.Trace = c.Trace
 
 	s.DNSClass = c.Class
 }
@@ -510,17 +524,19 @@ func (s *Lookup) retryingLookup(dnsType uint16, dnsClass uint16, name string, na
 	panic("loop must return")
 }
 
-func (s *Lookup) cachedRetryingLookup(dnsType uint16, dnsClass uint16, name string, nameServer string, layer string, depth int) (Result, zdns.Status, error) {
+func (s *Lookup) cachedRetryingLookup(dnsType uint16, dnsClass uint16, name string, nameServer string, layer string, depth int) (Result, zdns.Status, error, bool) {
+	isCached := false
 	s.VerboseLog(depth+1, "Cached retrying lookup. Name: ", name, ", Layer: ", layer, ", Nameserver: ", nameServer)
 	if s.IterativeStop.Before(time.Now()) {
 		s.VerboseLog(depth+2, "ITERATIVE_TIMEOUT ", name, ", Layer: ", layer, ", Nameserver: ", nameServer)
 		var r Result
-		return r, zdns.STATUS_ITER_TIMEOUT, nil
+		return r, zdns.STATUS_ITER_TIMEOUT, nil, isCached
 	}
 	// First, we check the answer
 	cachedResult, ok := s.Factory.Factory.GetCachedResult(name, dnsType, dnsType, depth+1, s.Factory.ThreadID)
 	if ok {
-		return cachedResult, zdns.STATUS_NOERROR, nil
+		isCached = true
+		return cachedResult, zdns.STATUS_NOERROR, nil, isCached
 	}
 	// Now, we check the authoritative:
 	name = strings.ToLower(name)
@@ -530,12 +546,12 @@ func (s *Lookup) cachedRetryingLookup(dnsType uint16, dnsClass uint16, name stri
 		if authName == "" {
 			s.VerboseLog(depth+2, "Can't parse name to authority properly. name: ", name, ", layer: ", layer)
 			var r Result
-			return r, zdns.STATUS_AUTHFAIL, nil
+			return r, zdns.STATUS_AUTHFAIL, nil, isCached
 		}
 		s.VerboseLog(depth+2, "Cache auth check for ", authName)
 		cachedResult, ok = s.Factory.Factory.GetCachedResult(authName, dns.TypeNS, dnsType, depth+2, s.Factory.ThreadID)
 		if ok {
-			return cachedResult, zdns.STATUS_NOERROR, nil
+			return cachedResult, zdns.STATUS_NOERROR, nil, isCached
 		}
 	}
 
@@ -544,7 +560,7 @@ func (s *Lookup) cachedRetryingLookup(dnsType uint16, dnsClass uint16, name stri
 	result, status, err := s.retryingLookup(dnsType, dnsClass, name, nameServer, false)
 
 	s.cacheUpdate(layer, result, depth+2)
-	return result, status, err
+	return result, status, err, isCached
 }
 
 func nameIsBeneath(name string, layer string) (bool, string) {
@@ -596,18 +612,18 @@ func (s *Lookup) checkGlue(server string, depth int, result Result) (Result, zdn
 	return r, zdns.STATUS_SERVFAIL
 }
 
-func (s *Lookup) extractAuthority(authority interface{}, layer string, depth int, result Result) (string, zdns.Status, string) {
+func (s *Lookup) extractAuthority(authority interface{}, layer string, depth int, result Result, trace []Trace) (string, zdns.Status, string, []Trace) {
 
 	// Is it an answer
 	ans, ok := authority.(Answer)
 	if !ok {
-		return "", zdns.STATUS_SERVFAIL, layer
+		return "", zdns.STATUS_SERVFAIL, layer, trace
 	}
 
 	// Is the layering correct
 	ok, layer = nameIsBeneath(ans.Name, layer)
 	if !ok {
-		return "", zdns.STATUS_AUTHFAIL, layer
+		return "", zdns.STATUS_AUTHFAIL, layer, trace
 	}
 
 	server := strings.TrimSuffix(ans.Answer, ".")
@@ -618,10 +634,10 @@ func (s *Lookup) extractAuthority(authority interface{}, layer string, depth int
 	res, status := s.checkGlue(server, depth, result)
 	if status != zdns.STATUS_NOERROR {
 		// Fall through to normal query
-		res, status, _ = s.iterativeLookup(dns.TypeA, dns.ClassINET, server, s.NameServer, depth+1, ".")
+		res, status, _, trace = s.iterativeLookup(dns.TypeA, dns.ClassINET, server, s.NameServer, depth+1, ".", trace)
 	}
 	if status == zdns.STATUS_ITER_TIMEOUT {
-		return "", status, ""
+		return "", status, "", trace
 	}
 	if status == zdns.STATUS_NOERROR {
 		// XXX we don't actually check the question here
@@ -632,11 +648,11 @@ func (s *Lookup) extractAuthority(authority interface{}, layer string, depth int
 			}
 			if inner_ans.Type == "A" {
 				server := strings.TrimSuffix(inner_ans.Answer, ".") + ":53"
-				return server, zdns.STATUS_NOERROR, layer
+				return server, zdns.STATUS_NOERROR, layer, trace
 			}
 		}
 	}
-	return "", zdns.STATUS_SERVFAIL, layer
+	return "", zdns.STATUS_SERVFAIL, layer, trace
 }
 
 func debugReverseLookup(name string) string {
@@ -648,41 +664,41 @@ func debugReverseLookup(name string) string {
 	return "unknown"
 }
 
-func (s *Lookup) iterateOnAuthorities(dnsType uint16, dnsClass uint16, name string, depth int, result Result, layer string) (Result, zdns.Status, error) {
+func (s *Lookup) iterateOnAuthorities(dnsType uint16, dnsClass uint16, name string, depth int, result Result, layer string, trace []Trace) (Result, zdns.Status, error, []Trace) {
 	if len(result.Authorities) == 0 {
 		var r Result
-		return r, zdns.STATUS_SERVFAIL, nil
+		return r, zdns.STATUS_SERVFAIL, nil, trace
 	}
 	for _, elem := range result.Authorities {
 		s.VerboseLog(depth+1, "Trying Authority: ", elem)
-		ns, ns_status, layer := s.extractAuthority(elem, layer, depth, result)
+		ns, ns_status, layer, trace := s.extractAuthority(elem, layer, depth, result, trace)
 		s.VerboseLog((depth + 1), "Output from extract authorities: ", ns)
 		if ns_status == zdns.STATUS_ITER_TIMEOUT {
 			var r Result
 			s.VerboseLog((depth + 2), "--> Hit iterative timeout: ")
-			return r, ns_status, nil
+			return r, ns_status, nil, trace
 		}
 		if ns_status != zdns.STATUS_NOERROR {
 			s.VerboseLog((depth + 2), "--> Auth find Failed: ", ns_status)
 			continue
 		}
-		r, status, err := s.iterativeLookup(dnsType, dnsClass, name, ns, depth+1, layer)
+		r, status, err, trace := s.iterativeLookup(dnsType, dnsClass, name, ns, depth+1, layer, trace)
 		if status == zdns.STATUS_ITER_TIMEOUT {
-			return r, status, err
+			return r, status, err, trace
 		}
 		if status != zdns.STATUS_NOERROR {
 			s.VerboseLog((depth + 2), "--> Auth resolution of ", ns, " Failed: ", status)
 			continue
 		}
 		s.VerboseLog((depth + 1), "--> Auth Resolution success: ", status)
-		return r, status, err
+		return r, status, err, trace
 	}
 	s.VerboseLog((depth + 1), "Unable to find authoritative name server")
 	var r Result
-	return r, zdns.STATUS_ERROR, errors.New("could not find authoritative name server")
+	return r, zdns.STATUS_ERROR, errors.New("could not find authoritative name server"), trace
 }
 
-func (s *Lookup) iterativeLookup(dnsType uint16, dnsClass uint16, name string, nameServer string, depth int, layer string) (Result, zdns.Status, error) {
+func (s *Lookup) iterativeLookup(dnsType uint16, dnsClass uint16, name string, nameServer string, depth int, layer string, trace []Trace) (Result, zdns.Status, error, []Trace) {
 	if log.GetLevel() == log.DebugLevel {
 		//s.VerboseLog((depth), "iterative lookup for ", name, " (", dnsType, ") against ", nameServer, " (", debugReverseLookup(nameServer), ") layer ", layer)
 		s.VerboseLog((depth), "iterative lookup for ", name, " (", dnsType, ") against ", nameServer, " layer ", layer)
@@ -690,12 +706,25 @@ func (s *Lookup) iterativeLookup(dnsType uint16, dnsClass uint16, name string, n
 	if depth > s.Factory.MaxDepth {
 		var r Result
 		s.VerboseLog((depth + 1), "-> Max recursion depth reached")
-		return r, zdns.STATUS_ERROR, errors.New("Max recursion depth reached")
+		return r, zdns.STATUS_ERROR, errors.New("Max recursion depth reached"), trace
 	}
-	result, status, err := s.cachedRetryingLookup(dnsType, dnsClass, name, nameServer, layer, depth)
+	result, status, err, isCached := s.cachedRetryingLookup(dnsType, dnsClass, name, nameServer, layer, depth)
+	if s.Factory.Trace && status == zdns.STATUS_NOERROR {
+		var t Trace
+		t.Result = result
+		t.DnsType = dnsType
+		t.DnsClass = dnsClass
+		t.Name = name
+		t.NameServer = nameServer
+		t.Layer = layer
+		t.Depth = depth
+		t.Cached = isCached
+		trace = append(trace, t)
+
+	}
 	if status != zdns.STATUS_NOERROR {
 		s.VerboseLog((depth + 1), "-> error occurred during lookup")
-		return result, status, err
+		return result, status, err, trace
 	} else if len(result.Answers) != 0 || result.Flags.Authoritative == true {
 		if len(result.Answers) != 0 {
 			s.VerboseLog((depth + 1), "-> answers found")
@@ -710,13 +739,13 @@ func (s *Lookup) iterativeLookup(dnsType uint16, dnsClass uint16, name string, n
 		} else {
 			s.VerboseLog((depth + 1), "-> authoritative response found")
 		}
-		return result, status, err
+		return result, status, err, trace
 	} else if len(result.Authorities) != 0 {
 		s.VerboseLog((depth + 1), "-> Authority found, iterating")
-		return s.iterateOnAuthorities(dnsType, dnsClass, name, depth, result, layer)
+		return s.iterateOnAuthorities(dnsType, dnsClass, name, depth, result, layer, trace)
 	} else {
 		s.VerboseLog((depth + 1), "-> No Authority found, error")
-		return result, zdns.STATUS_ERROR, errors.New("NOERROR record without any answers or authorities")
+		return result, zdns.STATUS_ERROR, errors.New("NOERROR record without any answers or authorities"), trace
 	}
 }
 
@@ -724,8 +753,11 @@ func (s *Lookup) DoMiekgLookup(name string) (interface{}, zdns.Status, error) {
 	if s.Factory.IterativeResolution {
 		s.VerboseLog(0, "MIEKG-IN: iterative lookup for ", name, " (", s.DNSType, ")")
 		s.IterativeStop = time.Now().Add(time.Duration(s.Factory.IterativeTimeout))
-		result, status, err := s.iterativeLookup(s.DNSType, s.DNSClass, name, s.NameServer, 1, ".")
+		result, status, err, trace := s.iterativeLookup(s.DNSType, s.DNSClass, name, s.NameServer, 1, ".", make([]Trace, 0))
 		s.VerboseLog(0, "MIEKG-OUT: iterative lookup for ", name, " (", s.DNSType, "): status: ", status, " , err: ", err)
+		if s.Factory.Trace {
+			result.Trace = trace
+		}
 		return result, status, err
 
 	} else {
@@ -737,8 +769,11 @@ func (s *Lookup) DoMiekgLookupForClass(name string, dnsClass uint16) (interface{
 	if s.Factory.IterativeResolution {
 		s.VerboseLog(0, "MIEKG-IN: iterative lookup for ", name, " (", s.DNSType, ") in class ", dnsClass)
 		s.IterativeStop = time.Now().Add(time.Duration(s.Factory.IterativeTimeout))
-		result, status, err := s.iterativeLookup(s.DNSType, s.DNSClass, name, s.NameServer, 1, ".")
+		result, status, err, trace := s.iterativeLookup(s.DNSType, s.DNSClass, name, s.NameServer, 1, ".", make([]Trace, 0))
 		s.VerboseLog(0, "MIEKG-OUT: iterative lookup for ", name, " (", s.DNSType, "): status: ", status, " , err: ", err)
+		if s.Factory.Trace {
+			result.Trace = trace
+		}
 		return result, status, err
 
 	} else {
@@ -753,8 +788,11 @@ func (s *Lookup) DoTypedMiekgLookup(name string, dnsType uint16) (interface{}, z
 	if s.Factory.IterativeResolution {
 		s.VerboseLog(0, "MIEKG-IN: iterative lookup for ", name, " (", dnsType, ")")
 		s.IterativeStop = time.Now().Add(time.Duration(s.Factory.IterativeTimeout))
-		result, status, err := s.iterativeLookup(dnsType, s.DNSClass, name, s.NameServer, 1, ".")
+		result, status, err, trace := s.iterativeLookup(dnsType, s.DNSClass, name, s.NameServer, 1, ".", make([]Trace, 0))
 		s.VerboseLog(0, "MIEKG-OUT: iterative lookup for ", name, " (", dnsType, "): status: ", status, " , err: ", err)
+		if s.Factory.Trace {
+			result.Trace = trace
+		}
 		return result, status, err
 	} else {
 		return s.retryingLookup(dnsType, s.DNSClass, name, s.NameServer, true)
@@ -768,8 +806,11 @@ func (s *Lookup) DoTypedMiekgLookupInClass(name string, dnsType uint16, dnsClass
 	if s.Factory.IterativeResolution {
 		s.VerboseLog(0, "MIEKG-IN: iterative lookup for ", name, " (", dnsType, ") in class ", dnsClass)
 		s.IterativeStop = time.Now().Add(time.Duration(s.Factory.IterativeTimeout))
-		result, status, err := s.iterativeLookup(dnsType, dnsClass, name, s.NameServer, 1, ".")
+		result, status, err, trace := s.iterativeLookup(dnsType, dnsClass, name, s.NameServer, 1, ".", make([]Trace, 0))
 		s.VerboseLog(0, "MIEKG-OUT: iterative lookup for ", name, " (", dnsType, "): status: ", status, " , err: ", err)
+		if s.Factory.Trace {
+			result.Trace = trace
+		}
 		return result, status, err
 	} else {
 		return s.retryingLookup(dnsType, dnsClass, name, s.NameServer, true)

--- a/modules/mxlookup/mxlookup.go
+++ b/modules/mxlookup/mxlookup.go
@@ -68,7 +68,7 @@ func (s *Lookup) LookupIPs(name string) (CachedAddresses, []interface{}) {
 	var retv CachedAddresses
 	trace := make([]interface{}, 0)
 	// ipv4
-	if s.Factory.Factory.IPv4Lookup {
+	if s.Factory.Factory.IPv4Lookup || !s.Factory.Factory.IPv6Lookup {
 		res, secondTrace, status, _ := s.DoTypedMiekgLookup(name, dns.TypeA)
 		trace = append(trace, secondTrace...)
 		if status == zdns.STATUS_NOERROR {

--- a/modules/mxlookup/mxlookup.go
+++ b/modules/mxlookup/mxlookup.go
@@ -57,7 +57,7 @@ func dotName(name string) string {
 	return strings.Join([]string{name, "."}, "")
 }
 
-func (s *Lookup) LookupIPs(name string) (CachedAddresses, interface{}) {
+func (s *Lookup) LookupIPs(name string) (CachedAddresses, []interface{}) {
 	s.Factory.Factory.CHmu.Lock()
 	// XXX this should be changed to a miekglookup
 	res, found := s.Factory.Factory.CacheHash.Get(name)
@@ -70,7 +70,7 @@ func (s *Lookup) LookupIPs(name string) (CachedAddresses, interface{}) {
 	// ipv4
 	if s.Factory.Factory.IPv4Lookup {
 		res, secondTrace, status, _ := s.DoTypedMiekgLookup(name, dns.TypeA)
-		trace = append(trace, secondTrace.([]interface{})...)
+		trace = append(trace, secondTrace...)
 		if status == zdns.STATUS_NOERROR {
 			cast, _ := res.(miekg.Result)
 			for _, innerRes := range cast.Answers {
@@ -85,7 +85,7 @@ func (s *Lookup) LookupIPs(name string) (CachedAddresses, interface{}) {
 	// ipv6
 	if s.Factory.Factory.IPv6Lookup {
 		res, secondTrace, status, _ := s.DoTypedMiekgLookup(name, dns.TypeAAAA)
-		trace = append(trace, secondTrace.([]interface{})...)
+		trace = append(trace, secondTrace...)
 		if status == zdns.STATUS_NOERROR {
 			cast, _ := res.(miekg.Result)
 			for _, innerRes := range cast.Answers {
@@ -103,7 +103,7 @@ func (s *Lookup) LookupIPs(name string) (CachedAddresses, interface{}) {
 	return retv, trace
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name string) (interface{}, []interface{}, zdns.Status, error) {
 	retv := Result{Servers: []MXRecord{}}
 	res, trace, status, err := s.DoTypedMiekgLookup(name, dns.TypeMX)
 	if status != zdns.STATUS_NOERROR {
@@ -121,7 +121,7 @@ func (s *Lookup) DoLookup(name string) (interface{}, interface{}, zdns.Status, e
 			rec.IPv4Addresses = ips.IPv4Addresses
 			rec.IPv6Addresses = ips.IPv6Addresses
 			retv.Servers = append(retv.Servers, rec)
-			trace = append(trace.([]interface{}), secondTrace.([]interface{})...)
+			trace = append(trace, secondTrace...)
 		}
 	}
 	return retv, trace, zdns.STATUS_NOERROR, nil

--- a/modules/nslookup/nslookup.go
+++ b/modules/nslookup/nslookup.go
@@ -48,7 +48,7 @@ func dotName(name string) string {
 	return strings.Join([]string{name, "."}, "")
 }
 
-func (s *Lookup) lookupIPs(name string, dnsType uint16) ([]string, interface{}) {
+func (s *Lookup) lookupIPs(name string, dnsType uint16) ([]string, []interface{}) {
 	var addresses []string
 	res, trace, status, _ := s.DoTypedMiekgLookup(name, dnsType)
 	if status == zdns.STATUS_NOERROR {
@@ -61,7 +61,7 @@ func (s *Lookup) lookupIPs(name string, dnsType uint16) ([]string, interface{}) 
 	return addresses, trace
 }
 
-func (s *Lookup) DoNSLookup(name string, lookupIPv4 bool, lookupIPv6 bool) (Result, interface{}, zdns.Status, error) {
+func (s *Lookup) DoNSLookup(name string, lookupIPv4 bool, lookupIPv6 bool) (Result, []interface{}, zdns.Status, error) {
 	var retv Result
 	res, trace, status, err := s.DoTypedMiekgLookup(name, dns.TypeNS)
 	if status != zdns.STATUS_NOERROR || err != nil {
@@ -95,18 +95,18 @@ func (s *Lookup) DoNSLookup(name string, lookupIPv4 bool, lookupIPv6 bool) (Resu
 		rec.Name = strings.TrimSuffix(a.Answer, ".")
 		rec.TTL = a.Ttl
 		if lookupIPv4 {
-			var secondTrace interface{}
+			var secondTrace []interface{}
 			rec.IPv4Addresses, secondTrace = s.lookupIPs(rec.Name, dns.TypeA)
-			trace = append(trace.([]interface{}), secondTrace.([]interface{})...)
+			trace = append(trace, secondTrace...)
 		} else if ip, ok := ipv4s[rec.Name]; ok {
 			rec.IPv4Addresses = []string{ip}
 		} else {
 			rec.IPv4Addresses = []string{}
 		}
 		if lookupIPv6 {
-			var secondTrace interface{}
+			var secondTrace []interface{}
 			rec.IPv6Addresses, secondTrace = s.lookupIPs(rec.Name, dns.TypeAAAA)
-			trace = append(trace.([]interface{}), secondTrace.([]interface{})...)
+			trace = append(trace, secondTrace...)
 		} else if ip, ok := ipv6s[rec.Name]; ok {
 			rec.IPv6Addresses = []string{ip}
 		} else {
@@ -122,7 +122,7 @@ func (s *Lookup) DoNSLookup(name string, lookupIPv4 bool, lookupIPv6 bool) (Resu
 
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name string) (interface{}, []interface{}, zdns.Status, error) {
 	return s.DoNSLookup(name, s.Factory.Factory.IPv4Lookup, s.Factory.Factory.IPv6Lookup)
 }
 

--- a/modules/nslookup/nslookup.go
+++ b/modules/nslookup/nslookup.go
@@ -48,9 +48,9 @@ func dotName(name string) string {
 	return strings.Join([]string{name, "."}, "")
 }
 
-func (s *Lookup) lookupIPs(name string, dnsType uint16) []string {
+func (s *Lookup) lookupIPs(name string, dnsType uint16) ([]string, interface{}) {
 	var addresses []string
-	res, status, _ := s.DoTypedMiekgLookup(name, dnsType)
+	res, trace, status, _ := s.DoTypedMiekgLookup(name, dnsType)
 	if status == zdns.STATUS_NOERROR {
 		cast, _ := res.(miekg.Result)
 		for _, innerRes := range cast.Answers {
@@ -58,14 +58,14 @@ func (s *Lookup) lookupIPs(name string, dnsType uint16) []string {
 			addresses = append(addresses, castInnerRes.Answer)
 		}
 	}
-	return addresses
+	return addresses, trace
 }
 
-func (s *Lookup) DoNSLookup(name string, lookupIPv4 bool, lookupIPv6 bool) (Result, zdns.Status, error) {
+func (s *Lookup) DoNSLookup(name string, lookupIPv4 bool, lookupIPv6 bool) (Result, interface{}, zdns.Status, error) {
 	var retv Result
-	res, status, err := s.DoTypedMiekgLookup(name, dns.TypeNS)
+	res, trace, status, err := s.DoTypedMiekgLookup(name, dns.TypeNS)
 	if status != zdns.STATUS_NOERROR || err != nil {
-		return retv, status, nil
+		return retv, trace, status, nil
 	}
 	ns := res.(miekg.Result)
 	ipv4s := make(map[string]string)
@@ -95,14 +95,18 @@ func (s *Lookup) DoNSLookup(name string, lookupIPv4 bool, lookupIPv6 bool) (Resu
 		rec.Name = strings.TrimSuffix(a.Answer, ".")
 		rec.TTL = a.Ttl
 		if lookupIPv4 {
-			rec.IPv4Addresses = s.lookupIPs(rec.Name, dns.TypeA)
+			var secondTrace interface{}
+			rec.IPv4Addresses, secondTrace = s.lookupIPs(rec.Name, dns.TypeA)
+			trace = append(trace.([]interface{}), secondTrace.([]interface{})...)
 		} else if ip, ok := ipv4s[rec.Name]; ok {
 			rec.IPv4Addresses = []string{ip}
 		} else {
 			rec.IPv4Addresses = []string{}
 		}
 		if lookupIPv6 {
-			rec.IPv6Addresses = s.lookupIPs(rec.Name, dns.TypeAAAA)
+			var secondTrace interface{}
+			rec.IPv6Addresses, secondTrace = s.lookupIPs(rec.Name, dns.TypeAAAA)
+			trace = append(trace.([]interface{}), secondTrace.([]interface{})...)
 		} else if ip, ok := ipv6s[rec.Name]; ok {
 			rec.IPv6Addresses = []string{ip}
 		} else {
@@ -111,14 +115,14 @@ func (s *Lookup) DoNSLookup(name string, lookupIPv4 bool, lookupIPv6 bool) (Resu
 		retv.Servers = append(retv.Servers, rec)
 	}
 	if len(retv.Servers) == 0 {
-		return retv, zdns.STATUS_NO_RECORD, nil
+		return retv, trace, zdns.STATUS_NO_RECORD, nil
 	}
 
-	return retv, zdns.STATUS_NOERROR, nil
+	return retv, trace, zdns.STATUS_NOERROR, nil
 
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name string) (interface{}, interface{}, zdns.Status, error) {
 	return s.DoNSLookup(name, s.Factory.Factory.IPv4Lookup, s.Factory.Factory.IPv6Lookup)
 }
 

--- a/modules/nslookup/nslookup.go
+++ b/modules/nslookup/nslookup.go
@@ -94,7 +94,7 @@ func (s *Lookup) DoNSLookup(name string, lookupIPv4 bool, lookupIPv6 bool) (Resu
 		rec.Type = a.Type
 		rec.Name = strings.TrimSuffix(a.Answer, ".")
 		rec.TTL = a.Ttl
-		if lookupIPv4 {
+		if lookupIPv4 || !lookupIPv6 {
 			var secondTrace []interface{}
 			rec.IPv4Addresses, secondTrace = s.lookupIPs(rec.Name, dns.TypeA)
 			trace = append(trace, secondTrace...)

--- a/modules/spf/spf.go
+++ b/modules/spf/spf.go
@@ -32,7 +32,7 @@ type Lookup struct {
 	miekg.Lookup
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name string) (interface{}, []interface{}, zdns.Status, error) {
 	var res Result
 	innerRes, trace, status, err := s.DoTxtLookup(name)
 	if status != zdns.STATUS_NOERROR {

--- a/modules/spf/spf.go
+++ b/modules/spf/spf.go
@@ -32,14 +32,14 @@ type Lookup struct {
 	miekg.Lookup
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name string) (interface{}, interface{}, zdns.Status, error) {
 	var res Result
-	innerRes, status, err := s.DoTxtLookup(name)
+	innerRes, trace, status, err := s.DoTxtLookup(name)
 	if status != zdns.STATUS_NOERROR {
-		return res, status, err
+		return res, trace, status, err
 	}
 	res.Spf = innerRes
-	return res, zdns.STATUS_NOERROR, nil
+	return res, trace, zdns.STATUS_NOERROR, nil
 }
 
 // Per GoRoutine Factory ======================================================

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -43,7 +43,7 @@ func main() {
 	flags.StringVar(&gc.NamePrefix, "prefix", "", "name to be prepended to what's passed in (e.g., www.)")
 	flags.BoolVar(&gc.AlexaFormat, "alexa", false, "is input file from Alexa Top Million download")
 	flags.BoolVar(&gc.IterativeResolution, "iterative", false, "Perform own iteration instead of relying on recursive resolver")
-	flags.BoolVar(&gc.Trace, "trace", false, "Output a trace of individual steps for iterative resolutions")
+	flags.BoolVar(&gc.Trace, "trace", false, "Output a trace of individual steps for each resolution")
 	flags.StringVar(&gc.InputFilePath, "input-file", "-", "names to read")
 	flags.StringVar(&gc.OutputFilePath, "output-file", "-", "where should JSON output be saved")
 	flags.StringVar(&gc.MetadataFilePath, "metadata-file", "", "where should JSON metadata be saved")

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -43,6 +43,7 @@ func main() {
 	flags.StringVar(&gc.NamePrefix, "prefix", "", "name to be prepended to what's passed in (e.g., www.)")
 	flags.BoolVar(&gc.AlexaFormat, "alexa", false, "is input file from Alexa Top Million download")
 	flags.BoolVar(&gc.IterativeResolution, "iterative", false, "Perform own iteration instead of relying on recursive resolver")
+	flags.BoolVar(&gc.Trace, "trace", false, "Output a trace of individual steps for iterative resolutions")
 	flags.StringVar(&gc.InputFilePath, "input-file", "-", "names to read")
 	flags.StringVar(&gc.OutputFilePath, "output-file", "-", "where should JSON output be saved")
 	flags.StringVar(&gc.MetadataFilePath, "metadata-file", "", "where should JSON metadata be saved")


### PR DESCRIPTION
This adds support for `trace`, a top level field in the json output that is a list of all queries zdns performed (including those that hit its own internal cache) as part of performing a resolution. This includes recursive and iterative queries, *Lookup and non lookup. (`trace` is omitted if `--trace` is not supplied as an option.)

```
$ echo "www.zdns-testing.com" | ./zdns/zdns a --trace | jq "." 
{
  "trace": [
    {
      "cached": false,
      "layer": "www.zdns-testing.com",
      "depth": 1,
      "name_server": "8.8.8.8:53",
      "name": "www.zdns-testing.com",
      "class": 1,
      "type": 1,
      "results": {
        "flags": {
          "error_code": 0,
          "response": true,
          "opcode": 0,
          "authoritative": false,
          "truncated": false,
          "recursion_desired": true,
          "recursion_available": true,
          "authenticated": false,
          "checking_disabled": false
        },
        "protocol": "udp",
        "authorities": [],
        "additionals": [],
        "answers": [
          {
            "answer": "zdns-testing.com.",
            "name": "www.zdns-testing.com",
            "class": "IN",
            "type": "CNAME",
            "ttl": 207
          },
          {
            "answer": "1.2.3.4",
            "name": "zdns-testing.com",
            "class": "IN",
            "type": "A",
            "ttl": 207
          },
          {
            "answer": "2.3.4.5",
            "name": "zdns-testing.com",
            "class": "IN",
            "type": "A",
            "ttl": 207
          },
          {
            "answer": "3.4.5.6",
            "name": "zdns-testing.com",
            "class": "IN",
            "type": "A",
            "ttl": 207
          }
        ]
      }
    }
  ],
  "data": {
    "flags": {
      "error_code": 0,
      "response": true,
      "opcode": 0,
      "authoritative": false,
      "truncated": false,
      "recursion_desired": true,
      "recursion_available": true,
      "authenticated": false,
      "checking_disabled": false
    },
    "protocol": "udp",
    "authorities": [],
    "additionals": [],
    "answers": [
      {
        "answer": "zdns-testing.com.",
        "name": "www.zdns-testing.com",
        "class": "IN",
        "type": "CNAME",
        "ttl": 207
      },
      {
        "answer": "1.2.3.4",
        "name": "zdns-testing.com",
        "class": "IN",
        "type": "A",
        "ttl": 207
      },
      {
        "answer": "2.3.4.5",
        "name": "zdns-testing.com",
        "class": "IN",
        "type": "A",
        "ttl": 207
      },
      {
        "answer": "3.4.5.6",
        "name": "zdns-testing.com",
        "class": "IN",
        "type": "A",
        "ttl": 207
      }
    ]
  },
  "timestamp": "2017-08-21T13:43:05-07:00",
  "status": "NOERROR",
  "class": "IN",
  "name": "www.zdns-testing.com"
}
```

```
$ echo "www.zdns-testing.com" | ./zdns/zdns alookup --trace --iterative | jq "." 
{
  "trace": [
    {
      "cached": false,
      "layer": ".",
      "depth": 1,
      "name_server": "198.41.0.4:53",
      "name": "www.zdns-testing.com",
      "class": 1,
      "type": 1,
      "results": {
        "flags": {
          "error_code": 0,
          "response": true,
          "opcode": 0,
          "authoritative": false,
          "truncated": false,
          "recursion_desired": false,
          "recursion_available": false,
          "authenticated": false,
          "checking_disabled": false
        },
        "protocol": "udp",
        "authorities": [
          {
            "answer": "a.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "b.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "c.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "d.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "e.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "f.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "g.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "h.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "i.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "j.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "k.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "l.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "m.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          }
        ],
        "additionals": [
          {
            "answer": "192.5.6.30",
            "name": "a.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.33.14.30",
            "name": "b.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.26.92.30",
            "name": "c.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.31.80.30",
            "name": "d.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.12.94.30",
            "name": "e.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.35.51.30",
            "name": "f.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.42.93.30",
            "name": "g.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.54.112.30",
            "name": "h.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.43.172.30",
            "name": "i.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.48.79.30",
            "name": "j.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.52.178.30",
            "name": "k.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.41.162.30",
            "name": "l.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.55.83.30",
            "name": "m.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "2001:503:a83e::2:30",
            "name": "a.gtld-servers.net",
            "class": "IN",
            "type": "AAAA",
            "ttl": 172800
          }
        ],
        "answers": []
      }
    },
    {
      "cached": false,
      "layer": "com",
      "depth": 2,
      "name_server": "192.5.6.30:53",
      "name": "www.zdns-testing.com",
      "class": 1,
      "type": 1,
      "results": {
        "flags": {
          "error_code": 0,
          "response": true,
          "opcode": 0,
          "authoritative": false,
          "truncated": false,
          "recursion_desired": false,
          "recursion_available": false,
          "authenticated": false,
          "checking_disabled": false
        },
        "protocol": "udp",
        "authorities": [
          {
            "answer": "ns-cloud-b1.googledomains.com",
            "name": "zdns-testing.com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "ns-cloud-b2.googledomains.com",
            "name": "zdns-testing.com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "ns-cloud-b3.googledomains.com",
            "name": "zdns-testing.com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "ns-cloud-b4.googledomains.com",
            "name": "zdns-testing.com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          }
        ],
        "additionals": [
          {
            "answer": "2001:4860:4802:32::6b",
            "name": "ns-cloud-b1.googledomains.com",
            "class": "IN",
            "type": "AAAA",
            "ttl": 172800
          },
          {
            "answer": "216.239.32.107",
            "name": "ns-cloud-b1.googledomains.com",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "2001:4860:4802:34::6b",
            "name": "ns-cloud-b2.googledomains.com",
            "class": "IN",
            "type": "AAAA",
            "ttl": 172800
          },
          {
            "answer": "216.239.34.107",
            "name": "ns-cloud-b2.googledomains.com",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "2001:4860:4802:36::6b",
            "name": "ns-cloud-b3.googledomains.com",
            "class": "IN",
            "type": "AAAA",
            "ttl": 172800
          },
          {
            "answer": "216.239.36.107",
            "name": "ns-cloud-b3.googledomains.com",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "2001:4860:4802:38::6b",
            "name": "ns-cloud-b4.googledomains.com",
            "class": "IN",
            "type": "AAAA",
            "ttl": 172800
          },
          {
            "answer": "216.239.38.107",
            "name": "ns-cloud-b4.googledomains.com",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          }
        ],
        "answers": []
      }
    },
    {
      "cached": false,
      "layer": "zdns-testing.com",
      "depth": 3,
      "name_server": "216.239.32.107:53",
      "name": "www.zdns-testing.com",
      "class": 1,
      "type": 1,
      "results": {
        "flags": {
          "error_code": 0,
          "response": true,
          "opcode": 0,
          "authoritative": true,
          "truncated": false,
          "recursion_desired": false,
          "recursion_available": false,
          "authenticated": false,
          "checking_disabled": false
        },
        "protocol": "udp",
        "authorities": [],
        "additionals": [],
        "answers": [
          {
            "answer": "zdns-testing.com.",
            "name": "www.zdns-testing.com",
            "class": "IN",
            "type": "CNAME",
            "ttl": 300
          },
          {
            "answer": "1.2.3.4",
            "name": "zdns-testing.com",
            "class": "IN",
            "type": "A",
            "ttl": 300
          },
          {
            "answer": "2.3.4.5",
            "name": "zdns-testing.com",
            "class": "IN",
            "type": "A",
            "ttl": 300
          },
          {
            "answer": "3.4.5.6",
            "name": "zdns-testing.com",
            "class": "IN",
            "type": "A",
            "ttl": 300
          }
        ]
      }
    }
  ],
  "data": {
    "ipv4_addresses": [
      "1.2.3.4",
      "2.3.4.5",
      "3.4.5.6"
    ]
  },
  "timestamp": "2017-08-21T13:43:54-07:00",
  "status": "NOERROR",
  "class": "IN",
  "name": "www.zdns-testing.com"
}
```

```
$ echo "www.cnn.com" | ./zdns/zdns alookup --trace --iterative | jq "." 
{
  "trace": [
    {
      "cached": false,
      "layer": ".",
      "depth": 1,
      "name_server": "199.7.91.13:53",
      "name": "www.cnn.com",
      "class": 1,
      "type": 1,
      "results": {
        "flags": {
          "error_code": 0,
          "response": true,
          "opcode": 0,
          "authoritative": false,
          "truncated": false,
          "recursion_desired": false,
          "recursion_available": false,
          "authenticated": false,
          "checking_disabled": false
        },
        "protocol": "udp",
        "authorities": [
          {
            "answer": "e.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "f.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "m.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "l.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "h.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "j.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "k.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "i.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "a.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "g.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "b.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "d.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "c.gtld-servers.net",
            "name": "com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          }
        ],
        "additionals": [
          {
            "answer": "192.5.6.30",
            "name": "a.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.33.14.30",
            "name": "b.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.26.92.30",
            "name": "c.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.31.80.30",
            "name": "d.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.12.94.30",
            "name": "e.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.35.51.30",
            "name": "f.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.42.93.30",
            "name": "g.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.54.112.30",
            "name": "h.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.43.172.30",
            "name": "i.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.48.79.30",
            "name": "j.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.52.178.30",
            "name": "k.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.41.162.30",
            "name": "l.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.55.83.30",
            "name": "m.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "2001:503:a83e::2:30",
            "name": "a.gtld-servers.net",
            "class": "IN",
            "type": "AAAA",
            "ttl": 172800
          }
        ],
        "answers": []
      }
    },
    {
      "cached": false,
      "layer": "com",
      "depth": 2,
      "name_server": "192.12.94.30:53",
      "name": "www.cnn.com",
      "class": 1,
      "type": 1,
      "results": {
        "flags": {
          "error_code": 0,
          "response": true,
          "opcode": 0,
          "authoritative": false,
          "truncated": false,
          "recursion_desired": false,
          "recursion_available": false,
          "authenticated": false,
          "checking_disabled": false
        },
        "protocol": "udp",
        "authorities": [
          {
            "answer": "ns-47.awsdns-05.com",
            "name": "cnn.com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "ns-576.awsdns-08.net",
            "name": "cnn.com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "ns-1630.awsdns-11.co.uk",
            "name": "cnn.com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "ns-1086.awsdns-07.org",
            "name": "cnn.com",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          }
        ],
        "additionals": [
          {
            "answer": "205.251.192.47",
            "name": "ns-47.awsdns-05.com",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "205.251.194.64",
            "name": "ns-576.awsdns-08.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          }
        ],
        "answers": []
      }
    },
    {
      "cached": false,
      "layer": "cnn.com",
      "depth": 3,
      "name_server": "205.251.192.47:53",
      "name": "www.cnn.com",
      "class": 1,
      "type": 1,
      "results": {
        "flags": {
          "error_code": 0,
          "response": true,
          "opcode": 0,
          "authoritative": true,
          "truncated": false,
          "recursion_desired": false,
          "recursion_available": false,
          "authenticated": false,
          "checking_disabled": false
        },
        "protocol": "udp",
        "authorities": [
          {
            "answer": "ns-1086.awsdns-07.org",
            "name": "cnn.com",
            "class": "IN",
            "type": "NS",
            "ttl": 3600
          },
          {
            "answer": "ns-1630.awsdns-11.co.uk",
            "name": "cnn.com",
            "class": "IN",
            "type": "NS",
            "ttl": 3600
          },
          {
            "answer": "ns-47.awsdns-05.com",
            "name": "cnn.com",
            "class": "IN",
            "type": "NS",
            "ttl": 3600
          },
          {
            "answer": "ns-576.awsdns-08.net",
            "name": "cnn.com",
            "class": "IN",
            "type": "NS",
            "ttl": 3600
          }
        ],
        "additionals": [],
        "answers": [
          {
            "answer": "turner-tls.map.fastly.net.",
            "name": "www.cnn.com",
            "class": "IN",
            "type": "CNAME",
            "ttl": 300
          }
        ]
      }
    },
    {
      "cached": false,
      "layer": ".",
      "depth": 1,
      "name_server": "199.7.91.13:53",
      "name": "turner-tls.map.fastly.net",
      "class": 1,
      "type": 1,
      "results": {
        "flags": {
          "error_code": 0,
          "response": true,
          "opcode": 0,
          "authoritative": false,
          "truncated": false,
          "recursion_desired": false,
          "recursion_available": false,
          "authenticated": false,
          "checking_disabled": false
        },
        "protocol": "udp",
        "authorities": [
          {
            "answer": "k.gtld-servers.net",
            "name": "net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "g.gtld-servers.net",
            "name": "net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "b.gtld-servers.net",
            "name": "net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "e.gtld-servers.net",
            "name": "net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "l.gtld-servers.net",
            "name": "net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "f.gtld-servers.net",
            "name": "net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "h.gtld-servers.net",
            "name": "net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "d.gtld-servers.net",
            "name": "net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "j.gtld-servers.net",
            "name": "net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "m.gtld-servers.net",
            "name": "net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "a.gtld-servers.net",
            "name": "net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "c.gtld-servers.net",
            "name": "net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "i.gtld-servers.net",
            "name": "net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          }
        ],
        "additionals": [
          {
            "answer": "192.5.6.30",
            "name": "a.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.33.14.30",
            "name": "b.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.26.92.30",
            "name": "c.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.31.80.30",
            "name": "d.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.12.94.30",
            "name": "e.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.35.51.30",
            "name": "f.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.42.93.30",
            "name": "g.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.54.112.30",
            "name": "h.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.43.172.30",
            "name": "i.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.48.79.30",
            "name": "j.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.52.178.30",
            "name": "k.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.41.162.30",
            "name": "l.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "192.55.83.30",
            "name": "m.gtld-servers.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "2001:503:a83e::2:30",
            "name": "a.gtld-servers.net",
            "class": "IN",
            "type": "AAAA",
            "ttl": 172800
          }
        ],
        "answers": []
      }
    },
    {
      "cached": false,
      "layer": "net",
      "depth": 2,
      "name_server": "192.52.178.30:53",
      "name": "turner-tls.map.fastly.net",
      "class": 1,
      "type": 1,
      "results": {
        "flags": {
          "error_code": 0,
          "response": true,
          "opcode": 0,
          "authoritative": false,
          "truncated": false,
          "recursion_desired": false,
          "recursion_available": false,
          "authenticated": false,
          "checking_disabled": false
        },
        "protocol": "udp",
        "authorities": [
          {
            "answer": "ns1.fastly.net",
            "name": "fastly.net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "ns2.fastly.net",
            "name": "fastly.net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "ns3.fastly.net",
            "name": "fastly.net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          },
          {
            "answer": "ns4.fastly.net",
            "name": "fastly.net",
            "class": "IN",
            "type": "NS",
            "ttl": 172800
          }
        ],
        "additionals": [
          {
            "answer": "23.235.32.32",
            "name": "ns1.fastly.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "104.156.80.32",
            "name": "ns2.fastly.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "23.235.36.32",
            "name": "ns3.fastly.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          },
          {
            "answer": "104.156.84.32",
            "name": "ns4.fastly.net",
            "class": "IN",
            "type": "A",
            "ttl": 172800
          }
        ],
        "answers": []
      }
    },
    {
      "cached": false,
      "layer": "fastly.net",
      "depth": 3,
      "name_server": "23.235.32.32:53",
      "name": "turner-tls.map.fastly.net",
      "class": 1,
      "type": 1,
      "results": {
        "flags": {
          "error_code": 0,
          "response": true,
          "opcode": 0,
          "authoritative": true,
          "truncated": false,
          "recursion_desired": false,
          "recursion_available": false,
          "authenticated": false,
          "checking_disabled": false
        },
        "protocol": "udp",
        "authorities": [
          {
            "answer": "ns1.fastly.net",
            "name": "fastly.net",
            "class": "IN",
            "type": "NS",
            "ttl": 7200
          },
          {
            "answer": "ns2.fastly.net",
            "name": "fastly.net",
            "class": "IN",
            "type": "NS",
            "ttl": 7200
          },
          {
            "answer": "ns3.fastly.net",
            "name": "fastly.net",
            "class": "IN",
            "type": "NS",
            "ttl": 7200
          },
          {
            "answer": "ns4.fastly.net",
            "name": "fastly.net",
            "class": "IN",
            "type": "NS",
            "ttl": 7200
          }
        ],
        "additionals": [],
        "answers": [
          {
            "answer": "151.101.41.67",
            "name": "turner-tls.map.fastly.net",
            "class": "IN",
            "type": "A",
            "ttl": 30
          }
        ]
      }
    }
  ],
  "data": {
    "ipv4_addresses": [
      "151.101.41.67"
    ]
  },
  "timestamp": "2017-08-21T13:45:45-07:00",
  "status": "NOERROR",
  "class": "IN",
  "name": "www.cnn.com"
}
```