### PR TITLE
fix port check to add default server port to IPv6 addresses

### DIFF
--- a/zdns/main.go
+++ b/zdns/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -140,9 +141,13 @@ func main() {
 		log.Info("no name servers specified. will use: ", strings.Join(gc.NameServers, ", "))
 	} else {
 		ns := strings.Split(*servers_string, ",")
+		rePort := regexp.MustCompile(":\\d+$")      // string ends with potential port number
+		reV6 := regexp.MustCompile("^([0-9a-f]*:)") // string starts like valid IPv6 address
 		for i, s := range ns {
-			if !strings.Contains(s, ":") {
+			if !rePort.MatchString(s) {
 				ns[i] = s + ":53"
+			} else if reV6.MatchString(s) {
+				ns[i] = "[" + s + "]:53"
 			}
 		}
 		gc.NameServers = ns

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -161,6 +161,9 @@ func main() {
 			if !rePort.MatchString(s) {
 				ns[i] = s + ":53"
 			} else if reV6.MatchString(s) {
+				ns[i] = "[" + s + "]:53"
+			}
+		}
 		gc.NameServers = ns
 		gc.NameServersSpecified = true
 	}


### PR DESCRIPTION
Fix regression from #174 (Default dns server port).

Providing a plain IPv6 address without a specific port causes ZDNS to fail because of missing port number, because the simple check recognizes a colon and does not append anything.
https://github.com/zmap/zdns/blob/e6a231848b048d8ac97a5c024b6b2826507b7501/zdns/main.go#L144
We should add brackets around such addresses and append the default port number

I've extended the check to use two regular expressions:
1. `:\d+$` - does the input end with a potential port number?
2. `^([0-9a-f]*:)` - does the input start like a valid IPv6 address? (only start matched, because encoded v4 addresses may end with v4 notation)

For completeness a list of possible input patterns (mismatches highlighted):

| Input              | Current result     | Valid result         |
| ------------------ | ------------------ | -------------------- |
| 192.0.2.0          | 192.0.2.0:53       | 192.0.2.0:53         |
| 192.0.2.0:53       | 192.0.2.0:53       | 192.0.2.0:53         |
| 2001:db8::1        | **2001:db8::1**    | **[2001:db8::1]:53** |
| [2001:db8::1]      | **[2001:db8::1]**  | **[2001:db8::1]:53** |
| [2001:db8::1]:53   | [2001:db8::1]:53   | [2001:db8::1]:53     |
| ::1                | **::1**            | **[::1]:53**         |
| [::1]              | **[::1]**          | **[::1]:53**         |
| [::1]:53           | [::1]:53           | [::1]:53             |
| dns.example.com    | dns.example.com:53 | dns.example.com:53   |
| dns.example.com:53 | dns.example.com:53 | dns.example.com:53   |
| localhost          | localhost:53       | localhost:53         |
| localhost:53       | localhost:53       | localhost:53         |
