### PR TITLE
add class filter for alookup module

### DIFF
--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -62,7 +62,8 @@ func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16
 		}
 		for _, a := range miekgResult.(miekg.Result).Answers {
 			ans, ok := a.(miekg.Answer)
-			if !ok {
+			// filter only valid answers of requested type or CNAME (#163)
+			if !ok || (dnsType != dns.StringToType[ans.Type] && dns.TypeCNAME != dns.StringToType[ans.Type]) {
 				continue
 			}
 			lowerCaseName := strings.ToLower(ans.Name)
@@ -70,7 +71,8 @@ func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16
 		}
 		for _, a := range miekgResult.(miekg.Result).Additional {
 			ans, ok := a.(miekg.Answer)
-			if !ok {
+			// filter only valid answers of requested type or CNAME (#163)
+			if !ok || (dnsType != dns.StringToType[ans.Type] && dns.TypeCNAME != dns.StringToType[ans.Type]) {
 				continue
 			}
 			lowerCaseName := strings.ToLower(ans.Name)

--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -41,7 +41,7 @@ func (s *Lookup) DoLookup(name string) (interface{}, []interface{}, zdns.Status,
 	return s.DoTargetedLookup(name, nameServer)
 }
 
-func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16, searchSet map[string][]miekg.Answer, origName string, depth int) ([]string, []interface{}, zdns.Status, error) {
+func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16, candidateSet map[string][]miekg.Answer, cnameSet map[string][]miekg.Answer, origName string, depth int) ([]string, []interface{}, zdns.Status, error) {
 	// avoid infinite loops
 	if name == origName && depth != 0 {
 		return nil, make([]interface{}, 0), zdns.STATUS_ERROR, errors.New("Infinite redirection loop")
@@ -52,7 +52,8 @@ func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16
 	// check if the record is already in our cache. if not, perform normal A lookup and
 	// see what comes back. Then iterate over results and if needed, perform further lookups
 	var trace []interface{}
-	if _, ok := searchSet[name]; !ok {
+	garbage := map[string][]miekg.Answer{}
+	if _, ok := candidateSet[name]; !ok {
 		var miekgResult interface{}
 		var status zdns.Status
 		var err error
@@ -63,64 +64,74 @@ func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16
 		for _, a := range miekgResult.(miekg.Result).Answers {
 			ans, ok := a.(miekg.Answer)
 			// filter only valid answers of requested type or CNAME (#163)
-			if !ok || (dnsType != dns.StringToType[ans.Type] && dns.TypeCNAME != dns.StringToType[ans.Type]) {
-				continue
+			if ok {
+				lowerCaseName := strings.ToLower(ans.Name)
+				ansType := dns.StringToType[ans.Type]
+				if dnsType == ansType {
+					candidateSet[lowerCaseName] = append(candidateSet[lowerCaseName], ans)
+				} else if ok && dns.TypeCNAME == ansType {
+					cnameSet[lowerCaseName] = append(cnameSet[lowerCaseName], ans)
+				} else {
+					garbage[lowerCaseName] = append(garbage[lowerCaseName], ans)
+				}
 			}
-			lowerCaseName := strings.ToLower(ans.Name)
-			searchSet[lowerCaseName] = append(searchSet[lowerCaseName], ans)
 		}
 		for _, a := range miekgResult.(miekg.Result).Additional {
 			ans, ok := a.(miekg.Answer)
 			// filter only valid answers of requested type or CNAME (#163)
-			if !ok || (dnsType != dns.StringToType[ans.Type] && dns.TypeCNAME != dns.StringToType[ans.Type]) {
-				continue
+			if ok {
+				lowerCaseName := strings.ToLower(ans.Name)
+				ansType := dns.StringToType[ans.Type]
+				if dnsType == ansType {
+					candidateSet[lowerCaseName] = append(candidateSet[lowerCaseName], ans)
+				} else if ok && dns.TypeCNAME == ansType {
+					cnameSet[lowerCaseName] = append(cnameSet[lowerCaseName], ans)
+				} else {
+					garbage[lowerCaseName] = append(garbage[lowerCaseName], ans)
+				}
 			}
-			lowerCaseName := strings.ToLower(ans.Name)
-			searchSet[lowerCaseName] = append(searchSet[lowerCaseName], ans)
 		}
 	}
 	// our cache should now have any data that exists about the current name
-	res, ok := searchSet[name]
-	if !ok || len(res) == 0 {
-		// we have no data whatsoever about this name. return an empty recordset to the user
-		var ips []string
-		return ips, trace, zdns.STATUS_NO_ANSWER, nil
-	} else if res[0].Type == dns.Type(dnsType).String() {
+	if res, ok := candidateSet[name]; ok && len(res) > 0 {
 		// we have IP addresses to hand back to the user. let's make an easy-to-use array of strings
 		var ips []string
 		for _, answer := range res {
-			if "CNAME" != answer.Type {
-				//	drop remaining CNAMEs here, if any
-				ips = append(ips, answer.Answer)
-			}
+			ips = append(ips, answer.Answer)
 		}
 		return ips, trace, zdns.STATUS_NOERROR, nil
-	} else if res[0].Type == dns.Type(dns.TypeCNAME).String() {
+	} else if res, ok = cnameSet[name]; ok && len(res) > 0 {
 		// we have a CNAME and need to further recurse to find IPs
 		shortName := strings.ToLower(res[0].Answer[0 : len(res[0].Answer)-1])
-		res, secondTrace, status, err := s.doLookupProtocol(shortName, nameServer, dnsType, searchSet, origName, depth+1)
+		res, secondTrace, status, err := s.doLookupProtocol(shortName, nameServer, dnsType, candidateSet, cnameSet, origName, depth+1)
 		trace = append(trace, secondTrace...)
 		return res, trace, status, err
-	} else {
+	} else if res, ok = garbage[name]; ok && len(res) > 0 {
 		return nil, trace, zdns.STATUS_ERROR, errors.New("Unexpected record type received")
+	} else {
+		// we have no data whatsoever about this name. return an empty recordset to the user
+		var ips []string
+		return ips, trace, zdns.STATUS_NO_ANSWER, nil
 	}
 }
 
 func (s *Lookup) DoTargetedLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	res := Result{}
-	searchSet := map[string][]miekg.Answer{}
+	candidateSet := map[string][]miekg.Answer{}
+	cnameSet := map[string][]miekg.Answer{}
 	var ipv4 []string
 	var ipv6 []string
 	var ipv4Trace []interface{}
 	var ipv6Trace []interface{}
 	if s.Factory.Factory.IPv4Lookup || !s.Factory.Factory.IPv6Lookup {
-		ipv4, ipv4Trace, _, _ = s.doLookupProtocol(name, nameServer, dns.TypeA, searchSet, name, 0)
+		ipv4, ipv4Trace, _, _ = s.doLookupProtocol(name, nameServer, dns.TypeA, candidateSet, cnameSet, name, 0)
 		res.IPv4Addresses = make([]string, len(ipv4))
 		copy(res.IPv4Addresses, ipv4)
 	}
-	searchSet = map[string][]miekg.Answer{}
+	candidateSet = map[string][]miekg.Answer{}
+	cnameSet = map[string][]miekg.Answer{}
 	if s.Factory.Factory.IPv6Lookup {
-		ipv6, ipv6Trace, _, _ = s.doLookupProtocol(name, nameServer, dns.TypeAAAA, searchSet, name, 0)
+		ipv6, ipv6Trace, _, _ = s.doLookupProtocol(name, nameServer, dns.TypeAAAA, candidateSet, cnameSet, name, 0)
 		res.IPv6Addresses = make([]string, len(ipv6))
 		copy(res.IPv6Addresses, ipv6)
 	}

--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -89,7 +89,10 @@ func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16
 		// we have IP addresses to hand back to the user. let's make an easy-to-use array of strings
 		var ips []string
 		for _, answer := range res {
-			ips = append(ips, answer.Answer)
+			if "CNAME" != answer.Type {
+				//	drop remaining CNAMEs here, if any
+				ips = append(ips, answer.Answer)
+			}
 		}
 		return ips, trace, zdns.STATUS_NOERROR, nil
 	} else if res[0].Type == dns.Type(dns.TypeCNAME).String() {

--- a/modules/alookup/alookup_test.go
+++ b/modules/alookup/alookup_test.go
@@ -165,6 +165,31 @@ func TestDoLookup(t *testing.T) {
 
 	res, _, _, _ = l.DoLookup("cname.example.com")
 	verifyResult(t, res.(Result), nil, []string{"2001:db8::1", "2001:db8::2"})
+
+	// Case 7: AAAA + CNAME (if this ever happens to be returned)
+	mockResults["cname.example.com"] = miekg.Result{
+		Answers: []interface{}{miekg.Answer{
+			Ttl:    3600,
+			Type:   "AAAA",
+			Class:  "IN",
+			Name:   "cname.example.com",
+			Answer: "2001:db8::3",
+		},
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "CNAME",
+				Class:  "IN",
+				Name:   "cname.example.com",
+				Answer: "example.com.",
+			}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+
+	res, _, _, _ = l.DoLookup("cname.example.com")
+	verifyResult(t, res.(Result), nil, []string{"2001:db8::3"})
 }
 
 func verifyResult(t *testing.T, res Result, ipv4 []string, ipv6 []string) {

--- a/modules/alookup/alookup_test.go
+++ b/modules/alookup/alookup_test.go
@@ -1,0 +1,194 @@
+/*
+ * ZDNS Copyright 2019 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package alookup
+
+import (
+	"github.com/zmap/zdns"
+	"github.com/zmap/zdns/modules/miekg"
+	"reflect"
+	"testing"
+)
+
+// Mock the actual Miekg lookup.
+func (s *Lookup) DoTypedMiekgLookup(name string, dnsType uint16) (interface{}, []interface{}, zdns.Status, error) {
+	if res, ok := mockResults[name]; ok {
+		return res, nil, zdns.STATUS_NOERROR, nil
+	} else {
+		return nil, nil, zdns.STATUS_NO_ANSWER, nil
+	}
+}
+
+var mockResults = make(map[string]miekg.Result)
+
+func TestDoLookup(t *testing.T) {
+	gc := new(zdns.GlobalConf)
+	gc.NameServers = []string{"127.0.0.1"}
+
+	glf := new(GlobalLookupFactory)
+	glf.GlobalConf = gc
+	glf.IPv4Lookup = true
+	glf.IPv6Lookup = false
+
+	rlf := new(RoutineLookupFactory)
+	rlf.Factory = glf
+
+	l, err := rlf.MakeLookup()
+	if l == nil || err != nil {
+		t.Error("Failed to initialize lookup")
+	}
+
+	// Case 1: single A response
+	mockResults["example.com"] = miekg.Result{
+		Answers: []interface{}{miekg.Answer{
+			Ttl:    3600,
+			Type:   "A",
+			Class:  "IN",
+			Name:   "example.com",
+			Answer: "192.0.2.1",
+		}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+
+	res, _, _, _ := l.DoLookup("example.com")
+	verifyResult(t, res.(Result), []string{"192.0.2.1"}, nil)
+
+	// Case 2: double A response
+	mockResults["example.com"] = miekg.Result{
+		Answers: []interface{}{miekg.Answer{
+			Ttl:    3600,
+			Type:   "A",
+			Class:  "IN",
+			Name:   "example.com",
+			Answer: "192.0.2.1",
+		},
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "A",
+				Class:  "IN",
+				Name:   "example.com",
+				Answer: "192.0.2.2",
+			}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+
+	res, _, _, _ = l.DoLookup("example.com")
+	verifyResult(t, res.(Result), []string{"192.0.2.1", "192.0.2.2"}, nil)
+
+	// Case 3: mixed A and AAAA response
+	mockResults["example.com"] = miekg.Result{
+		Answers: []interface{}{miekg.Answer{
+			Ttl:    3600,
+			Type:   "A",
+			Class:  "IN",
+			Name:   "example.com",
+			Answer: "192.0.2.1",
+		},
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "AAAA",
+				Class:  "IN",
+				Name:   "example.com",
+				Answer: "2001:db8::1",
+			}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+
+	res, _, _, _ = l.DoLookup("example.com")
+	verifyResult(t, res.(Result), []string{"192.0.2.1"}, nil)
+
+	// Case 4: same mixed response, but both types requested.
+	glf.IPv6Lookup = true
+
+	res, _, _, _ = l.DoLookup("example.com")
+	verifyResult(t, res.(Result), []string{"192.0.2.1"}, []string{"2001:db8::1"})
+
+	// Case 5: double AAAA response
+	mockResults["example.com"] = miekg.Result{
+		Answers: []interface{}{miekg.Answer{
+			Ttl:    3600,
+			Type:   "AAAA",
+			Class:  "IN",
+			Name:   "example.com",
+			Answer: "2001:db8::1",
+		},
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "AAAA",
+				Class:  "IN",
+				Name:   "example.com",
+				Answer: "2001:db8::2",
+			}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+
+	res, _, _, _ = l.DoLookup("example.com")
+	verifyResult(t, res.(Result), nil, []string{"2001:db8::1", "2001:db8::2"})
+
+	// Case 6: CNAME
+	mockResults["cname.example.com"] = miekg.Result{
+		Answers: []interface{}{miekg.Answer{
+			Ttl:    3600,
+			Type:   "CNAME",
+			Class:  "IN",
+			Name:   "cname.example.com",
+			Answer: "example.com.",
+		}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+
+	res, _, _, _ = l.DoLookup("cname.example.com")
+	verifyResult(t, res.(Result), nil, []string{"2001:db8::1", "2001:db8::2"})
+}
+
+func verifyResult(t *testing.T, res Result, ipv4 []string, ipv6 []string) {
+	if ipv4 == nil && res.IPv4Addresses != nil && len(res.IPv4Addresses) > 0 {
+		t.Error("Received IPv4 addresses while none expected")
+	} else if ipv4 != nil {
+		if res.IPv4Addresses == nil || len(res.IPv4Addresses) == 0 {
+			t.Error("Received no IPv4 addresses while expected")
+		} else if len(res.IPv4Addresses) != len(ipv4) {
+			t.Errorf("Received %v IPv4 addresses while %v is expected", len(res.IPv4Addresses), len(ipv4))
+		} else if !reflect.DeepEqual(res.IPv4Addresses, ipv4) {
+			t.Error("Received unexpected IPv4 address(es)")
+		}
+	}
+
+	if ipv6 == nil && res.IPv6Addresses != nil && len(res.IPv4Addresses) > 0 {
+		t.Error("Received no IPv6 addresses while expected")
+	} else if ipv6 != nil {
+		if res.IPv6Addresses == nil || len(res.IPv6Addresses) == 0 {
+			t.Error("Received no IPv6 addresses while expected")
+		} else if len(res.IPv4Addresses) != len(ipv4) {
+			t.Errorf("Received %v IPv6 addresses while %v is expected", len(res.IPv6Addresses), len(ipv6))
+		} else if !reflect.DeepEqual(res.IPv6Addresses, ipv6) {
+			t.Error("Received unexpected IPv6 address(es)")
+		}
+	}
+}


### PR DESCRIPTION
Targeting #163 the alookup module currently returns all answers from the nameserver if the first answer matches the requested type (`A`/`AAAA`).

I've added a filter in the loop to only collect the requested type and `CNAME` records.

Because this still failed to deliver correct results if both an `A` and a `CNAME` record (never seen in the wild but you never know) or multiple `CNAME` records (which is not valid, but possible to configure with older BIND servers up to 9.1.0 <sup>1</sup>). In both cases the resulting domain names have been added to the IP set.

To avoid double filtering I've slightly refactored the routing to collect target type and CNAME in separate sets.

All changes covered by previously written tests.

----
[1] https://docstore.mik.ua/orelly/networking_2ndEd/dns/ch10_07.htm