### PR TITLE
performance tune what we cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ ZDNS provides several types of modules.
 Raw DNS Modules
 ---------------
 
-The `A`, `AAAA`, `ANY`, `AXFR`, `CAA`, `CNAME`, `DMARC`, `MX`, `NS`, `PTR`, `TXT`,
-`SOA`, and `SPF` modules provide the raw DNS response in JSON form, similar to dig.
+The `A`, `AAAA`, `ANY`, `AXFR`, `CAA`, `CDS`, `CDNSKEY`, `CNAME`, `DMARC`, `DS`, `DNSKEY`,
+`MX`, `NAPTR`, `NS`, `NSEC`, `NSEC3`, `NSEC3PARAM`, `PTR`,  `RRSIG`, `SOA`, `SPF`,
+`SRV`, `TLSA`, and `TXT` modules provide the raw DNS response in JSON form, similar to dig.
 
 For example, the command:
 
@@ -155,6 +156,13 @@ You can control the number of concurrent connections with the `--threads` and
 specified with `--name-servers`. ZDNS will rotate through these servers when
 making requests.
 
+While the number of go routines you use will depend on both hardware and the
+type of request, we've rarely seen performance increase with more than 5,000 go
+routines. In most cases, either performance will decrease and/or timeouts will
+increase beyond that point. We've seen good ZDNS performance by running multiple
+processes. Running 4 instances of ZDNS each with 2,500 threads is a great place
+to start testing if you're performing large studies.
+
 Unsupported Types
 -----------------
 
@@ -169,7 +177,7 @@ parser support.
 License
 =======
 
-ZDNS Copyright 2016 Regents of the University of Michigan
+ZDNS Copyright 2020 Regents of the University of Michigan
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -671,12 +671,13 @@ func (s *GlobalLookupFactory) AddCachedAnswer(answer interface{}, name string, d
 		// we can't cache this entry because we have no idea what to name it
 		return
 	}
-	// only cache records that can help prevent future iteration.
-	// There's no reason to cache the leaf records that are unlikely to be useful in the future
+	// only cache records that can help prevent future iteration: A(AAA), NS, (C|D)NAME.
+	// This will prevent some entries that will never help future iteration (e.g., PTR)
+	// from causing unnecessary cache evictions.
 	// TODO: this is overly broad right now and will unnecessarily cache some leaf A/AAAA records. However,
 	// it's a lot of work to understand _why_ we're doing a specific lookup and this will still help
 	// in other cases, e.g., PTR lookups
-	if !(dnsType == dns.TypeA || dnsType == dns.TypeAAAA || dnsType == dns.TypeNS || dnsType == dns.TypeDNAME) {
+	if !(dnsType == dns.TypeA || dnsType == dns.TypeAAAA || dnsType == dns.TypeNS || dnsType == dns.TypeDNAME || dnsType == dns.TypeCNAME) {
 		return
 	}
 	key := makeCacheKey(name, dnsType)

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -566,14 +566,14 @@ func ParseAnswer(ans dns.RR) interface{} {
 				Ttl:     rrsig.Hdr.Ttl,
 			},
 			TypeCovered: rrsig.TypeCovered,
-			Algorithm: rrsig.Algorithm,
-			Labels: rrsig.Labels,
+			Algorithm:   rrsig.Algorithm,
+			Labels:      rrsig.Labels,
 			OriginalTtl: rrsig.OrigTtl,
-			Expiration: rrsig.Expiration,
-			Inception: rrsig.Inception,
-			KeyTag: rrsig.KeyTag,
-			SignerName: rrsig.SignerName,
-			Signature: rrsig.Signature,
+			Expiration:  rrsig.Expiration,
+			Inception:   rrsig.Inception,
+			KeyTag:      rrsig.KeyTag,
+			SignerName:  rrsig.SignerName,
+			Signature:   rrsig.Signature,
 		}
 	} else {
 		return struct {
@@ -671,6 +671,14 @@ func (s *GlobalLookupFactory) AddCachedAnswer(answer interface{}, name string, d
 		// we can't cache this entry because we have no idea what to name it
 		return
 	}
+	// only cache records that can help prevent future iteration.
+	// There's no reason to cache the leaf records that are unlikely to be useful in the future
+	// TODO: this is overly broad right now and will unnecessarily cache some leaf A/AAAA records. However,
+	// it's a lot of work to understand _why_ we're doing a specific lookup and this will still help
+	// in other cases, e.g., PTR lookups
+	if !(dnsType == dns.TypeA || dnsType == dns.TypeAAAA || dnsType == dns.TypeNS || dnsType == dns.TypeDNAME) {
+		return
+	}
 	key := makeCacheKey(name, dnsType)
 	expiresAt := time.Now().Add(time.Duration(ttl) * time.Second)
 	s.CacheMutex.Lock()
@@ -690,9 +698,9 @@ func (s *GlobalLookupFactory) AddCachedAnswer(answer interface{}, name string, d
 		Answer:    answer,
 		ExpiresAt: expiresAt}
 	ca.Answers[a] = ta
-	s.VerboseGlobalLog(depth+1, threadID, "Add cached answer ", key, " ", ca)
 	s.IterativeCache.Add(key, ca)
 	s.CacheMutex.Unlock()
+	s.VerboseGlobalLog(depth+1, threadID, "Add cached answer ", key, " ", ca)
 }
 
 func (s *GlobalLookupFactory) GetCachedResult(name string, dnsType uint16, isAuthCheck bool, depth int, threadID int) (Result, bool) {


### PR DESCRIPTION
Currently, when we perform large-scale PTR lookups, our cache fills up with PTR records which doesn't help solve any problems, and in fact slows things down by (1) grabbing a write lock on the cache, and (2) evicting useful data in the cache.

This PR changes our cache before to only cache A/AAAA/NS/DNAME records since those can be used for future lookups. This solution isn't 100% perfect since if we're doing A lookups on a tremendous number of names, those will still end up in the cache. However, that's a _significantly_ more complex problem to address and will be handled separately. 