### PR TITLE
Allow `dig like` resolution of a single name from the cmd line.

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -17,19 +17,19 @@ package zdns
 import "time"
 
 type GlobalConf struct {
-	Threads             int
-	Timeout             time.Duration
-	IterationTimeout    time.Duration
-	Retries             int
-	AlexaFormat         bool
-	IterativeResolution bool
-	Trace               bool
-	MaxDepth            int
-	CacheSize           int
-	GoMaxProcs          int
-	Verbosity           int
-	TimeFormat          string
-
+	Threads              int
+	Timeout              time.Duration
+	IterationTimeout     time.Duration
+	Retries              int
+	AlexaFormat          bool
+	IterativeResolution  bool
+	Trace                bool
+	MaxDepth             int
+	CacheSize            int
+	GoMaxProcs           int
+	Verbosity            int
+	TimeFormat           string
+	PassedName           string
 	NameServersSpecified bool
 	NameServers          []string
 

--- a/lookup.go
+++ b/lookup.go
@@ -157,29 +157,33 @@ func doOutput(out <-chan string, path string, wg *sync.WaitGroup) error {
 }
 
 // read input file and put results into channel
-func doInput(in chan<- interface{}, path string, wg *sync.WaitGroup, zonefileInput bool) error {
-	var f *os.File
-	if path == "" || path == "-" {
-		f = os.Stdin
+func doInput(in chan<- interface{}, path string, wg *sync.WaitGroup, zonefileInput bool, passedName string) error {
+	if len(passedName) > 0 {
+		in <- passedName
 	} else {
-		var err error
-		f, err = os.Open(path)
-		if err != nil {
-			log.Fatal("unable to open input file:", err.Error())
+		var f *os.File
+		if path == "" || path == "-" {
+			f = os.Stdin
+		} else {
+			var err error
+			f, err = os.Open(path)
+			if err != nil {
+				log.Fatal("unable to open input file:", err.Error())
+			}
 		}
-	}
-	if zonefileInput {
-		tokens := dns.ParseZone(f, ".", path)
-		for t := range tokens {
-			in <- t
-		}
-	} else {
-		s := bufio.NewScanner(f)
-		for s.Scan() {
-			in <- s.Text()
-		}
-		if err := s.Err(); err != nil {
-			log.Fatal("input unable to read file", err)
+		if zonefileInput {
+			tokens := dns.ParseZone(f, ".", path)
+			for t := range tokens {
+				in <- t
+			}
+		} else {
+			s := bufio.NewScanner(f)
+			for s.Scan() {
+				in <- s.Text()
+			}
+			if err := s.Err(); err != nil {
+				log.Fatal("input unable to read file", err)
+			}
 		}
 	}
 	close(in)
@@ -213,7 +217,7 @@ func DoLookups(g *GlobalLookupFactory, c *GlobalConf) error {
 	metaChan := make(chan routineMetadata, c.Threads)
 	var routineWG sync.WaitGroup
 	go doOutput(outChan, c.OutputFilePath, &routineWG)
-	go doInput(inChan, c.InputFilePath, &routineWG, (*g).ZonefileInput())
+	go doInput(inChan, c.InputFilePath, &routineWG, (*g).ZonefileInput(), c.PassedName)
 	routineWG.Add(2)
 	// create pool of worker goroutines
 	var lookupWG sync.WaitGroup

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -151,7 +151,7 @@ func main() {
 		if (stat.Mode()&os.ModeCharDevice) != 0 && gc.InputFilePath == "-" && len(flags.Args()) == 1 {
 			gc.PassedName = flags.Args()[0]
 		} else {
-			log.Fatal("Unpassed command line flags: ", flags.Args())
+			log.Fatal("Unused command line flags: ", flags.Args())
 		}
 	}
 

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -144,6 +144,17 @@ func main() {
 	if gc.GoMaxProcs != 0 {
 		runtime.GOMAXPROCS(gc.GoMaxProcs)
 	}
+	if len(flags.Args()) > 0 {
+		stat, _ := os.Stdin.Stat()
+		// If stdin is piped from the terminal, and we havent specified a file, and if we have unparsed args
+		// use them for a dig like reslution
+		if (stat.Mode()&os.ModeCharDevice) != 0 && gc.InputFilePath == "-" && len(flags.Args()) == 1 {
+			gc.PassedName = flags.Args()[0]
+		} else {
+			log.Fatal("Unpassed command line flags: ", flags.Args())
+		}
+	}
+
 	// some modules require multiple passes over a file (this is really just the case for zone files)
 	if !factory.AllowStdIn() && gc.InputFilePath == "-" {
 		log.Fatal("Specified module does not allow reading from stdin")


### PR DESCRIPTION
Usage:
```
$ zdns A example.com | jq "."
{
  "data": {
    "flags": {
      "error_code": 0,
      "response": true,
      "opcode": 0,
      "authoritative": false,
      "truncated": false,
      "recursion_desired": true,
      "recursion_available": true,
      "authenticated": false,
      "checking_disabled": false
    },
    "protocol": "udp",
    "authorities": [],
    "additionals": [],
    "answers": [
      {
        "answer": "93.184.216.34",
        "name": "example.com",
        "class": "IN",
        "type": "A",
        "ttl": 63020
      }
    ]
  },
  "timestamp": "2017-10-08T18:20:45-07:00",
  "status": "NOERROR",
  "class": "IN",
  "name": "example.com"
}
```