### PR TITLE
fix possible empty response for alookup

### DIFF
--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -65,14 +65,16 @@ func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16
 			if !ok {
 				continue
 			}
-			searchSet[ans.Name] = append(searchSet[ans.Name], ans)
+			lowerCaseName := strings.ToLower(ans.Name)
+			searchSet[lowerCaseName] = append(searchSet[lowerCaseName], ans)
 		}
 		for _, a := range miekgResult.(miekg.Result).Additional {
 			ans, ok := a.(miekg.Answer)
 			if !ok {
 				continue
 			}
-			searchSet[ans.Name] = append(searchSet[ans.Name], ans)
+			lowerCaseName := strings.ToLower(ans.Name)
+			searchSet[lowerCaseName] = append(searchSet[lowerCaseName], ans)
 		}
 	}
 	// our cache should now have any data that exists about the current name


### PR DESCRIPTION
For certain domains like "nyu.edu", running with module "A" returns valid response but running with module "ALOOKUP" doesn't. Because the response contains upper case domain ("NYU.EDU") where alookup module fails to deal with. Simple fix by lowering the answer name could solve.