### PR TITLE
add prefix to IPv4-mapped IPv6 addresses

### DIFF
--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -154,7 +154,12 @@ func ParseAnswer(ans dns.RR) interface{} {
 			Name:    a.Hdr.Name,
 			Answer:  a.A.String()}
 	} else if aaaa, ok := ans.(*dns.AAAA); ok {
-		retv = Answer{Ttl: aaaa.Hdr.Ttl, Type: dns.Type(aaaa.Hdr.Rrtype).String(), rrType: aaaa.Hdr.Rrtype, Class: dns.Class(aaaa.Hdr.Class).String(), rrClass: aaaa.Hdr.Class, Name: aaaa.Hdr.Name, Answer: aaaa.AAAA.String()}
+		ip := aaaa.AAAA.String()
+		if aaaa.AAAA.To4() != nil {
+			// we have a IPv4-mapped address, append prefix (#164)
+			ip = "::ffff:" + ip
+		}
+		retv = Answer{Ttl: aaaa.Hdr.Ttl, Type: dns.Type(aaaa.Hdr.Rrtype).String(), rrType: aaaa.Hdr.Rrtype, Class: dns.Class(aaaa.Hdr.Class).String(), rrClass: aaaa.Hdr.Class, Name: aaaa.Hdr.Name, Answer: ip}
 	} else if cname, ok := ans.(*dns.CNAME); ok {
 		retv = Answer{Ttl: cname.Hdr.Ttl, Type: dns.Type(cname.Hdr.Rrtype).String(), rrType: cname.Hdr.Rrtype, Class: dns.Class(cname.Hdr.Class).String(), rrClass: cname.Hdr.Class, Name: cname.Hdr.Name, Answer: cname.Target}
 	} else if dname, ok := ans.(*dns.DNAME); ok {

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -156,7 +156,7 @@ func ParseAnswer(ans dns.RR) interface{} {
 	} else if aaaa, ok := ans.(*dns.AAAA); ok {
 		ip := aaaa.AAAA.String()
 		// verify we really got full 16-byte address
-		if len(aaaa.AAAA) == net.IPv6len {
+		if !aaaa.AAAA.IsLoopback() && !aaaa.AAAA.IsUnspecified() && len(aaaa.AAAA) == net.IPv6len {
 			if aaaa.AAAA.To4() != nil {
 				// we have a IPv4-mapped address, append prefix (#164)
 				ip = "::ffff:" + ip

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -155,9 +155,24 @@ func ParseAnswer(ans dns.RR) interface{} {
 			Answer:  a.A.String()}
 	} else if aaaa, ok := ans.(*dns.AAAA); ok {
 		ip := aaaa.AAAA.String()
-		if aaaa.AAAA.To4() != nil {
-			// we have a IPv4-mapped address, append prefix (#164)
-			ip = "::ffff:" + ip
+		// verify we really got full 16-byte address
+		if len(aaaa.AAAA) == net.IPv6len {
+			if aaaa.AAAA.To4() != nil {
+				// we have a IPv4-mapped address, append prefix (#164)
+				ip = "::ffff:" + ip
+			} else {
+				v4compat := true
+				for _, o := range aaaa.AAAA[:11] {
+					if o != 0 {
+						v4compat = false
+						break
+					}
+				}
+				if v4compat {
+					// we have a IPv4-compatible address, append prefix (#164)
+					ip = "::" + aaaa.AAAA[12:].String()
+				}
+			}
 		}
 		retv = Answer{Ttl: aaaa.Hdr.Ttl, Type: dns.Type(aaaa.Hdr.Rrtype).String(), rrType: aaaa.Hdr.Rrtype, Class: dns.Class(aaaa.Hdr.Class).String(), rrClass: aaaa.Hdr.Class, Name: aaaa.Hdr.Name, Answer: ip}
 	} else if cname, ok := ans.(*dns.CNAME); ok {

--- a/modules/miekg/miekg_test.go
+++ b/modules/miekg/miekg_test.go
@@ -1,0 +1,85 @@
+package miekg
+
+import (
+	"github.com/miekg/dns"
+	"net"
+	"testing"
+)
+
+func TestParseAnswer(t *testing.T) {
+	var rr dns.RR
+
+	// typical A record
+	rr = &dns.A{
+		Hdr: dns.RR_Header{
+			Name:     "ipv4.example.com",
+			Rrtype:   dns.TypeA,
+			Class:    dns.ClassINET,
+			Ttl:      3600,
+			Rdlength: 4,
+		},
+		A: net.ParseIP("192.0.2.1"),
+	}
+
+	res := ParseAnswer(rr)
+	verifyResult(t, res, rr, "192.0.2.1")
+
+	// typical AAAA record
+	rr = &dns.AAAA{
+		Hdr: dns.RR_Header{
+			Name:     "ipv6.example.com",
+			Rrtype:   dns.TypeAAAA,
+			Class:    dns.ClassINET,
+			Ttl:      7200,
+			Rdlength: 16,
+		},
+		AAAA: net.ParseIP("2001:db8::1"),
+	}
+
+	res = ParseAnswer(rr)
+	verifyResult(t, res, rr, "2001:db8::1")
+
+	// IPv4-Mapped IPv6 address as AAAA record
+	rr = &dns.AAAA{
+		Hdr: dns.RR_Header{
+			Name:     "ipv6.example.com",
+			Rrtype:   dns.TypeAAAA,
+			Class:    dns.ClassINET,
+			Ttl:      7200,
+			Rdlength: 16,
+		},
+		AAAA: net.ParseIP("192.0.2.1"),
+	}
+
+	res = ParseAnswer(rr)
+	verifyResult(t, res, rr, "::ffff:192.0.2.1")
+
+	// TODO: test remaining RR types
+}
+
+func verifyResult(t *testing.T, answer interface{}, original dns.RR, expectedAnswer string) {
+	ans, ok := answer.(Answer)
+	if !ok {
+		t.Error("Failed to parse record")
+		return
+	}
+
+	if ans.Name != original.Header().Name {
+		t.Errorf("Unxpected name. Expected %v, got %v", original.Header().Name, ans.Name)
+	}
+	if ans.rrType != original.Header().Rrtype {
+		t.Errorf("Unxpected RR type. Expected %v, got %v", original.Header().Rrtype, ans.rrType)
+	}
+	if ans.Type != dns.TypeToString[original.Header().Rrtype] {
+		t.Errorf("Unxpected RR type (string). Expected %v, got %v", dns.TypeToString[original.Header().Rrtype], ans.Type)
+	}
+	if ans.rrClass != original.Header().Class {
+		t.Errorf("Unxpected RR class. Expected %v, got %v", original.Header().Class, ans.rrClass)
+	}
+	if ans.Class != dns.ClassToString[original.Header().Class] {
+		t.Errorf("Unxpected RR class (string). Expected %v, got %v", dns.TypeToString[original.Header().Class], ans.Class)
+	}
+	if ans.Answer != expectedAnswer {
+		t.Errorf("Unxpected answer. Expected %v, got %v", expectedAnswer, ans.Answer)
+	}
+}

--- a/modules/miekg/miekg_test.go
+++ b/modules/miekg/miekg_test.go
@@ -48,11 +48,26 @@ func TestParseAnswer(t *testing.T) {
 			Ttl:      7200,
 			Rdlength: 16,
 		},
-		AAAA: net.ParseIP("192.0.2.1"),
+		AAAA: net.ParseIP("::ffff:192.0.2.1"),
 	}
 
 	res = ParseAnswer(rr)
 	verifyResult(t, res, rr, "::ffff:192.0.2.1")
+
+	// IPv4-compatible IPv6 address as AAAA record
+	rr = &dns.AAAA{
+		Hdr: dns.RR_Header{
+			Name:     "ipv6.example.com",
+			Rrtype:   dns.TypeAAAA,
+			Class:    dns.ClassINET,
+			Ttl:      7200,
+			Rdlength: 16,
+		},
+		AAAA: net.ParseIP("::192.0.2.1"),
+	}
+
+	res = ParseAnswer(rr)
+	verifyResult(t, res, rr, "::192.0.2.1")
 
 	// TODO: test remaining RR types
 }

--- a/modules/miekg/miekg_test.go
+++ b/modules/miekg/miekg_test.go
@@ -36,8 +36,32 @@ func TestParseAnswer(t *testing.T) {
 		AAAA: net.ParseIP("2001:db8::1"),
 	}
 
+	// loopback AAAA record
+	rr = &dns.AAAA{
+		Hdr: dns.RR_Header{
+			Name:     "ipv6.example.com",
+			Rrtype:   dns.TypeAAAA,
+			Class:    dns.ClassINET,
+			Ttl:      7200,
+			Rdlength: 16,
+		},
+		AAAA: net.ParseIP("::1"),
+	}
+
+	// unspecified AAAA record
+	rr = &dns.AAAA{
+		Hdr: dns.RR_Header{
+			Name:     "ipv6.example.com",
+			Rrtype:   dns.TypeAAAA,
+			Class:    dns.ClassINET,
+			Ttl:      7200,
+			Rdlength: 16,
+		},
+		AAAA: net.ParseIP("::"),
+	}
+
 	res = ParseAnswer(rr)
-	verifyResult(t, res, rr, "2001:db8::1")
+	verifyResult(t, res, rr, "::")
 
 	// IPv4-Mapped IPv6 address as AAAA record
 	rr = &dns.AAAA{


### PR DESCRIPTION
Add a `::ffff:` prefix to IPv4-mapped IPv6 addresses when parsing AAAA answers.

Claimed in #164 mapped IPs like `::ffff:192.0.2.1` are stripped down `192.0.2.1` in ZDNS results.

Go's `net.IP` `String()` simply returns the 4-octet notation while the full 16 bytes are stored internally.
Trying to obtain 4-byte version suceeds on such addresses while it fails on "real" v6 addresses. In fact such constructs are used all over the `IP` lib:
```go
if ip4 := ip.To4(); ip4 != nil {
    // IPv4 address
} else {
    // IPv6 address
}
```

Using the same check we now add the well-known `::ffff:` prefix in those cases.

Started a unit test for the `ParseAnswer()` function to verify my changes.