### PR TITLE
Output configuration data in metadata and add --nanoseconds

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -51,6 +51,7 @@ type Metadata struct {
 	NameServers []string       `json:"name_servers"`
 	Timeout     int            `json:"timeout"`
 	Retries     int            `json:"retries"`
+	Conf        *GlobalConf    `json:"conf"`
 }
 
 type Result struct {

--- a/conf.go
+++ b/conf.go
@@ -28,6 +28,7 @@ type GlobalConf struct {
 	CacheSize           int
 	GoMaxProcs          int
 	Verbosity           int
+	TimeFormat          string
 
 	NameServersSpecified bool
 	NameServers          []string

--- a/lookup.go
+++ b/lookup.go
@@ -114,7 +114,7 @@ func doLookup(g *GlobalLookupFactory, gc *GlobalConf, input <-chan interface{}, 
 			res.Class = dns.Class(gc.Class).String()
 			innerRes, trace, status, err = l.DoLookup(lookupName)
 		}
-		res.Timestamp = time.Now().Format(time.RFC3339)
+		res.Timestamp = time.Now().Format(gc.TimeFormat)
 		if status != STATUS_NO_OUTPUT {
 			res.Status = string(status)
 			res.Data = innerRes
@@ -218,7 +218,7 @@ func DoLookups(g *GlobalLookupFactory, c *GlobalConf) error {
 	// create pool of worker goroutines
 	var lookupWG sync.WaitGroup
 	lookupWG.Add(c.Threads)
-	startTime := time.Now().Format(time.RFC3339)
+	startTime := time.Now().Format(c.TimeFormat)
 	for i := 0; i < c.Threads; i++ {
 		go doLookup(g, c, inChan, outChan, metaChan, &lookupWG, i)
 	}
@@ -230,7 +230,7 @@ func DoLookups(g *GlobalLookupFactory, c *GlobalConf) error {
 		// we're done processing data. aggregate all the data from individual routines
 		metaData := aggregateMetadata(metaChan)
 		metaData.StartTime = startTime
-		metaData.EndTime = time.Now().Format(time.RFC3339)
+		metaData.EndTime = time.Now().Format(c.TimeFormat)
 		metaData.NameServers = c.NameServers
 		metaData.Retries = c.Retries
 		// Seconds() returns a float. However, timeout is passed in as an integer

--- a/lookup.go
+++ b/lookup.go
@@ -226,19 +226,20 @@ func DoLookups(g *GlobalLookupFactory, c *GlobalConf) error {
 	close(outChan)
 	close(metaChan)
 	routineWG.Wait()
-	// we're done processing data. aggregate all the data from individual routines
-	metadata := aggregateMetadata(metaChan)
-	metadata.StartTime = startTime
-	metadata.EndTime = time.Now().Format(time.RFC3339)
-	metadata.NameServers = c.NameServers
-	metadata.Retries = c.Retries
-	// Seconds() returns a float. However, timeout is passed in as an integer
-	// command line argument, so there should be no loss of data when casting
-	// back to an integer here.
-	metadata.Timeout = int(c.Timeout.Seconds())
-	// add global lookup-related metadata
-	// write out metadata
 	if c.MetadataFilePath != "" {
+		// we're done processing data. aggregate all the data from individual routines
+		metaData := aggregateMetadata(metaChan)
+		metaData.StartTime = startTime
+		metaData.EndTime = time.Now().Format(time.RFC3339)
+		metaData.NameServers = c.NameServers
+		metaData.Retries = c.Retries
+		// Seconds() returns a float. However, timeout is passed in as an integer
+		// command line argument, so there should be no loss of data when casting
+		// back to an integer here.
+		metaData.Timeout = int(c.Timeout.Seconds())
+		metaData.Conf = c
+		// add global lookup-related metadata
+		// write out metadata
 		var f *os.File
 		if c.MetadataFilePath == "-" {
 			f = os.Stderr
@@ -250,7 +251,7 @@ func DoLookups(g *GlobalLookupFactory, c *GlobalConf) error {
 			}
 			defer f.Close()
 		}
-		j, err := json.Marshal(metadata)
+		j, err := json.Marshal(metaData)
 		if err != nil {
 			log.Fatal("unable to JSON encode metadata:", err.Error())
 		}

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -57,6 +57,7 @@ func main() {
 	timeout := flags.Int("timeout", 15, "timeout for resolving an individual name")
 	iterationTimeout := flags.Int("iteration-timeout", 4, "timeout for resolving a single iteration in an iterative query")
 	class_string := flags.String("class", "INET", "DNS class to query (INET, CSNET, CHAOS, HESIOD, NONE, ANY (default INET)")
+	nanoSeconds := flags.Bool("nanoseconds", false, "Use nanosecond resolution timestamps")
 	// allow module to initialize and add its own flags before we parse
 	if len(os.Args) < 2 {
 		log.Fatal("No lookup module specified. Valid modules: ", zdns.ValidlookupsString())
@@ -131,6 +132,11 @@ func main() {
 	} else {
 		gc.NameServers = strings.Split(*servers_string, ",")
 		gc.NameServersSpecified = true
+	}
+	if *nanoSeconds {
+		gc.TimeFormat = time.RFC3339Nano
+	} else {
+		gc.TimeFormat = time.RFC3339
 	}
 	if gc.GoMaxProcs < 0 {
 		log.Fatal("Invalid argument for --go-processes. Must be >1.")


### PR DESCRIPTION
Resolves #120 and #122.