### PR TITLE
Omits empty and nil "servers" list from result.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.7.4
+- 1.9.3
 before_install:
 - go get github.com/sirupsen/logrus
 - go get github.com/miekg/dns

--- a/modules/axfr/axfr.go
+++ b/modules/axfr/axfr.go
@@ -44,7 +44,7 @@ type AXFRServerResult struct {
 }
 
 type AXFRResult struct {
-	Servers []AXFRServerResult `json:"servers"`
+	Servers []AXFRServerResult `json:"servers,omitempty"`
 }
 
 func dotName(name string) string {


### PR DESCRIPTION
A nil sever field is invalid, so it should either not exist or be a list with members.