### PR TITLE
Fix #155

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.9.3
+- 1.10.1
 before_install:
 - go get github.com/sirupsen/logrus
 - go get github.com/miekg/dns

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -506,9 +506,9 @@ func DoLookupWorker(udp *dns.Client, tcp *dns.Client, dnsType uint16, dnsClass u
 	res.Protocol = "udp"
 
 	r, _, err := udp.Exchange(m, nameServer)
-	if err == dns.ErrTruncated {
+	if err == nil && r.Truncated {
 		if tcp == nil {
-			return res, zdns.STATUS_TRUNCATED, err
+			return res, zdns.STATUS_TRUNCATED, errors.New("Error - message is truncated and tcp connection failed")
 		}
 
 		r, _, err = tcp.Exchange(m, nameServer)


### PR DESCRIPTION
This addresses an update to github.com/miekg/dns that removed
ErrTruncated from the library. An explanation for why is here:
https://github.com/miekg/dns/commit/1ff265a78454967a4321dc2c0e38e267323bc3d4