### PR TITLE
Name Server Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ supports mixing and matching both modes by piping in a comma-delimited list of
 ```echo "google.com,8.8.8.8" | ./zdns A``` will send an `A` query for
 `google.com` to `8.8.8.8` regardless of what name servers are specified by
 `--name-servers=` flag. Lines that do not explicitly specify a name server will
-use the servers specified by the OS or `--name-server` flag as would normally
+use the servers specified by the OS or `--name-servers` flag as would normally
 happen.
 
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,30 @@ flag and specifying a list of fields, e.g., `--include-fields=flags,resolver`.
 Additional fields are: class, protocol, ttl, resolver, flags.
 
 
+Name Server Mode
+----------------
+
+By default ZDNS expects to receive a list of names to lookup on a small number
+of name servers. For example:
+
+```echo "google.com" | ./zdns A --name-servers=8.8.8.8,8.8.4.4```
+
+However, there are times where you instead want to lookup the same name across
+a large number of servers. This can be accomplished using _name server mode_.
+For example:
+
+```echo "8.8.8.8" | ./zdns A --override-name="google.com"```
+
+Here, every line piped in ZDNS is sent an A query for `google.com`. ZDNS also
+supports mixing and matching both modes by piping in a comma-delimited list of
+`name,nameServer`. For example:
+
+```echo "google.com,8.8.8.8" | ./zdns A``` will send an `A` query for
+`google.com` to `8.8.8.8` regardless of what name servers are specified by
+`--name-servers=` flag. Lines that do not explicitly specify a name server will
+use the servers specified by the OS or `--name-server` flag as would normally
+happen.
+
 
 Running ZDNS
 ------------

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ However, there are times where you instead want to lookup the same name across
 a large number of servers. This can be accomplished using _name server mode_.
 For example:
 
-```echo "8.8.8.8" | ./zdns A --override-name="google.com"```
+```echo "8.8.8.8" | ./zdns A --name-server-mode= --override-name="google.com"```
 
 Here, every line piped in ZDNS is sent an A query for `google.com`. ZDNS also
 supports mixing and matching both modes by piping in a comma-delimited list of

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ However, there are times where you instead want to lookup the same name across
 a large number of servers. This can be accomplished using _name server mode_.
 For example:
 
-```echo "8.8.8.8" | ./zdns A --name-server-mode= --override-name="google.com"```
+```echo "8.8.8.8" | ./zdns A --name-server-mode --override-name="google.com"```
 
 Here, every line piped in ZDNS is sent an A query for `google.com`. ZDNS also
 supports mixing and matching both modes by piping in a comma-delimited list of

--- a/conf.go
+++ b/conf.go
@@ -17,12 +17,13 @@ package zdns
 import "time"
 
 type GlobalConf struct {
-	Threads             int
-	Timeout             time.Duration
-	IterationTimeout    time.Duration
-	Retries             int
-	AlexaFormat         bool
-	IterativeResolution bool
+	Threads               int
+	Timeout               time.Duration
+	IterationTimeout      time.Duration
+	Retries               int
+	AlexaFormat           bool
+	NameServerInputFormat bool
+	IterativeResolution   bool
 
 	ResultVerbosity string
 	IncludeInOutput string
@@ -47,7 +48,9 @@ type GlobalConf struct {
 	LogFilePath      string
 	MetadataFilePath string
 
-	NamePrefix string
+	NamePrefix     string
+	NameOverride   string
+	NameServerMode bool
 
 	Module string
 	Class  uint16

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,4 @@ require (
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
 )
 
-replace github.com/miekg/dns => /Users/zakir/Sandbox/zmap/dns
+replace github.com/miekg/dns => github.com/zmap/dns v1.1.28-zmap

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,4 @@ require (
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
 )
 
-replace github.com/miekg/dns => github.com/zmap/dns v1.1.28-zmap
+replace github.com/miekg/dns => /Users/zakir/Sandbox/zmap/dns

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -3,6 +3,7 @@ import copy
 import subprocess
 import json
 import unittest
+import tempfile
 
 def recursiveSort(obj):
 
@@ -28,6 +29,7 @@ def recursiveSort(obj):
     else:
         return obj
 
+
 class Tests(unittest.TestCase):
 
     maxDiff = None
@@ -36,6 +38,17 @@ class Tests(unittest.TestCase):
         c = u"echo '%s' | %s" % (name, command)
         o = subprocess.check_output(c, shell=True)
         return c, json.loads(o.rstrip())
+
+    def run_zdns_multiline(self, command, names):
+        d = tempfile.mkdtemp
+        f = "/".join([d,"temp"])
+        with open(f) as fd:
+            for name in names:
+                fd.writeline(name)
+        c = u"cat '%s' | %s" % (f, command)
+        o = subprocess.check_output(c, shell=True)
+        os.rm(f)
+        return c, [json.loads(l.rstrip()) for l in o]
 
     ROOT_A = set([
         u"1.2.3.4",
@@ -137,7 +150,6 @@ class Tests(unittest.TestCase):
             ]
         }
     }
-
 
     A_LOOKUP_IPV4_WWW_ZDNS_TESTING = copy.deepcopy(A_LOOKUP_WWW_ZDNS_TESTING)
     del A_LOOKUP_IPV4_WWW_ZDNS_TESTING["data"]["ipv6_addresses"]
@@ -318,7 +330,11 @@ class Tests(unittest.TestCase):
     def assertEqualAnswers(self, res, correct, cmd, key='answer'):
         for answer in res["data"]["answers"]:
             del answer["ttl"]
-        self.assertEqual(sorted(res["data"]["answers"], key=lambda x: x[key]), sorted(correct, key=lambda x: x[key]), cmd)
+        a = sorted(res["data"]["answers"], key=lambda x: x[key])
+        b = sorted(correct, key=lambda x: x[key])
+        helptext = "%s\nExpected:\n%s\n\nActual:\n%s" % (cmd,
+                json.dumps(b,indent=4), json.dumps(a,indent=4))
+        self.assertEqual(a, b, helptext)
 
     def assertEqualNXDOMAIN(self, res, correct):
         self.assertEqual(res["name"], correct["name"])
@@ -386,7 +402,6 @@ class Tests(unittest.TestCase):
         name = u"zdns-testing-nxdomain.com"
         cmd, res = self.run_zdns(c, name)
         self.assertEqualNXDOMAIN(res, self.NXDOMAIN_ANSWER)
-
 
     def test_aaaa(self):
         c = u"./zdns/zdns AAAA"
@@ -570,6 +585,26 @@ class Tests(unittest.TestCase):
         self.assertEquals(res["data"]["protocol"], "tcp")
         self.assertEqualAnswers(res, self.TCP_LARGE_TXT_ANSWERS, cmd,
                 key="answer")
+
+    def test_override_name(self):
+        c = u"./zdns/zdns A --override-name=zdns-testing.com"
+        name = u"notrealname.com"
+        cmd, res = self.run_zdns(c, name)
+        self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd)
+
+    def test_server_mode_a_lookup_ipv4(self):
+        c = u"./zdns/zdns A --override-name=zdns-testing.com --name-server-mode"
+        name = u"8.8.8.8:53"
+        cmd, res = self.run_zdns(c, name)
+        self.assertEqual(res["data"]["resolver"], "8.8.8.8:53")
+        self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd)
+
+    def test_mixed_mode_a_lookup_ipv4(self):
+        c = u"./zdns/zdns A --name-servers=0.0.0.0"
+        name = u"zdns-testing.com,8.8.8.8:53"
+        cmd, res = self.run_zdns(c, name)
+        self.assertEqual(res["data"]["resolver"], "8.8.8.8:53")
+        self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd)
 
 
 if __name__ == '__main__':

--- a/interface.go
+++ b/interface.go
@@ -45,7 +45,7 @@ import (
 // one Lookup per IP/name/connection ==========================================
 //
 type Lookup interface {
-	DoLookup(name string) (interface{}, []interface{}, Status, error)
+	DoLookup(name string, nameServer string) (interface{}, []interface{}, Status, error)
 	DoZonefileLookup(record *dns.Token) (interface{}, Status, error)
 }
 

--- a/lookup.go
+++ b/lookup.go
@@ -60,8 +60,8 @@ func parseAlexa(line string) (string, int) {
 
 func parseNormalInputLine(line string) (string, string) {
 	s := strings.SplitN(line, ",", 2)
-	if s[1] == "" {
-		return s[0], s[1]
+	if len(s) == 1 {
+		return s[0], ""
 	} else {
 		return s[0], AddDefaultPortToDNSServerName(s[1])
 	}

--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -36,8 +36,10 @@ type Lookup struct {
 	miekg.Lookup
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, []interface{}, zdns.Status, error) {
-	nameServer := s.Factory.Factory.RandomNameServer()
+func (s *Lookup) DoLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
+	if nameServer == "" {
+		nameServer = s.Factory.Factory.RandomNameServer()
+	}
 	return s.DoTargetedLookup(name, nameServer)
 }
 
@@ -57,7 +59,7 @@ func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16
 		var miekgResult interface{}
 		var status zdns.Status
 		var err error
-		miekgResult, trace, status, err = s.DoTypedMiekgLookup(name, dnsType)
+		miekgResult, trace, status, err = s.DoTypedMiekgLookup(name, dnsType, nameServer)
 		if status != zdns.STATUS_NOERROR || err != nil {
 			return nil, trace, status, err
 		}

--- a/modules/alookup/alookup_test.go
+++ b/modules/alookup/alookup_test.go
@@ -146,7 +146,7 @@ func TestDoLookup(t *testing.T) {
 		Flags:       miekg.DNSFlags{},
 	}
 
-	res, _, _, _ = l.DoLookup("example.com")
+	res, _, _, _ = l.DoLookup("example.com", "")
 	verifyResult(t, res.(Result), nil, []string{"2001:db8::1", "2001:db8::2"})
 
 	// Case 6: CNAME

--- a/modules/alookup/alookup_test.go
+++ b/modules/alookup/alookup_test.go
@@ -15,14 +15,15 @@
 package alookup
 
 import (
-	"github.com/zmap/zdns"
-	"github.com/zmap/zdns/modules/miekg"
 	"reflect"
 	"testing"
+
+	"github.com/zmap/zdns"
+	"github.com/zmap/zdns/modules/miekg"
 )
 
 // Mock the actual Miekg lookup.
-func (s *Lookup) DoTypedMiekgLookup(name string, dnsType uint16) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoTypedMiekgLookup(name string, dnsType uint16, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	if res, ok := mockResults[name]; ok {
 		return res, nil, zdns.STATUS_NOERROR, nil
 	} else {
@@ -64,7 +65,7 @@ func TestDoLookup(t *testing.T) {
 		Flags:       miekg.DNSFlags{},
 	}
 
-	res, _, _, _ := l.DoLookup("example.com")
+	res, _, _, _ := l.DoLookup("example.com", "")
 	verifyResult(t, res.(Result), []string{"192.0.2.1"}, nil)
 
 	// Case 2: double A response
@@ -89,7 +90,7 @@ func TestDoLookup(t *testing.T) {
 		Flags:       miekg.DNSFlags{},
 	}
 
-	res, _, _, _ = l.DoLookup("example.com")
+	res, _, _, _ = l.DoLookup("example.com", "")
 	verifyResult(t, res.(Result), []string{"192.0.2.1", "192.0.2.2"}, nil)
 
 	// Case 3: mixed A and AAAA response
@@ -114,13 +115,13 @@ func TestDoLookup(t *testing.T) {
 		Flags:       miekg.DNSFlags{},
 	}
 
-	res, _, _, _ = l.DoLookup("example.com")
+	res, _, _, _ = l.DoLookup("example.com", "")
 	verifyResult(t, res.(Result), []string{"192.0.2.1"}, nil)
 
 	// Case 4: same mixed response, but both types requested.
 	glf.IPv6Lookup = true
 
-	res, _, _, _ = l.DoLookup("example.com")
+	res, _, _, _ = l.DoLookup("example.com", "")
 	verifyResult(t, res.(Result), []string{"192.0.2.1"}, []string{"2001:db8::1"})
 
 	// Case 5: double AAAA response
@@ -163,7 +164,7 @@ func TestDoLookup(t *testing.T) {
 		Flags:       miekg.DNSFlags{},
 	}
 
-	res, _, _, _ = l.DoLookup("cname.example.com")
+	res, _, _, _ = l.DoLookup("cname.example.com", "")
 	verifyResult(t, res.(Result), nil, []string{"2001:db8::1", "2001:db8::2"})
 
 	// Case 7: AAAA + CNAME (if this ever happens to be returned)
@@ -188,7 +189,7 @@ func TestDoLookup(t *testing.T) {
 		Flags:       miekg.DNSFlags{},
 	}
 
-	res, _, _, _ = l.DoLookup("cname.example.com")
+	res, _, _, _ = l.DoLookup("cname.example.com", "")
 	verifyResult(t, res.(Result), nil, []string{"2001:db8::3"})
 
 	// Case 8: unexpected MX record only
@@ -206,7 +207,7 @@ func TestDoLookup(t *testing.T) {
 		Flags:       miekg.DNSFlags{},
 	}
 
-	res, _, status, _ := l.DoLookup("example.com")
+	res, _, status, _ := l.DoLookup("example.com", "")
 	if status != zdns.STATUS_NO_ANSWER {
 		t.Errorf("Expected NO_ANSWER status, got %v", status)
 	} else if res != nil {
@@ -241,7 +242,7 @@ func TestDoLookup(t *testing.T) {
 		Flags:       miekg.DNSFlags{},
 	}
 
-	res, _, _, _ = l.DoLookup("example.com")
+	res, _, _, _ = l.DoLookup("example.com", "")
 	verifyResult(t, res.(Result), []string{"192.0.2.3"}, []string{"2001:db8::4"})
 }
 

--- a/modules/axfr/axfr.go
+++ b/modules/axfr/axfr.go
@@ -95,18 +95,22 @@ func (s *Lookup) DoAXFR(name string, server string) AXFRServerResult {
 	return retv
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, []interface{}, zdns.Status, error) {
-	parsedNS, trace, status, err := s.DoNSLookup(name, true, false)
-	if status != zdns.STATUS_NOERROR {
-		return nil, trace, status, err
-	}
+func (s *Lookup) DoLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	var retv AXFRResult
-	for _, server := range parsedNS.Servers {
-		if len(server.IPv4Addresses) > 0 {
-			retv.Servers = append(retv.Servers, s.DoAXFR(name, server.IPv4Addresses[0]))
+	if nameServer == "" {
+		parsedNS, trace, status, err := s.DoNSLookup(name, true, false, nameServer)
+		if status != zdns.STATUS_NOERROR {
+			return nil, trace, status, err
 		}
+		for _, server := range parsedNS.Servers {
+			if len(server.IPv4Addresses) > 0 {
+				retv.Servers = append(retv.Servers, s.DoAXFR(name, server.IPv4Addresses[0]))
+			}
+		}
+	} else {
+		retv.Servers = append(retv.Servers, s.DoAXFR(name, nameServer))
 	}
-	return retv, trace, zdns.STATUS_NOERROR, nil
+	return retv, nil, zdns.STATUS_NOERROR, nil
 }
 
 // Per GoRoutine Factory ======================================================

--- a/modules/dmarc/dmarc.go
+++ b/modules/dmarc/dmarc.go
@@ -32,9 +32,9 @@ type Lookup struct {
 	miekg.Lookup
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	var res Result
-	innerRes, trace, status, err := s.DoTxtLookup(name)
+	innerRes, trace, status, err := s.DoTxtLookup(name, nameServer)
 	if status != zdns.STATUS_NOERROR {
 		return res, nil, status, err
 	}

--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -1300,7 +1300,7 @@ func (s *Lookup) iterativeLookup(dnsType uint16, dnsClass uint16, name string, n
 	}
 }
 
-func (s *Lookup) DoMiekgLookup(name string) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoMiekgLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	if s.DNSType == dns.TypePTR {
 		var err error
 		name, err = dns.ReverseAddr(name)
@@ -1309,26 +1309,31 @@ func (s *Lookup) DoMiekgLookup(name string) (interface{}, []interface{}, zdns.St
 		}
 		name = name[:len(name)-1]
 	}
+	if nameServer == "" {
+		nameServer = s.NameServer
+	}
 	if s.Factory.IterativeResolution {
 		s.VerboseLog(0, "MIEKG-IN: iterative lookup for ", name, " (", s.DNSType, ")")
 		s.IterativeStop = time.Now().Add(time.Duration(s.Factory.IterativeTimeout))
-		result, trace, status, err := s.iterativeLookup(s.DNSType, s.DNSClass, name, s.NameServer, 1, ".", make([]interface{}, 0))
+		result, trace, status, err := s.iterativeLookup(s.DNSType, s.DNSClass, name, nameServer, 1, ".", make([]interface{}, 0))
 		s.VerboseLog(0, "MIEKG-OUT: iterative lookup for ", name, " (", s.DNSType, "): status: ", status, " , err: ", err)
 		if s.Factory.Trace {
 			return result, trace, status, err
 		}
 		return result, trace, status, err
-
 	} else {
-		return s.tracedRetryingLookup(s.DNSType, s.DNSClass, name, s.NameServer, true)
+		return s.tracedRetryingLookup(s.DNSType, s.DNSClass, name, nameServer, true)
 	}
 }
 
-func (s *Lookup) DoMiekgLookupForClass(name string, dnsClass uint16) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoMiekgLookupForClass(name string, dnsClass uint16, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
+	if nameServer == "" {
+		nameServer = s.NameServer
+	}
 	if s.Factory.IterativeResolution {
 		s.VerboseLog(0, "MIEKG-IN: iterative lookup for ", name, " (", s.DNSType, ") in class ", dnsClass)
 		s.IterativeStop = time.Now().Add(time.Duration(s.Factory.IterativeTimeout))
-		result, trace, status, err := s.iterativeLookup(s.DNSType, s.DNSClass, name, s.NameServer, 1, ".", make([]interface{}, 0))
+		result, trace, status, err := s.iterativeLookup(s.DNSType, s.DNSClass, name, nameServer, 1, ".", make([]interface{}, 0))
 		s.VerboseLog(0, "MIEKG-OUT: iterative lookup for ", name, " (", s.DNSType, "): status: ", status, " , err: ", err)
 		if s.Factory.Trace {
 			return result, trace, status, err
@@ -1336,48 +1341,54 @@ func (s *Lookup) DoMiekgLookupForClass(name string, dnsClass uint16) (interface{
 		return result, trace, status, err
 
 	} else {
-		return s.tracedRetryingLookup(s.DNSType, s.DNSClass, name, s.NameServer, true)
+		return s.tracedRetryingLookup(s.DNSType, s.DNSClass, name, nameServer, true)
 	}
 }
 
-func (s *Lookup) DoTypedMiekgLookup(name string, dnsType uint16) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoTypedMiekgLookup(name string, dnsType uint16, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	if s.Factory == nil {
 		panic("factory not defined")
+	}
+	if nameServer == "" {
+		nameServer = s.NameServer
 	}
 	if s.Factory.IterativeResolution {
 		s.VerboseLog(0, "MIEKG-IN: iterative lookup for ", name, " (", dnsType, ")")
 		s.IterativeStop = time.Now().Add(time.Duration(s.Factory.IterativeTimeout))
-		result, trace, status, err := s.iterativeLookup(dnsType, s.DNSClass, name, s.NameServer, 1, ".", make([]interface{}, 0))
+		result, trace, status, err := s.iterativeLookup(dnsType, s.DNSClass, name, nameServer, 1, ".", make([]interface{}, 0))
 		s.VerboseLog(0, "MIEKG-OUT: iterative lookup for ", name, " (", dnsType, "): status: ", status, " , err: ", err)
 		if s.Factory.Trace {
 			return result, trace, status, err
 		}
 		return result, trace, status, err
 	} else {
-		return s.tracedRetryingLookup(dnsType, s.DNSClass, name, s.NameServer, true)
+		return s.tracedRetryingLookup(dnsType, s.DNSClass, name, nameServer, true)
 	}
 }
 
-func (s *Lookup) DoTypedMiekgLookupInClass(name string, dnsType uint16, dnsClass uint16) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoTypedMiekgLookupInClass(name string, dnsType uint16, dnsClass uint16, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	if s.Factory == nil {
 		panic("factory not defined")
+	}
+	if nameServer == "" {
+		nameServer = s.NameServer
 	}
 	if s.Factory.IterativeResolution {
 		s.VerboseLog(0, "MIEKG-IN: iterative lookup for ", name, " (", dnsType, ") in class ", dnsClass)
 		s.IterativeStop = time.Now().Add(time.Duration(s.Factory.IterativeTimeout))
-		result, trace, status, err := s.iterativeLookup(dnsType, dnsClass, name, s.NameServer, 1, ".", make([]interface{}, 0))
+		result, trace, status, err := s.iterativeLookup(dnsType, dnsClass, name, nameServer, 1, ".", make([]interface{}, 0))
 		s.VerboseLog(0, "MIEKG-OUT: iterative lookup for ", name, " (", dnsType, "): status: ", status, " , err: ", err)
 		if s.Factory.Trace {
 			return result, trace, status, err
 		}
 		return result, trace, status, err
 	} else {
-		return s.tracedRetryingLookup(dnsType, dnsClass, name, s.NameServer, true)
+		return s.tracedRetryingLookup(dnsType, dnsClass, name, nameServer, true)
 	}
 }
 
-func (s *Lookup) DoTxtLookup(name string) (string, []interface{}, zdns.Status, error) {
-	res, trace, status, err := s.DoMiekgLookup(name)
+func (s *Lookup) DoTxtLookup(name string, nameServer string) (string, []interface{}, zdns.Status, error) {
+	res, trace, status, err := s.DoMiekgLookup(name, nameServer)
 	if status != zdns.STATUS_NOERROR {
 		return "", trace, status, err
 	}
@@ -1393,8 +1404,8 @@ func (s *Lookup) DoTxtLookup(name string) (string, []interface{}, zdns.Status, e
 }
 
 // allow miekg to be used as a ZDNS module
-func (s *Lookup) DoLookup(name string) (interface{}, []interface{}, zdns.Status, error) {
-	return s.DoMiekgLookup(name)
+func (s *Lookup) DoLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
+	return s.DoMiekgLookup(name, nameServer)
 }
 
 func (s *GlobalLookupFactory) Help() string {

--- a/modules/mxlookup/mxlookup.go
+++ b/modules/mxlookup/mxlookup.go
@@ -57,7 +57,7 @@ func dotName(name string) string {
 	return strings.Join([]string{name, "."}, "")
 }
 
-func (s *Lookup) LookupIPs(name string) (CachedAddresses, []interface{}) {
+func (s *Lookup) LookupIPs(name string, nameServer string) (CachedAddresses, []interface{}) {
 	s.Factory.Factory.CHmu.Lock()
 	// XXX this should be changed to a miekglookup
 	res, found := s.Factory.Factory.CacheHash.Get(name)
@@ -69,7 +69,7 @@ func (s *Lookup) LookupIPs(name string) (CachedAddresses, []interface{}) {
 	trace := make([]interface{}, 0)
 	// ipv4
 	if s.Factory.Factory.IPv4Lookup || !s.Factory.Factory.IPv6Lookup {
-		res, secondTrace, status, _ := s.DoTypedMiekgLookup(name, dns.TypeA)
+		res, secondTrace, status, _ := s.DoTypedMiekgLookup(name, dns.TypeA, nameServer)
 		trace = append(trace, secondTrace...)
 		if status == zdns.STATUS_NOERROR {
 			cast, _ := res.(miekg.Result)
@@ -84,7 +84,7 @@ func (s *Lookup) LookupIPs(name string) (CachedAddresses, []interface{}) {
 	}
 	// ipv6
 	if s.Factory.Factory.IPv6Lookup {
-		res, secondTrace, status, _ := s.DoTypedMiekgLookup(name, dns.TypeAAAA)
+		res, secondTrace, status, _ := s.DoTypedMiekgLookup(name, dns.TypeAAAA, nameServer)
 		trace = append(trace, secondTrace...)
 		if status == zdns.STATUS_NOERROR {
 			cast, _ := res.(miekg.Result)
@@ -103,9 +103,9 @@ func (s *Lookup) LookupIPs(name string) (CachedAddresses, []interface{}) {
 	return retv, trace
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	retv := Result{Servers: []MXRecord{}}
-	res, trace, status, err := s.DoTypedMiekgLookup(name, dns.TypeMX)
+	res, trace, status, err := s.DoTypedMiekgLookup(name, dns.TypeMX, nameServer)
 	if status != zdns.STATUS_NOERROR {
 		return retv, trace, status, err
 	}
@@ -117,7 +117,7 @@ func (s *Lookup) DoLookup(name string) (interface{}, []interface{}, zdns.Status,
 		if mxAns, ok := ans.(miekg.MXAnswer); ok {
 			name = strings.TrimSuffix(mxAns.Answer.Answer, ".")
 			rec := MXRecord{TTL: mxAns.Ttl, Type: mxAns.Type, Class: mxAns.Class, Name: name, Preference: mxAns.Preference}
-			ips, secondTrace := s.LookupIPs(name)
+			ips, secondTrace := s.LookupIPs(name, nameServer)
 			rec.IPv4Addresses = ips.IPv4Addresses
 			rec.IPv6Addresses = ips.IPv6Addresses
 			retv.Servers = append(retv.Servers, rec)

--- a/modules/spf/spf.go
+++ b/modules/spf/spf.go
@@ -32,9 +32,9 @@ type Lookup struct {
 	miekg.Lookup
 }
 
-func (s *Lookup) DoLookup(name string) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	var res Result
-	innerRes, trace, status, err := s.DoTxtLookup(name)
+	innerRes, trace, status, err := s.DoTxtLookup(name, nameServer)
 	if status != zdns.STATUS_NOERROR {
 		return res, trace, status, err
 	}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,21 @@
+package zdns
+
+import "regexp"
+
+var rePort *regexp.Regexp
+var reV6 *regexp.Regexp
+
+func AddDefaultPortToDNSServerName(s string) string {
+	if !rePort.MatchString(s) {
+		return s + ":53"
+	} else if reV6.MatchString(s) {
+		return "[" + s + "]:53"
+	} else {
+		return s
+	}
+}
+
+func init() {
+	rePort = regexp.MustCompile(":\\d+$")      // string ends with potential port number
+	reV6 = regexp.MustCompile("^([0-9a-f]*:)") // string starts like valid IPv6 address
+}

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -16,13 +16,12 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
+	"math/rand"
 	"os"
-	"regexp"
 	"runtime"
 	"strings"
 	"time"
-	"io/ioutil"
-	"math/rand"
 
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
@@ -46,6 +45,7 @@ func main() {
 	flags.IntVar(&gc.Threads, "threads", 1000, "number of lightweight go threads")
 	flags.IntVar(&gc.GoMaxProcs, "go-processes", 0, "number of OS processes (GOMAXPROCS)")
 	flags.StringVar(&gc.NamePrefix, "prefix", "", "name to be prepended to what's passed in (e.g., www.)")
+	flags.StringVar(&gc.NameOverride, "override-name", "", "name overrides all passed in names")
 	flags.BoolVar(&gc.AlexaFormat, "alexa", false, "is input file from Alexa Top Million download")
 	flags.BoolVar(&gc.IterativeResolution, "iterative", false, "Perform own iteration instead of relying on recursive resolver")
 	flags.StringVar(&gc.InputFilePath, "input-file", "-", "names to read")
@@ -64,6 +64,7 @@ func main() {
 	flags.StringVar(&gc.OutputHandler, "output-handler", "file", "handler to output names")
 	flags.BoolVar(&gc.TCPOnly, "tcp-only", false, "Only perform lookups over TCP")
 	flags.BoolVar(&gc.UDPOnly, "udp-only", false, "Only perform lookups over UDP")
+	flags.BoolVar(&gc.NameServerMode, "name-server-mode", false, "Treats input as nameservers to query with a static query rather than queries to send to a static name server")
 	servers_string := flags.String("name-servers", "", "List of DNS servers to use. Can be passed as comma-delimited string or via @/path/to/file. If no port is specified, defaults to 53.")
 	config_file := flags.String("conf-file", "/etc/resolv.conf", "config file for DNS servers")
 	timeout := flags.Int("timeout", 15, "timeout for resolving an individual name")
@@ -142,6 +143,9 @@ func main() {
 		gc.NameServersSpecified = false
 		log.Info("no name servers specified. will use: ", strings.Join(gc.NameServers, ", "))
 	} else {
+		if gc.NameServerMode {
+			log.Fatal("name servers cannot be specified on command line in --name-server-mode")
+		}
 		var ns []string
 		if (*servers_string)[0] == '@' {
 			filepath := (*servers_string)[1:]
@@ -156,14 +160,8 @@ func main() {
 		} else {
 			ns = strings.Split(*servers_string, ",")
 		}
-		rePort := regexp.MustCompile(":\\d+$")      // string ends with potential port number
-		reV6 := regexp.MustCompile("^([0-9a-f]*:)") // string starts like valid IPv6 address
 		for i, s := range ns {
-			if !rePort.MatchString(s) {
-				ns[i] = s + ":53"
-			} else if reV6.MatchString(s) {
-				ns[i] = "[" + s + "]:53"
-			}
+			ns[i] = zdns.AddDefaultPortToDNSServerName(s)
 		}
 		gc.NameServers = ns
 		gc.NameServersSpecified = true
@@ -181,6 +179,12 @@ func main() {
 	}
 	if gc.UDPOnly && gc.TCPOnly {
 		log.Fatal("TCP Only and UDP Only are conflicting")
+	}
+	if gc.NameServerMode && gc.AlexaFormat {
+		log.Fatal("Alexa mode is incompatible with name server mode")
+	}
+	if gc.NameServerMode && gc.NameOverride == "" {
+		log.Fatal("Static Name must be defined with --override-name in --name-server-mode")
 	}
 	// Output Groups are defined by a base + any additional fields that the user wants
 	groups := strings.Split(gc.IncludeInOutput, ",")
@@ -204,7 +208,7 @@ func main() {
 
 	// Seeding for RandomNameServer()
 	rand.Seed(time.Now().UnixNano())
-	
+
 	// some modules require multiple passes over a file (this is really just the case for zone files)
 	if !factory.AllowStdIn() && gc.InputFilePath == "-" {
 		log.Fatal("Specified module does not allow reading from stdin")


### PR DESCRIPTION
This PR introduces the notion of "Name Server Mode", which allows pivoting ZDNS from its normal behavior of:

```cat "list of names" | zdns A --name-servers=[...]```

to 

```cat "list of name servers" | zdns A --name-server-mode --override-name=google.com```

It also supports tuples of `(name,nameServer)`s, e.g.,

```echo "google.com,8.8.8.8" | zdns A```