### PR TITLE
fix verbosity=5 runtime bug

### DIFF
--- a/modules/miekg/miekg.go
+++ b/modules/miekg/miekg.go
@@ -183,8 +183,8 @@ func (s *GlobalLookupFactory) AddCachedAnswer(answer interface{}, name string, d
 		ExpiresAt: expiresAt}
 	ca.Answers[a] = ta
 	s.IterativeCache.Add(key, ca)
-	s.IterativeCache.Unlock(key)
 	s.VerboseGlobalLog(depth+1, threadID, "Add cached answer ", key, " ", ca)
+	s.IterativeCache.Unlock(key)
 }
 
 func (s *GlobalLookupFactory) GetCachedResult(name string, dnsType uint16, isAuthCheck bool, depth int, threadID int) (Result, bool) {


### PR DESCRIPTION
Currently at verbosity = 5 we get
"fatal error: concurrent map iteration and map write"
at runtime. This is due to passing a map datastructure
to the logger (which we then iterate over) while another
thread grabs the same structure and edits (deletes due to
timeout) it. Fix is to move the log into the lock. This
sucks for performance but we've already given up on
performance at v=5