### PR TITLE
File I/O Handlers implement interface

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -45,8 +45,8 @@ type GlobalConf struct {
 	LocalAddrSpecified   bool
 	LocalAddrs           []net.IP
 
-	InputHandler  string
-	OutputHandler string
+	InputHandler  InputHandler
+	OutputHandler OutputHandler
 
 	InputFilePath    string
 	OutputFilePath   string

--- a/interface.go
+++ b/interface.go
@@ -174,20 +174,6 @@ func RegisterLookup(name string, s GlobalLookupFactory) {
 	lookups[name] = s
 }
 
-func RegisterInputHandler(name string, h InputHandler) {
-	if inputHandlers == nil {
-		inputHandlers = make(map[string]InputHandler)
-	}
-	inputHandlers[name] = h
-}
-
-func RegisterOutputHandler(name string, h OutputHandler) {
-	if outputHandlers == nil {
-		outputHandlers = make(map[string]OutputHandler)
-	}
-	outputHandlers[name] = h
-}
-
 func ValidlookupsString() string {
 	valid := make([]string, len(lookups))
 	i := 0
@@ -200,26 +186,8 @@ func ValidlookupsString() string {
 }
 
 func GetLookup(name string) GlobalLookupFactory {
-
-	factory, ok := lookups[name]
-	if !ok {
-		return nil
+	if factory, ok := lookups[name]; ok {
+		return factory
 	}
-	return factory
-}
-
-func GetInputHandler(name string) InputHandler {
-	inHandler, ok := inputHandlers[name]
-	if !ok {
-		return nil
-	}
-	return inHandler
-}
-
-func GetOutputHandler(name string) OutputHandler {
-	outHandler, ok := outputHandlers[name]
-	if !ok {
-		return nil
-	}
-	return outHandler
+	return nil
 }

--- a/iohandlers/file/file.go
+++ b/iohandlers/file/file.go
@@ -10,15 +10,15 @@ import (
 	"github.com/zmap/zdns"
 )
 
-type InputHandler struct {
+type FileInputHandler struct {
 	filepath string
 }
 
-func (h *InputHandler) Initialize(conf *zdns.GlobalConf) {
+func (h *FileInputHandler) Initialize(conf *zdns.GlobalConf) {
 	h.filepath = conf.InputFilePath
 }
 
-func (h *InputHandler) FeedChannel(in chan<- interface{}, wg *sync.WaitGroup, zonefileInput bool) error {
+func (h *FileInputHandler) FeedChannel(in chan<- interface{}, wg *sync.WaitGroup, zonefileInput bool) error {
 	defer close(in)
 	defer (*wg).Done()
 
@@ -49,15 +49,15 @@ func (h *InputHandler) FeedChannel(in chan<- interface{}, wg *sync.WaitGroup, zo
 	return nil
 }
 
-type OutputHandler struct {
+type FileOutputHandler struct {
 	filepath string
 }
 
-func (h *OutputHandler) Initialize(conf *zdns.GlobalConf) {
+func (h *FileOutputHandler) Initialize(conf *zdns.GlobalConf) {
 	h.filepath = conf.OutputFilePath
 }
 
-func (h *OutputHandler) WriteResults(results <-chan string, wg *sync.WaitGroup) error {
+func (h *FileOutputHandler) WriteResults(results <-chan string, wg *sync.WaitGroup) error {
 	defer (*wg).Done()
 
 	var f *os.File
@@ -75,13 +75,4 @@ func (h *OutputHandler) WriteResults(results <-chan string, wg *sync.WaitGroup) 
 		f.WriteString(n + "\n")
 	}
 	return nil
-}
-
-// register handlers
-func init() {
-	in := new(InputHandler)
-	zdns.RegisterInputHandler("file", in)
-
-	out := new(OutputHandler)
-	zdns.RegisterOutputHandler("file", out)
 }

--- a/lookup.go
+++ b/lookup.go
@@ -182,18 +182,17 @@ func DoLookups(g *GlobalLookupFactory, c *GlobalConf) error {
 	metaChan := make(chan routineMetadata, c.Threads)
 	var routineWG sync.WaitGroup
 
-	inHandler := GetInputHandler(c.InputHandler)
-	outHandler := GetOutputHandler(c.OutputHandler)
+	inHandler := c.InputHandler
 	if inHandler == nil {
-		log.Fatal("Unknown input handler \"" + c.InputHandler + "\"")
-	} else {
-		inHandler.Initialize(c)
+		log.Fatal("Input handler is nil")
 	}
+	inHandler.Initialize(c)
+
+	outHandler := c.OutputHandler
 	if outHandler == nil {
-		log.Fatal("Unknown output handler \"" + c.OutputHandler + "\"")
-	} else {
-		outHandler.Initialize(c)
+		log.Fatal("Output handler is nil")
 	}
+	outHandler.Initialize(c)
 
 	// Use handlers to populate the input and output/results channel
 	go inHandler.FeedChannel(inChan, &routineWG, (*g).ZonefileInput())

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -36,12 +36,16 @@ import (
 	_ "github.com/zmap/zdns/modules/nslookup"
 	_ "github.com/zmap/zdns/modules/spf"
 
-	_ "github.com/zmap/zdns/iohandlers/file"
+	"github.com/zmap/zdns/iohandlers/file"
 )
 
 func main() {
 
-	var gc zdns.GlobalConf
+	gc := zdns.GlobalConf{
+		InputHandler:  &file.FileInputHandler{},
+		OutputHandler: &file.FileOutputHandler{},
+	}
+
 	// global flags relevant to every lookup module
 	flags := flag.NewFlagSet("flags", flag.ExitOnError)
 	flags.IntVar(&gc.Threads, "threads", 1000, "number of lightweight go threads")
@@ -62,8 +66,6 @@ func main() {
 	flags.IntVar(&gc.Retries, "retries", 1, "how many times should zdns retry query if timeout or temporary failure")
 	flags.IntVar(&gc.MaxDepth, "max-depth", 10, "how deep should we recurse when performing iterative lookups")
 	flags.IntVar(&gc.CacheSize, "cache-size", 10000, "how many items can be stored in internal recursive cache")
-	flags.StringVar(&gc.InputHandler, "input-handler", "file", "handler to input names")
-	flags.StringVar(&gc.OutputHandler, "output-handler", "file", "handler to output names")
 	flags.BoolVar(&gc.TCPOnly, "tcp-only", false, "Only perform lookups over TCP")
 	flags.BoolVar(&gc.UDPOnly, "udp-only", false, "Only perform lookups over UDP")
 	flags.BoolVar(&gc.NameServerMode, "name-server-mode", false, "Treats input as nameservers to query with a static query rather than queries to send to a static name server")


### PR DESCRIPTION
We already have an interface for InputHandler and OutputHandler.  This
change removes the registration system and instead relies on the
implementations of the interface methods to do the right thing.  The
GlobalConf object now holds a pointer to an implementation the
interfaces.

    * CLI users could only use the "file" handler type anyway, so this
    option is removed.
    * The registration system (and the associated getters) are removed,
    Since the config holds an implementation, the factory can check that
    the config's InputHandler and OutputHandler are not nil before
    calling their  methods.
    * Some minor changes to Golang's style: for example, avoiding "else"
    after a Fatal keeps the happy-path less indented

This change leaves the functionality of the CLI unmodified (I hope!)
while also making it easier for programs using zdns as a library to
create their own implementations of the I/OHandler interfaces---they can
simply stick them into a znds.GlobalConfig object instead of having to
go through registration.