### PR TITLE
include dns resolver in result

### DIFF
--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -118,6 +118,7 @@ type Result struct {
 	Additional  []interface{} `json:"additionals"`
 	Authorities []interface{} `json:"authorities"`
 	Protocol    string        `json:"protocol"`
+	Resolver    string        `json:"resolver"`
 	Flags       DNSFlags      `json:"flags"`
 }
 
@@ -672,6 +673,7 @@ func (s *Lookup) doLookup(dnsType uint16, dnsClass uint16, name string, nameServ
 // Expose the inner logic so other tools can use it
 func DoLookupWorker(udp *dns.Client, tcp *dns.Client, dnsType uint16, dnsClass uint16, name string, nameServer string, recursive bool) (Result, zdns.Status, error) {
 	res := Result{Answers: []interface{}{}, Authorities: []interface{}{}, Additional: []interface{}{}}
+	res.Resolver = nameServer
 
 	m := new(dns.Msg)
 	m.SetQuestion(dotName(name), dnsType)
@@ -1049,7 +1051,9 @@ func handleStatus(status *zdns.Status, err error) (*zdns.Status, error) {
 	}
 }
 
-func (s *Lookup) iterateOnAuthorities(dnsType uint16, dnsClass uint16, name string, depth int, result Result, layer string, trace []interface{}) (Result, []interface{}, zdns.Status, error) {
+func (s *Lookup) iterateOnAuthorities(dnsType uint16, dnsClass uint16, name string,
+	depth int, result Result, layer string, trace []interface{}) (Result, []interface{}, zdns.Status, error) {
+	//
 	if len(result.Authorities) == 0 {
 		var r Result
 		return r, trace, zdns.STATUS_SERVFAIL, nil
@@ -1095,7 +1099,9 @@ func (s *Lookup) iterateOnAuthorities(dnsType uint16, dnsClass uint16, name stri
 	return r, trace, zdns.STATUS_ERROR, errors.New("could not find authoritative name server")
 }
 
-func (s *Lookup) iterativeLookup(dnsType uint16, dnsClass uint16, name string, nameServer string, depth int, layer string, trace []interface{}) (Result, []interface{}, zdns.Status, error) {
+func (s *Lookup) iterativeLookup(dnsType uint16, dnsClass uint16, name string,
+	nameServer string, depth int, layer string, trace []interface{}) (Result, []interface{}, zdns.Status, error) {
+	//
 	if log.GetLevel() == log.DebugLevel {
 		//s.VerboseLog((depth), "iterative lookup for ", name, " (", dnsType, ") against ", nameServer, " (", debugReverseLookup(nameServer), ") layer ", layer)
 		s.VerboseLog((depth), "iterative lookup for ", name, " (", dnsType, ") against ", nameServer, " layer ", layer)


### PR DESCRIPTION
I think this was an oversight, but while we specify things like what protocol the response was sent over, we don't include the server that sent back the response, which is incredibly useful.