### PR TITLE
sharded cache hash

### DIFF
--- a/cachehash/cachehash.go
+++ b/cachehash/cachehash.go
@@ -24,7 +24,7 @@ type CacheHash struct {
 	l       *list.List
 	len     int
 	maxLen  int
-	mutex   *sync.RWMutex
+	mutex   *sync.Mutex
 	ejectCB func(interface{}, interface{})
 }
 
@@ -34,7 +34,7 @@ type keyValue struct {
 }
 
 func (c *CacheHash) Init(maxLen int) {
-	c.mutex = &sync.RWMutex{}
+	c.mutex = &sync.Mutex{}
 	c.l = list.New()
 	c.l = c.l.Init()
 	c.h = make(map[interface{}]*list.Element)

--- a/cachehash/cachehash.go
+++ b/cachehash/cachehash.go
@@ -20,11 +20,11 @@ import (
 )
 
 type CacheHash struct {
+	sync.Mutex
 	h       map[interface{}]*list.Element
 	l       *list.List
 	len     int
 	maxLen  int
-	mutex   *sync.Mutex
 	ejectCB func(interface{}, interface{})
 }
 
@@ -34,20 +34,11 @@ type keyValue struct {
 }
 
 func (c *CacheHash) Init(maxLen int) {
-	c.mutex = &sync.Mutex{}
 	c.l = list.New()
 	c.l = c.l.Init()
 	c.h = make(map[interface{}]*list.Element)
 	c.len = 0
 	c.maxLen = maxLen
-}
-
-func (c *CacheHash) Lock() {
-	c.mutex.Lock()
-}
-
-func (c *CacheHash) Unlock() {
-	c.mutex.Unlock()
 }
 
 func (c *CacheHash) Eject() {

--- a/cachehash/cachehash.go
+++ b/cachehash/cachehash.go
@@ -14,13 +14,17 @@
 
 package cachehash
 
-import "container/list"
+import (
+	"container/list"
+	"sync"
+)
 
 type CacheHash struct {
 	h       map[interface{}]*list.Element
 	l       *list.List
 	len     int
 	maxLen  int
+	mutex   *sync.RWMutex
 	ejectCB func(interface{}, interface{})
 }
 
@@ -30,11 +34,20 @@ type keyValue struct {
 }
 
 func (c *CacheHash) Init(maxLen int) {
+	c.mutex = &sync.RWMutex{}
 	c.l = list.New()
 	c.l = c.l.Init()
 	c.h = make(map[interface{}]*list.Element)
 	c.len = 0
 	c.maxLen = maxLen
+}
+
+func (c *CacheHash) Lock() {
+	c.mutex.Lock()
+}
+
+func (c *CacheHash) Unlock() {
+	c.mutex.Unlock()
 }
 
 func (c *CacheHash) Eject() {

--- a/cachehash/shardedcachehash.go
+++ b/cachehash/shardedcachehash.go
@@ -1,0 +1,82 @@
+/*
+ * ZGrab Copyright 2015 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package cachehash
+
+import (
+	"fmt"
+	"hash/crc32"
+)
+
+type ShardedCacheHash struct {
+	shards    []CacheHash
+	shardsLen int
+}
+
+func (c *ShardedCacheHash) Init(maxLen int, shards int) {
+	fmt.Println(" fuck you ", shards)
+	c.shardsLen = shards
+	shardLen := maxLen / shards
+	c.shards = make([]CacheHash, shards)
+	for i := 0; i < shards; i++ {
+		//c.shards[i] = new(CacheHash)
+		c.shards[i].Init(shardLen)
+	}
+}
+
+func (c *ShardedCacheHash) getShardID(k interface{}) int {
+	if kb, ok := k.(*[]byte); !ok {
+		return 0
+	} else {
+		return int(crc32.ChecksumIEEE(*kb)) % c.shardsLen
+	}
+}
+
+func (c *ShardedCacheHash) getShard(k interface{}) *CacheHash {
+	return &c.shards[c.getShardID(k)]
+}
+
+func (c *ShardedCacheHash) Add(k interface{}, v interface{}) bool {
+	return c.getShard(k).Add(k, v)
+}
+
+func (c *ShardedCacheHash) Get(k interface{}) (interface{}, bool) {
+	return c.getShard(k).Get(k)
+}
+
+func (c *ShardedCacheHash) GetNoMove(k interface{}) (interface{}, bool) {
+	return c.getShard(k).GetNoMove(k)
+}
+
+func (c *ShardedCacheHash) Has(k interface{}) bool {
+	return c.getShard(k).Has(k)
+}
+
+func (c *ShardedCacheHash) Delete(k interface{}) (interface{}, bool) {
+	return c.getShard(k).Delete(k)
+}
+
+func (c *ShardedCacheHash) RegisterCB(newCB func(interface{}, interface{})) {
+	for i := 0; i < c.shardsLen; i++ {
+		c.shards[i].RegisterCB(newCB)
+	}
+}
+
+func (c *ShardedCacheHash) Lock(k interface{}) {
+	c.getShard(k).Lock()
+}
+
+func (c *ShardedCacheHash) Unlock(k interface{}) {
+	c.getShard(k).Unlock()
+}

--- a/cachehash/shardedcachehash.go
+++ b/cachehash/shardedcachehash.go
@@ -25,22 +25,17 @@ type ShardedCacheHash struct {
 }
 
 func (c *ShardedCacheHash) Init(maxLen int, shards int) {
-	fmt.Println(" fuck you ", shards)
 	c.shardsLen = shards
 	shardLen := maxLen / shards
 	c.shards = make([]CacheHash, shards)
 	for i := 0; i < shards; i++ {
-		//c.shards[i] = new(CacheHash)
 		c.shards[i].Init(shardLen)
 	}
 }
 
 func (c *ShardedCacheHash) getShardID(k interface{}) int {
-	if kb, ok := k.(*[]byte); !ok {
-		return 0
-	} else {
-		return int(crc32.ChecksumIEEE(*kb)) % c.shardsLen
-	}
+	kb := []byte(fmt.Sprintf("%v", k))
+	return int(crc32.ChecksumIEEE(kb)) % c.shardsLen
 }
 
 func (c *ShardedCacheHash) getShard(k interface{}) *CacheHash {

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -631,7 +631,7 @@ func (s *GlobalLookupFactory) Initialize(c *zdns.GlobalConf) error {
 	if err != nil {
 		return err
 	}
-	s.IterativeCache.Init(c.CacheSize, 256)
+	s.IterativeCache.Init(c.CacheSize, 4096)
 	s.DNSClass = dns.ClassINET
 
 	return nil


### PR DESCRIPTION
This provides 15-20% at 5K threads and 20-25% at 10K threads performance improvement. While it's tiny bit less fair in eviction, the removal of a global lock over every cache entry more than makes up for it empirically, so I don't see much if any downside. It also allows much higher number of threads without slowdown.

This also changes the RWMutex to a normal mutex since we never used Read vs Write locks anyway.