### PR TITLE
add support for NAPTR lookups

### DIFF
--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -90,6 +90,16 @@ type NSEC3ParamAnswer struct {
 	Salt          string `json:"salt"`
 }
 
+type NAPTRAnswer struct {
+	Answer
+	Order       uint16 `json:"order"`
+	Preference  uint16 `json:"preference"`
+	Flags       string `json:"flags"`
+	Service     string `json:"service"`
+	Regexp      string `json:"regexp"`
+	Replacement string `json:"replacement"`
+}
+
 type DNSFlags struct {
 	Response           bool `json:"response"`
 	Opcode             int  `json:"opcode"`
@@ -400,6 +410,23 @@ func ParseAnswer(ans dns.RR) interface{} {
 			Flags:         nsec3param.Flags,
 			Iterations:    nsec3param.Iterations,
 			Salt:          nsec3param.Salt,
+		}
+	} else if naptr, ok := ans.(*dns.NAPTR); ok {
+		return NAPTRAnswer{
+			Answer: Answer{
+				Name:    strings.TrimSuffix(naptr.Hdr.Name, "."),
+				Type:    dns.Type(naptr.Hdr.Rrtype).String(),
+				rrType:  naptr.Hdr.Rrtype,
+				Class:   dns.Class(naptr.Hdr.Class).String(),
+				rrClass: naptr.Hdr.Class,
+				Ttl:     naptr.Hdr.Ttl,
+			},
+			Order:       naptr.Order,
+			Preference:  naptr.Preference,
+			Flags:       naptr.Flags,
+			Service:     naptr.Service,
+			Regexp:      naptr.Regexp,
+			Replacement: naptr.Replacement,
 		}
 	} else {
 		return struct {
@@ -1268,4 +1295,7 @@ func init() {
 	nsec3param.SetDNSType(dns.TypeNSEC3PARAM)
 	zdns.RegisterLookup("NSEC3PARAM", nsec3param)
 
+	naptr := new(GlobalLookupFactory)
+	naptr.SetDNSType(dns.TypeNAPTR)
+	zdns.RegisterLookup("NAPTR", naptr)
 }

--- a/modules/miekg/miekg_test.go
+++ b/modules/miekg/miekg_test.go
@@ -93,6 +93,49 @@ func TestParseAnswer(t *testing.T) {
 	res = ParseAnswer(rr)
 	verifyResult(t, res, rr, "::192.0.2.1")
 
+	// NAPTR record für aa e.164 phone number (+1-234-555-6789)
+	rr = &dns.NAPTR{
+		Hdr: dns.RR_Header{
+			Name:     "9.8.7.6.5.5.5.4.3.2.1.e164.arpa",
+			Rrtype:   dns.TypeNAPTR,
+			Class:    dns.ClassINET,
+			Ttl:      300,
+			Rdlength: 0,
+		},
+		Order:       100,
+		Preference:  10,
+		Flags:       "u",
+		Service:     "sip+E2U",
+		Regexp:      "!^.*$!sip:number@example.com!",
+		Replacement: ".",
+	}
+
+	res = ParseAnswer(rr)
+	answer, ok := res.(NAPTRAnswer)
+	if !ok {
+		t.Error("Failed to parse record")
+		return
+	}
+	verifyResult(t, answer.Answer, rr, "")
+	if answer.Order != 100 {
+		t.Errorf("Unxpected order. Expected %v, got %v", 100, answer.Order)
+	}
+	if answer.Preference != 10 {
+		t.Errorf("Unxpected preference. Expected %v, got %v", 10, answer.Preference)
+	}
+	if answer.Flags != "u" {
+		t.Errorf("Unxpected flags. Expected %v, got %v", "u", answer.Flags)
+	}
+	if answer.Service != "sip+E2U" {
+		t.Errorf("Unxpected service. Expected %v, got %v", "sip+E2U", answer.Service)
+	}
+	if answer.Regexp != "!^.*$!sip:number@example.com!" {
+		t.Errorf("Unxpected regexp. Expected %v, got %v", "!^.*$!sip:number@example.com!", answer.Regexp)
+	}
+	if answer.Replacement != "." {
+		t.Errorf("Unxpected replacement. Expected %v, got %v", ".", answer.Replacement)
+	}
+
 	// TODO: test remaining RR types
 }
 


### PR DESCRIPTION
Adds support for RR type 35 aka _Naming Authority Pointer_ (NAPTR) according to [RFC 2915](https://tools.ietf.org/html/rfc2915)

Real world applications can be found here for example:
* `http.uri.arpa` (generic HTTP URIs)
* `4.4.2.2.3.3.5.6.8.1.4.4.e164.arpa` (E164 phone number lookup for SIP)

I've added a trivial test case for the RR parser.
