### PR TITLE
Refactor input/output

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -33,6 +33,9 @@ type GlobalConf struct {
 	NameServersSpecified bool
 	NameServers          []string
 
+	InputHandler  string
+	OutputHandler string
+
 	InputFilePath    string
 	OutputFilePath   string
 	LogFilePath      string

--- a/iohandlers/file/file.go
+++ b/iohandlers/file/file.go
@@ -1,0 +1,87 @@
+package file
+
+import (
+	"bufio"
+	"os"
+	"sync"
+
+	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
+	"github.com/zmap/zdns"
+)
+
+type InputHandler struct {
+	filepath string
+}
+
+func (h *InputHandler) Initialize(conf *zdns.GlobalConf) {
+	h.filepath = conf.InputFilePath
+}
+
+func (h *InputHandler) FeedChannel(in chan<- interface{}, wg *sync.WaitGroup, zonefileInput bool) error {
+	defer close(in)
+	defer (*wg).Done()
+
+	var f *os.File
+	if h.filepath == "" || h.filepath == "-" {
+		f = os.Stdin
+	} else {
+		var err error
+		f, err = os.Open(h.filepath)
+		if err != nil {
+			log.Fatal("unable to open input file:", err.Error())
+		}
+	}
+	if zonefileInput {
+		tokens := dns.ParseZone(f, ".", h.filepath)
+		for t := range tokens {
+			in <- t
+		}
+	} else {
+		s := bufio.NewScanner(f)
+		for s.Scan() {
+			in <- s.Text()
+		}
+		if err := s.Err(); err != nil {
+			log.Fatal("input unable to read file", err)
+		}
+	}
+	return nil
+}
+
+type OutputHandler struct {
+	filepath string
+}
+
+func (h *OutputHandler) Initialize(conf *zdns.GlobalConf) {
+	h.filepath = conf.OutputFilePath
+}
+
+func (h *OutputHandler) WriteResults(results <-chan string, wg *sync.WaitGroup) error {
+	defer (*wg).Done()
+
+	var f *os.File
+	if h.filepath == "" || h.filepath == "-" {
+		f = os.Stdout
+	} else {
+		var err error
+		f, err = os.OpenFile(h.filepath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			log.Fatal("unable to open output file:", err.Error())
+		}
+		defer f.Close()
+	}
+	for n := range results {
+		f.WriteString(n + "\n")
+	}
+	return nil
+}
+
+// register handlers
+func init() {
+	in := new(InputHandler)
+	zdns.RegisterInputHandler("file", in)
+
+	out := new(OutputHandler)
+	zdns.RegisterOutputHandler("file", out)
+}

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -31,6 +31,8 @@ import (
 	_ "github.com/zmap/zdns/modules/mxlookup"
 	_ "github.com/zmap/zdns/modules/nslookup"
 	_ "github.com/zmap/zdns/modules/spf"
+
+	_ "github.com/zmap/zdns/iohandlers/file"
 )
 
 func main() {
@@ -52,6 +54,8 @@ func main() {
 	flags.IntVar(&gc.Retries, "retries", 1, "how many times should zdns retry query if timeout or temporary failure")
 	flags.IntVar(&gc.MaxDepth, "max-depth", 10, "how deep should we recurse when performing iterative lookups")
 	flags.IntVar(&gc.CacheSize, "cache-size", 10000, "how many items can be stored in internal recursive cache")
+	flags.StringVar(&gc.InputHandler, "input-handler", "file", "handler to input names")
+	flags.StringVar(&gc.OutputHandler, "output-handler", "file", "handler to output names")
 	servers_string := flags.String("name-servers", "", "comma-delimited list of DNS servers to use")
 	config_file := flags.String("conf-file", "/etc/resolv.conf", "config file for DNS servers")
 	timeout := flags.Int("timeout", 15, "timeout for resolving an individual name")


### PR DESCRIPTION
This allows domain inputs and result outputs to be handled in a more
modular way. Just add iohandlers to define what will populate the input
and output channels. This would allow a workaround to issues like #127.