### PR TITLE
Don't repeat back-to-back types in parameter lists

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -47,7 +47,7 @@ import (
 // one Lookup per IP/name/connection ==========================================
 //
 type Lookup interface {
-	DoLookup(name string, nameServer string) (interface{}, []interface{}, Status, error)
+	DoLookup(name, nameServer string) (interface{}, []interface{}, Status, error)
 	DoZonefileLookup(record *dns.Token) (interface{}, Status, error)
 }
 

--- a/lookup.go
+++ b/lookup.go
@@ -67,7 +67,7 @@ func parseNormalInputLine(line string) (string, string) {
 	}
 }
 
-func makeName(name string, prefix string, nameOverride string) (string, bool) {
+func makeName(name, prefix, nameOverride string) (string, bool) {
 	if nameOverride != "" {
 		return nameOverride, true
 	}

--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -36,14 +36,14 @@ type Lookup struct {
 	miekg.Lookup
 }
 
-func (s *Lookup) DoLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	if nameServer == "" {
 		nameServer = s.Factory.Factory.RandomNameServer()
 	}
 	return s.DoTargetedLookup(name, nameServer)
 }
 
-func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16, candidateSet map[string][]miekg.Answer, cnameSet map[string][]miekg.Answer, origName string, depth int) ([]string, []interface{}, zdns.Status, error) {
+func (s *Lookup) doLookupProtocol(name, nameServer string, dnsType uint16, candidateSet map[string][]miekg.Answer, cnameSet map[string][]miekg.Answer, origName string, depth int) ([]string, []interface{}, zdns.Status, error) {
 	// avoid infinite loops
 	if name == origName && depth != 0 {
 		return nil, make([]interface{}, 0), zdns.STATUS_ERROR, errors.New("Infinite redirection loop")
@@ -63,6 +63,7 @@ func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16
 		if status != zdns.STATUS_NOERROR || err != nil {
 			return nil, trace, status, err
 		}
+
 		for _, a := range miekgResult.(miekg.Result).Answers {
 			// filter only valid answers of requested type or CNAME (#163)
 			if ans, ok := a.(miekg.Answer); ok {
@@ -115,7 +116,7 @@ func (s *Lookup) doLookupProtocol(name string, nameServer string, dnsType uint16
 	}
 }
 
-func (s *Lookup) DoTargetedLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoTargetedLookup(name, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	res := Result{}
 	candidateSet := map[string][]miekg.Answer{}
 	cnameSet := map[string][]miekg.Answer{}

--- a/modules/axfr/axfr.go
+++ b/modules/axfr/axfr.go
@@ -51,7 +51,7 @@ func dotName(name string) string {
 	return strings.Join([]string{name, "."}, "")
 }
 
-func (s *Lookup) DoAXFR(name string, server string) AXFRServerResult {
+func (s *Lookup) DoAXFR(name, server string) AXFRServerResult {
 	var retv AXFRServerResult
 	retv.Server = server
 	// check if the server address is blacklisted and if so, exclude
@@ -95,7 +95,7 @@ func (s *Lookup) DoAXFR(name string, server string) AXFRServerResult {
 	return retv
 }
 
-func (s *Lookup) DoLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	var retv AXFRResult
 	if nameServer == "" {
 		parsedNS, trace, status, err := s.DoNSLookup(name, true, false, nameServer)

--- a/modules/bindversion/bindversion.go
+++ b/modules/bindversion/bindversion.go
@@ -33,7 +33,7 @@ type Lookup struct {
 	miekg.Lookup
 }
 
-func (s *Lookup) DoLookup(_ string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(_, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	var res Result
 	res.Resolver = nameServer
 	innerRes, trace, status, err := s.DoTxtLookup("VERSION.BIND", nameServer)

--- a/modules/mxlookup/mxlookup.go
+++ b/modules/mxlookup/mxlookup.go
@@ -57,7 +57,7 @@ func dotName(name string) string {
 	return strings.Join([]string{name, "."}, "")
 }
 
-func (s *Lookup) LookupIPs(name string, nameServer string) (CachedAddresses, []interface{}) {
+func (s *Lookup) LookupIPs(name, nameServer string) (CachedAddresses, []interface{}) {
 	s.Factory.Factory.CHmu.Lock()
 	// XXX this should be changed to a miekglookup
 	res, found := s.Factory.Factory.CacheHash.Get(name)
@@ -103,7 +103,7 @@ func (s *Lookup) LookupIPs(name string, nameServer string) (CachedAddresses, []i
 	return retv, trace
 }
 
-func (s *Lookup) DoLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	retv := Result{Servers: []MXRecord{}}
 	res, trace, status, err := s.DoTypedMiekgLookup(name, dns.TypeMX, nameServer)
 	if status != zdns.STATUS_NOERROR {

--- a/modules/nslookup/nslookup.go
+++ b/modules/nslookup/nslookup.go
@@ -63,7 +63,7 @@ func (s *Lookup) lookupIPs(name string, dnsType uint16, nameServer string) ([]st
 	return addresses, trace
 }
 
-func (s *Lookup) DoNSLookup(name string, lookupIPv4 bool, lookupIPv6 bool, nameServer string) (Result, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoNSLookup(name string, lookupIPv4, lookupIPv6 bool, nameServer string) (Result, []interface{}, zdns.Status, error) {
 	var retv Result
 	res, trace, status, err := s.DoTypedMiekgLookup(name, dns.TypeNS, nameServer)
 	if status != zdns.STATUS_NOERROR || err != nil {
@@ -124,7 +124,7 @@ func (s *Lookup) DoNSLookup(name string, lookupIPv4 bool, lookupIPv6 bool, nameS
 
 }
 
-func (s *Lookup) DoLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	return s.DoNSLookup(name, s.Factory.Factory.IPv4Lookup, s.Factory.Factory.IPv6Lookup, nameServer)
 }
 

--- a/modules/spf/spf.go
+++ b/modules/spf/spf.go
@@ -32,7 +32,7 @@ type Lookup struct {
 	miekg.Lookup
 }
 
-func (s *Lookup) DoLookup(name string, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoLookup(name, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
 	var res Result
 	innerRes, trace, status, err := s.DoTxtLookup(name, nameServer)
 	if status != zdns.STATUS_NOERROR {


### PR DESCRIPTION
This makes parameter lists a bit easier to read and conforms with
typical Golang style to use type elisions where applicable.