### PR TITLE
do not omit zero TTL values in answer section (fix #165)

### DIFF
--- a/integration_tests.py
+++ b/integration_tests.py
@@ -137,7 +137,7 @@ class Tests(unittest.TestCase):
         "type":"PTR",
         "class":"IN",
         "name":"8.8.8.8.in-addr.arpa",
-        "answer":"google-public-dns-a.google.com."
+        "answer":"dns.google."
       }
     ]
 

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -18,7 +18,7 @@ import (
 )
 
 type Answer struct {
-	Ttl     uint32 `json:"ttl,omitempty"`
+	Ttl     uint32 `json:"ttl"`
 	Type    string `json:"type,omitempty"`
 	rrType  uint16
 	Class   string `json:"class,omitempty"`
@@ -76,10 +76,10 @@ type SRVAnswer struct {
 
 type TLSAAnswer struct {
 	Answer
-	CertUsage     uint8 `json:"cert_usage"`
-	Selector      uint8 `json:"selector"`
-	MatchingType  uint8 `json:"matching_type"`
-	Certificate   string `json:"certificate"`
+	CertUsage    uint8  `json:"cert_usage"`
+	Selector     uint8  `json:"selector"`
+	MatchingType uint8  `json:"matching_type"`
+	Certificate  string `json:"certificate"`
 }
 
 type DNSFlags struct {
@@ -297,10 +297,10 @@ func ParseAnswer(ans dns.RR) interface{} {
 				rrClass: tlsa.Hdr.Class,
 				Ttl:     tlsa.Hdr.Ttl,
 			},
-			CertUsage:     tlsa.Usage,
-			Selector:      tlsa.Selector,
-			MatchingType:  tlsa.MatchingType,
-			Certificate:   tlsa.Certificate,
+			CertUsage:    tlsa.Usage,
+			Selector:     tlsa.Selector,
+			MatchingType: tlsa.MatchingType,
+			Certificate:  tlsa.Certificate,
 		}
 	} else {
 		return struct {


### PR DESCRIPTION
TTL is a mandatory value of the RR header and zero is a valid value.
However the Go JSON marshaller cannot distinguish between unset and zero numeric values so the result got dropped.

From what I think valid records with missing TTL (not zero, but completely missing) would be completely omitted in previous steps so the simple solution of not omitting "empty" (i.e. zero) values in the output should be OK.