### PR TITLE
introduce --result-verbosity={short,normal,long,trace}

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,19 +70,11 @@ returns:
         "data": "ns-cloud-e1.googledomains.com."
       },
     ],
-    "protocol": "udp"
+    "protocol": "udp",
+    "resolver": "30.128.52.190:53"
   }
 }
 ```
-
-Trace DNS Delegation
----------------------
-
-`echo "censys.io" | ./zdns a --trace`
-
-returns:
-```json { ... }```
-
 
 Lookup Modules
 --------------
@@ -144,6 +136,23 @@ is used, ZDNS will round-robin between the published root servers (e.g.,
 specifying `--cache-size` and the timeout for individual iterations by setting
 `--iteration-timeout`. The `--timeout` flag controls the timeout of the entire
 resolution for a given input (i.e., the sum of all iterative steps).
+
+Output Verbosity
+----------------
+
+DNS includes a lot of extraneous data that is not always useful. There are four
+result verbosity levels: `short`, `normal` (default), `long`, and `trace`:
+
+ * `short`: Short is the most terse result output. It contains only information about the responses
+ * `normal`: Normal provides everything included in short as well as data about the responding server
+ * `long`: Long outputs everything the server included in the DNS packet, including flags.
+ * `trace`: Trace outputs everything from every step of the recursion process
+
+Users can also include specific additional fields using the `--include-fields`
+flag and specifying a list of fields, e.g., `--include-fields=flags,resolver`.
+Additional fields are: class, protocol, ttl, resolver, flags.
+
+
 
 Running ZDNS
 ------------

--- a/conf.go
+++ b/conf.go
@@ -17,13 +17,17 @@ package zdns
 import "time"
 
 type GlobalConf struct {
-	Threads              int
-	Timeout              time.Duration
-	IterationTimeout     time.Duration
-	Retries              int
-	AlexaFormat          bool
-	IterativeResolution  bool
-	Trace                bool
+	Threads             int
+	Timeout             time.Duration
+	IterationTimeout    time.Duration
+	Retries             int
+	AlexaFormat         bool
+	IterativeResolution bool
+
+	ResultVerbosity string
+	IncludeInOutput string
+	OutputGroups    []string
+
 	MaxDepth             int
 	CacheSize            int
 	GoMaxProcs           int
@@ -61,16 +65,16 @@ type Metadata struct {
 }
 
 type Result struct {
-	AlteredName string        `json:"altered_name,omitempty"`
-	Name        string        `json:"name,omitempty"`
-	Nameserver  string        `json:"nameserver,omitempty"`
-	Class       string        `json:"class,omitempty"`
-	AlexaRank   int           `json:"alexa_rank,omitempty"`
-	Status      string        `json:"status,omitempty"`
-	Error       string        `json:"error,omitempty"`
-	Timestamp   string        `json:"timestamp,omitempty"`
-	Data        interface{}   `json:"data,omitempty"`
-	Trace       []interface{} `json:"trace,omitempty"`
+	AlteredName string        `json:"altered_name,omitempty" groups:"short,normal,long,trace"`
+	Name        string        `json:"name,omitempty" groups:"short,normal,long,trace"`
+	Nameserver  string        `json:"nameserver,omitempty" groups:"normal,long,trace"`
+	Class       string        `json:"class,omitempty" groups:"long,trace"`
+	AlexaRank   int           `json:"alexa_rank,omitempty" groups:"short,normal,long,trace"`
+	Status      string        `json:"status,omitempty" groups:"short,normal,long,trace"`
+	Error       string        `json:"error,omitempty" groups:"short,normal,long,trace"`
+	Timestamp   string        `json:"timestamp,omitempty" groups:"short,normal,long,trace"`
+	Data        interface{}   `json:"data,omitempty" groups:"short,normal,long,trace"`
+	Trace       []interface{} `json:"trace,omitempty" groups:"trace"`
 }
 
 type TargetedDomain struct {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.13
 
 require (
 	github.com/asergeyev/nradix v0.0.0-20170505151046-3872ab85bb56 // indirect
+	github.com/hashicorp/go-version v1.2.0
 	github.com/kavu/go_reuseport v1.4.0 // indirect
+	github.com/liip/sheriff v0.0.0-20190308094614-91aa83a45a3d
 	github.com/miekg/dns v1.1.27
 	github.com/sirupsen/logrus v1.4.2
 	github.com/zmap/go-iptree v0.0.0-20170831022036-1948b1097e25

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,14 @@ github.com/asergeyev/nradix v0.0.0-20170505151046-3872ab85bb56 h1:Wi5Tgn8K+jDcBY
 github.com/asergeyev/nradix v0.0.0-20170505151046-3872ab85bb56/go.mod h1:8BhOLuqtSuT5NZtZMwfvEibi09RO3u79uqfHZzfDTR4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
+github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/kavu/go_reuseport v1.4.0 h1:YIp/96RZ3sJfn0LN+FFkkXIq3H3dfVOdRUtNejhDcxc=
 github.com/kavu/go_reuseport v1.4.0/go.mod h1:CG8Ee7ceMFSMnx/xr25Vm0qXaj2Z4i5PWoUx+JZ5/CU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/liip/sheriff v0.0.0-20190308094614-91aa83a45a3d h1:sw/HcaIZ8fPd+FdiK6LVMZCxuDo1OwOIuALMleQtx9o=
+github.com/liip/sheriff v0.0.0-20190308094614-91aa83a45a3d/go.mod h1:2MJBI19QKEBYwmKsVelNJefqecj84mwgi80HqQ5pwLQ=
 github.com/miekg/dns v1.1.27 h1:aEH/kqUzUxGJ/UHcEKdJY+ugH6WEzsEBBSPa8zuy1aM=
 github.com/miekg/dns v1.1.27/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/lookup.go
+++ b/lookup.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-version"
+	"github.com/liip/sheriff"
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 )
@@ -121,7 +123,13 @@ func doLookup(g *GlobalLookupFactory, gc *GlobalConf, input <-chan interface{}, 
 			if err != nil {
 				res.Error = err.Error()
 			}
-			jsonRes, err := json.Marshal(res)
+			v, _ := version.NewVersion("0.0.0")
+			o := &sheriff.Options{
+				Groups:     gc.OutputGroups,
+				ApiVersion: v,
+			}
+			data, err := sheriff.Marshal(o, res)
+			jsonRes, err := json.Marshal(data)
 			if err != nil {
 				log.Fatal("Unable to marshal JSON result", err)
 			}

--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -25,8 +25,8 @@ import (
 )
 
 type Result struct {
-	IPv4Addresses []string `json:"ipv4_addresses,omitempty"`
-	IPv6Addresses []string `json:"ipv6_addresses,omitempty"`
+	IPv4Addresses []string `json:"ipv4_addresses,omitempty" groups:"short,normal,long,trace"`
+	IPv6Addresses []string `json:"ipv6_addresses,omitempty" groups:"short,normal,long,trace"`
 }
 
 // Per Connection Lookup ======================================================

--- a/modules/axfr/axfr.go
+++ b/modules/axfr/axfr.go
@@ -37,14 +37,14 @@ type Lookup struct {
 }
 
 type AXFRServerResult struct {
-	Server  string        `json:"server"`
-	Status  string        `json:"status"`
-	Error   string        `json:"error,omitempty"`
-	Records []interface{} `json:"records,omitempty"`
+	Server  string        `json:"server" groups:"short,normal,long,trace"`
+	Status  string        `json:"status" groups:"short,normal,long,trace"`
+	Error   string        `json:"error,omitempty" groups:"short,normal,long,trace"`
+	Records []interface{} `json:"records,omitempty" groups:"short,normal,long,trace"`
 }
 
 type AXFRResult struct {
-	Servers []AXFRServerResult `json:"servers,omitempty"`
+	Servers []AXFRServerResult `json:"servers,omitempty" groups:"short,normal,long,trace"`
 }
 
 func dotName(name string) string {

--- a/modules/dmarc/dmarc.go
+++ b/modules/dmarc/dmarc.go
@@ -22,7 +22,7 @@ import (
 
 // result to be returned by scan of host
 type Result struct {
-	Dmarc string `json:"dmarc,omitempty"`
+	Dmarc string `json:"dmarc,omitempty" groups:"short,normal,long,trace"`
 }
 
 // Per Connection Lookup ======================================================

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -91,68 +91,68 @@ var typeNames = map[uint16]string{
 }
 
 type Answer struct {
-	Ttl     uint32 `json:"ttl"`
-	Type    string `json:"type,omitempty"`
+	Ttl     uint32 `json:"ttl" groups:"ttl,normal,long,trace"`
+	Type    string `json:"type,omitempty" groups:"short,normal,long,trace"`
 	rrType  uint16
-	Class   string `json:"class,omitempty"`
+	Class   string `json:"class,omitempty" groups:"short,normal,long,trace"`
 	rrClass uint16
-	Name    string `json:"name,omitempty"`
-	Answer  string `json:"answer,omitempty"`
+	Name    string `json:"name,omitempty" groups:"short,normal,long,trace"`
+	Answer  string `json:"answer,omitempty" groups:"short,normal,long,trace"`
 }
 
 type MXAnswer struct {
 	Answer
-	Preference uint16 `json:"preference"`
+	Preference uint16 `json:"preference" groups:"short,normal,long,trace"`
 }
 
 type DSAnswer struct {
 	Answer
-	KeyTag     uint16 `json:"key_tag"`
-	Algorithm  uint8  `json:"algorithm"`
-	DigestType uint8  `json:"digest_type"`
-	Digest     string `json:"digest"`
+	KeyTag     uint16 `json:"key_tag" groups:"short,normal,long,trace"`
+	Algorithm  uint8  `json:"algorithm" groups:"short,normal,long,trace"`
+	DigestType uint8  `json:"digest_type" groups:"short,normal,long,trace"`
+	Digest     string `json:"digest" groups:"short,normal,long,trace"`
 }
 
 type DNSKEYAnswer struct {
 	Answer
-	Flags     uint16 `json:"flags"`
-	Protocol  uint8  `json:"protocol"`
-	Algorithm uint8  `json:"algorithm"`
-	PublicKey string `json:"public_key"`
+	Flags     uint16 `json:"flags" groups:"short,normal,long,trace"`
+	Protocol  uint8  `json:"protocol" groups:"short,normal,long,trace"`
+	Algorithm uint8  `json:"algorithm" groups:"short,normal,long,trace"`
+	PublicKey string `json:"public_key" groups:"short,normal,long,trace"`
 }
 
 type CAAAnswer struct {
 	Answer
-	Tag   string `json:"tag"`
-	Value string `json:"value"`
-	Flag  uint8  `json:"flag"`
+	Tag   string `json:"tag" groups:"short,normal,long,trace"`
+	Value string `json:"value" groups:"short,normal,long,trace"`
+	Flag  uint8  `json:"flag" groups:"short,normal,long,trace"`
 }
 
 type SOAAnswer struct {
 	Answer
-	Ns      string `json:"ns"`
-	Mbox    string `json:"mbox"`
-	Serial  uint32 `json:"serial"`
-	Refresh uint32 `json:"refresh"`
-	Retry   uint32 `json:"retry"`
-	Expire  uint32 `json:"expire"`
-	Minttl  uint32 `json:"min_ttl"`
+	Ns      string `json:"ns" groups:"short,normal,long,trace"`
+	Mbox    string `json:"mbox" groups:"short,normal,long,trace"`
+	Serial  uint32 `json:"serial" groups:"short,normal,long,trace"`
+	Refresh uint32 `json:"refresh" groups:"short,normal,long,trace"`
+	Retry   uint32 `json:"retry" groups:"short,normal,long,trace"`
+	Expire  uint32 `json:"expire" groups:"short,normal,long,trace"`
+	Minttl  uint32 `json:"min_ttl" groups:"short,normal,long,trace"`
 }
 
 type SRVAnswer struct {
 	Answer
-	Priority uint16 `json:"priority"`
-	Weight   uint16 `json:"weight"`
-	Port     uint16 `json:"port"`
-	Target   string `json:"target"`
+	Priority uint16 `json:"priority" groups:"short,normal,long,trace"`
+	Weight   uint16 `json:"weight" groups:"short,normal,long,trace"`
+	Port     uint16 `json:"port" groups:"short,normal,long,trace"`
+	Target   string `json:"target" groups:"short,normal,long,trace"`
 }
 
 type TLSAAnswer struct {
 	Answer
-	CertUsage    uint8  `json:"cert_usage"`
-	Selector     uint8  `json:"selector"`
-	MatchingType uint8  `json:"matching_type"`
-	Certificate  string `json:"certificate"`
+	CertUsage    uint8  `json:"cert_usage" groups:"short,normal,long,trace"`
+	Selector     uint8  `json:"selector" groups:"short,normal,long,trace"`
+	MatchingType uint8  `json:"matching_type" groups:"short,normal,long,trace"`
+	Certificate  string `json:"certificate" groups:"short,normal,long,trace"`
 }
 
 type NSECAnswer struct {
@@ -161,74 +161,74 @@ type NSECAnswer struct {
 
 type NSEC3Answer struct {
 	Answer
-	HashAlgorithm uint8  `json:"hash_algorithm"`
-	Flags         uint8  `json:"flags"`
-	Iterations    uint16 `json:"iterations"`
-	Salt          string `json:"salt"`
+	HashAlgorithm uint8  `json:"hash_algorithm" groups:"short,normal,long,trace"`
+	Flags         uint8  `json:"flags" groups:"short,normal,long,trace"`
+	Iterations    uint16 `json:"iterations" groups:"short,normal,long,trace"`
+	Salt          string `json:"salt" groups:"short,normal,long,trace"`
 }
 
 type NSEC3ParamAnswer struct {
 	Answer
-	HashAlgorithm uint8  `json:"hash_algorithm"`
-	Flags         uint8  `json:"flags"`
-	Iterations    uint16 `json:"iterations"`
-	Salt          string `json:"salt"`
+	HashAlgorithm uint8  `json:"hash_algorithm" groups:"short,normal,long,trace"`
+	Flags         uint8  `json:"flags" groups:"short,normal,long,trace"`
+	Iterations    uint16 `json:"iterations" groups:"short,normal,long,trace"`
+	Salt          string `json:"salt" groups:"short,normal,long,trace"`
 }
 
 type NAPTRAnswer struct {
 	Answer
-	Order       uint16 `json:"order"`
-	Preference  uint16 `json:"preference"`
-	Flags       string `json:"flags"`
-	Service     string `json:"service"`
-	Regexp      string `json:"regexp"`
-	Replacement string `json:"replacement"`
+	Order       uint16 `json:"order" groups:"short,normal,long,trace"`
+	Preference  uint16 `json:"preference" groups:"short,normal,long,trace"`
+	Flags       string `json:"flags" groups:"short,normal,long,trace"`
+	Service     string `json:"service" groups:"short,normal,long,trace"`
+	Regexp      string `json:"regexp" groups:"short,normal,long,trace"`
+	Replacement string `json:"replacement" groups:"short,normal,long,trace"`
 }
 
 type RRSIGAnswer struct {
 	Answer
-	TypeCovered uint16 `json:"type_covered"`
-	Algorithm   uint8  `json:"algorithm"`
-	Labels      uint8  `json:"labels"`
-	OriginalTtl uint32 `json:"original_ttl"`
-	Expiration  uint32 `json:"expiration"`
-	Inception   uint32 `json:"inception"`
-	KeyTag      uint16 `json:"keytag"`
-	SignerName  string `json:"signer_name"`
-	Signature   string `json:"signature"`
+	TypeCovered uint16 `json:"type_covered" groups:"short,normal,long,trace"`
+	Algorithm   uint8  `json:"algorithm" groups:"short,normal,long,trace"`
+	Labels      uint8  `json:"labels" groups:"short,normal,long,trace"`
+	OriginalTtl uint32 `json:"original_ttl" groups:"short,normal,long,trace"`
+	Expiration  uint32 `json:"expiration" groups:"short,normal,long,trace"`
+	Inception   uint32 `json:"inception" groups:"short,normal,long,trace"`
+	KeyTag      uint16 `json:"keytag" groups:"short,normal,long,trace"`
+	SignerName  string `json:"signer_name" groups:"short,normal,long,trace"`
+	Signature   string `json:"signature" groups:"short,normal,long,trace"`
 }
 
 type DNSFlags struct {
-	Response           bool `json:"response"`
-	Opcode             int  `json:"opcode"`
-	Authoritative      bool `json:"authoritative"`
-	Truncated          bool `json:"truncated"`
-	RecursionDesired   bool `json:"recursion_desired"`
-	RecursionAvailable bool `json:"recursion_available"`
-	Authenticated      bool `json:"authenticated"`
-	CheckingDisabled   bool `json:"checking_disabled"`
-	ErrorCode          int  `json:"error_code"`
+	Response           bool `json:"response" groups:"flags,long,trace"`
+	Opcode             int  `json:"opcode" groups:"flags,long,trace"`
+	Authoritative      bool `json:"authoritative" groups:"flags,long,trace"`
+	Truncated          bool `json:"truncated" groups:"flags,long,trace"`
+	RecursionDesired   bool `json:"recursion_desired" groups:"flags,long,trace"`
+	RecursionAvailable bool `json:"recursion_available" groups:"flags,long,trace"`
+	Authenticated      bool `json:"authenticated" groups:"flags,long,trace"`
+	CheckingDisabled   bool `json:"checking_disabled" groups:"flags,long,trace"`
+	ErrorCode          int  `json:"error_code" groups:"flags,long,trace"`
 }
 
 // result to be returned by scan of host
 type Result struct {
-	Answers     []interface{} `json:"answers"`
-	Additional  []interface{} `json:"additionals"`
-	Authorities []interface{} `json:"authorities"`
-	Protocol    string        `json:"protocol"`
-	Resolver    string        `json:"resolver"`
-	Flags       DNSFlags      `json:"flags"`
+	Answers     []interface{} `json:"answers" groups:"short,normal,long,trace"`
+	Additional  []interface{} `json:"additionals" groups:"short,normal,long,trace"`
+	Authorities []interface{} `json:"authorities" groups:"short,normal,long,trace"`
+	Protocol    string        `json:"protocol" groups:"protocol,normal,long,trace"`
+	Resolver    string        `json:"resolver" groups:"resolver,normal,long,trace"`
+	Flags       DNSFlags      `json:"flags" groups:"flags,long,trace"`
 }
 
 type TraceStep struct {
-	Result     Result   `json:"results"`
-	DnsType    uint16   `json:"type"`
-	DnsClass   uint16   `json:"class"`
-	Name       string   `json:"name"`
-	NameServer string   `json:"name_server"`
-	Depth      int      `json:"depth"`
-	Layer      string   `json:"layer"`
-	Cached     IsCached `json:"cached"`
+	Result     Result   `json:"results" groups:"trace"`
+	DnsType    uint16   `json:"type" groups:"trace"`
+	DnsClass   uint16   `json:"class" groups:"trace"`
+	Name       string   `json:"name" groups:"trace"`
+	NameServer string   `json:"name_server" groups:"trace"`
+	Depth      int      `json:"depth" groups:"trace"`
+	Layer      string   `json:"layer" groups:"trace"`
+	Cached     IsCached `json:"cached" groups:"trace"`
 }
 
 type TimedAnswer struct {
@@ -622,7 +622,8 @@ func (s *GlobalLookupFactory) BlacklistInit() error {
 }
 
 func (s *GlobalLookupFactory) AddFlags(f *flag.FlagSet) {
-	f.StringVar(&s.BlacklistPath, "blacklist-file", "", "blacklist file for servers to exclude from lookups, only effective for iterative lookups")
+	f.StringVar(&s.BlacklistPath, "blacklist-file", "",
+		"blacklist file for servers to exclude from lookups, only effective for iterative lookups")
 }
 
 func (s *GlobalLookupFactory) Initialize(c *zdns.GlobalConf) error {
@@ -790,7 +791,11 @@ func (s *RoutineLookupFactory) Initialize(c *zdns.GlobalConf) {
 	s.Retries = c.Retries
 	s.MaxDepth = c.MaxDepth
 	s.IterativeResolution = c.IterativeResolution
-	s.Trace = c.Trace
+	if c.ResultVerbosity == "trace" {
+		s.Trace = true
+	} else {
+		s.Trace = false
+	}
 
 	s.DNSClass = c.Class
 }

--- a/modules/mxlookup/mxlookup.go
+++ b/modules/mxlookup/mxlookup.go
@@ -33,13 +33,13 @@ type CachedAddresses struct {
 }
 
 type MXRecord struct {
-	Name          string   `json:"name"`
-	Type          string   `json:"type"`
-	Class         string   `json:"class"`
-	Preference    uint16   `json:"preference"`
-	IPv4Addresses []string `json:"ipv4_addresses,omitempty"`
-	IPv6Addresses []string `json:"ipv6_addresses,omitempty"`
-	TTL           uint32   `json:"ttl"`
+	Name          string   `json:"name" groups:"short,normal,long,trace"`
+	Type          string   `json:"type" groups:"short,normal,long,trace"`
+	Class         string   `json:"class" groups:"short,normal,long,trace"`
+	Preference    uint16   `json:"preference" groups:"short,normal,long,trace"`
+	IPv4Addresses []string `json:"ipv4_addresses,omitempty" groups:"short,normal,long,trace"`
+	IPv6Addresses []string `json:"ipv6_addresses,omitempty" groups:"short,normal,long,trace"`
+	TTL           uint32   `json:"ttl" groups:"ttl,normal,long,trace"`
 }
 
 type Result struct {

--- a/modules/mxlookup/mxlookup.go
+++ b/modules/mxlookup/mxlookup.go
@@ -43,7 +43,7 @@ type MXRecord struct {
 }
 
 type Result struct {
-	Servers []MXRecord `json:"exchanges"`
+	Servers []MXRecord `json:"exchanges" groups:"short,normal,long,trace"`
 }
 
 // Per Connection Lookup ======================================================

--- a/modules/spf/spf.go
+++ b/modules/spf/spf.go
@@ -22,7 +22,7 @@ import (
 
 // result to be returned by scan of host
 type Result struct {
-	Spf string `json:"spf,omitempty"`
+	Spf string `json:"spf,omitempty" groups:"short,normal,long,trace"`
 }
 
 // Per Connection Lookup ======================================================


### PR DESCRIPTION
ZDNS output is very verbose today, and most of the data isn't useful for day-to-day operations. This flag allows the user to determine how much information they want returned.