### PR TITLE
add CDS/CDNSKEY support

### DIFF
--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -32,7 +32,7 @@ type MXAnswer struct {
 
 type CDSAnswer struct {
 	Answer
-	KeyTag uint16 `json:"keytag"`
+	KeyTag uint16 `json:"key_tag"`
 	Algorithm uint8 `json:"algorithm"`
 	DigestType uint8 `json:"digest_type"`
 	Digest string `json:"digest"`

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -43,7 +43,7 @@ type CDNSKEYAnswer struct {
 	Flags uint16 `json:"flags"`
 	Protocol uint8 `json:"protocol"`
 	Algorithm uint8 `json:"algorithm"`
-	PublicKey string `json:"publickey"`
+	PublicKey string `json:"public_key"`
 }
 
 type CAAAnswer struct {

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -34,7 +34,7 @@ type CDSAnswer struct {
 	Answer
 	KeyTag uint16 `json:"keytag"`
 	Algorithm uint8 `json:"algorithm"`
-	DigestType uint8 `json:"digesttype"`
+	DigestType uint8 `json:"digest_type"`
 	Digest string `json:"digest"`
 }
 


### PR DESCRIPTION
Adds CDS and CDNSKEY lookup type support. A CDS or CDNSKEY RRset can be used by zone owners as a signaling mechanism for automated DNSSEC delegation trust maintenance (RFC 7344).