### PR TITLE
update Sirupsen -> sirupsen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zdns/zdns
 .*
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 go:
 - 1.7.4
 before_install:
-- go get github.com/Sirupsen/logrus
+- go get github.com/sirupsen/logrus
 - go get github.com/miekg/dns
 - go get github.com/zmap/go-iptree/iptree
 - go get github.com/zmap/go-iptree/blacklist

--- a/interface.go
+++ b/interface.go
@@ -19,8 +19,8 @@ import (
 	"math/rand"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
 )
 
 /* Each lookup module registers a single GlobalLookupFactory, which is

--- a/lookup.go
+++ b/lookup.go
@@ -23,8 +23,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
 )
 
 type routineMetadata struct {

--- a/modules/axfr/axfr.go
+++ b/modules/axfr/axfr.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/miekg/dns"
 	"github.com/zmap/go-iptree/blacklist"

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/miekg/dns"
 	"github.com/zmap/zdns"

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zdns"
 	_ "github.com/zmap/zdns/modules/alookup"
 	_ "github.com/zmap/zdns/modules/axfr"


### PR DESCRIPTION
The Sirupsen package is lowercased (https://github.com/sirupsen/logrus/pull/384), which is what other parts of ZMap/Censys are using (https://github.com/censys/certificate-daemon).

For consistency (and to get code that uses zdns to build) I'm updating the import here.