### PR TITLE
Allow to pass metadata from input to output similar to Alexa rank

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -25,6 +25,7 @@ type GlobalConf struct {
 	IterationTimeout      time.Duration
 	Retries               int
 	AlexaFormat           bool
+	MetadataFormat        bool
 	NameServerInputFormat bool
 	IterativeResolution   bool
 
@@ -78,6 +79,7 @@ type Result struct {
 	Nameserver  string        `json:"nameserver,omitempty" groups:"normal,long,trace"`
 	Class       string        `json:"class,omitempty" groups:"long,trace"`
 	AlexaRank   int           `json:"alexa_rank,omitempty" groups:"short,normal,long,trace"`
+	Metadata    string        `json:"meta_data,omitempty" groups:"short,normal,long,trace"`
 	Status      string        `json:"status,omitempty" groups:"short,normal,long,trace"`
 	Error       string        `json:"error,omitempty" groups:"short,normal,long,trace"`
 	Timestamp   string        `json:"timestamp,omitempty" groups:"short,normal,long,trace"`

--- a/conf.go
+++ b/conf.go
@@ -79,7 +79,7 @@ type Result struct {
 	Nameserver  string        `json:"nameserver,omitempty" groups:"normal,long,trace"`
 	Class       string        `json:"class,omitempty" groups:"long,trace"`
 	AlexaRank   int           `json:"alexa_rank,omitempty" groups:"short,normal,long,trace"`
-	Metadata    string        `json:"meta_data,omitempty" groups:"short,normal,long,trace"`
+	Metadata    string        `json:"metadata,omitempty" groups:"short,normal,long,trace"`
 	Status      string        `json:"status,omitempty" groups:"short,normal,long,trace"`
 	Error       string        `json:"error,omitempty" groups:"short,normal,long,trace"`
 	Timestamp   string        `json:"timestamp,omitempty" groups:"short,normal,long,trace"`

--- a/lookup.go
+++ b/lookup.go
@@ -58,6 +58,14 @@ func parseAlexa(line string) (string, int) {
 	return s[1], rank
 }
 
+func parseMetadataInputLine(line string) (string, string) {
+	s := strings.SplitN(line, ",", 2)
+	if len(s) == 1 {
+		return s[0], ""
+	}
+	return s[0], s[1]
+}
+
 func parseNormalInputLine(line string) (string, string) {
 	s := strings.SplitN(line, ",", 2)
 	if len(s) == 1 {
@@ -101,9 +109,13 @@ func doLookup(g GlobalLookupFactory, gc *GlobalConf, input <-chan interface{}, o
 		rawName := ""
 		nameServer := ""
 		var rank int
+		var entryMetadata string
 		if gc.AlexaFormat == true {
 			rawName, rank = parseAlexa(line)
 			res.AlexaRank = rank
+		} else if gc.MetadataFormat {
+			rawName, entryMetadata = parseMetadataInputLine(line)
+			res.Metadata = entryMetadata
 		} else if gc.NameServerMode {
 			nameServer = AddDefaultPortToDNSServerName(line)
 		} else {

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -50,7 +50,7 @@ func main() {
 	flags.StringVar(&gc.NamePrefix, "prefix", "", "name to be prepended to what's passed in (e.g., www.)")
 	flags.StringVar(&gc.NameOverride, "override-name", "", "name overrides all passed in names")
 	flags.BoolVar(&gc.AlexaFormat, "alexa", false, "is input file from Alexa Top Million download")
-	flags.BoolVar(&gc.MetadataFormat, "metadata", false, "is input file has the form 'name,METADATA', METADATA will be propagated to the output")
+	flags.BoolVar(&gc.MetadataFormat, "metadata-passthrough", false, "if input records have the form 'name,METADATA', METADATA will be propagated to the output")
 	flags.BoolVar(&gc.IterativeResolution, "iterative", false, "Perform own iteration instead of relying on recursive resolver")
 	flags.StringVar(&gc.InputFilePath, "input-file", "-", "names to read")
 	flags.StringVar(&gc.OutputFilePath, "output-file", "-", "where should JSON output be saved")

--- a/zdns/main.go
+++ b/zdns/main.go
@@ -50,6 +50,7 @@ func main() {
 	flags.StringVar(&gc.NamePrefix, "prefix", "", "name to be prepended to what's passed in (e.g., www.)")
 	flags.StringVar(&gc.NameOverride, "override-name", "", "name overrides all passed in names")
 	flags.BoolVar(&gc.AlexaFormat, "alexa", false, "is input file from Alexa Top Million download")
+	flags.BoolVar(&gc.MetadataFormat, "metadata", false, "is input file has the form 'name,METADATA', METADATA will be propagated to the output")
 	flags.BoolVar(&gc.IterativeResolution, "iterative", false, "Perform own iteration instead of relying on recursive resolver")
 	flags.StringVar(&gc.InputFilePath, "input-file", "-", "names to read")
 	flags.StringVar(&gc.OutputFilePath, "output-file", "-", "where should JSON output be saved")
@@ -223,6 +224,9 @@ func main() {
 	if gc.NameServerMode && gc.AlexaFormat {
 		log.Fatal("Alexa mode is incompatible with name server mode")
 	}
+        if gc.NameServerMode && gc.MetadataFormat {
+                log.Fatal("Metadata mode is incompatible with name server mode")
+        }
 	if gc.NameServerMode && gc.NameOverride == "" && gc.Module != "BINDVERSION" {
 		log.Fatal("Static Name must be defined with --override-name in --name-server-mode unless DNS module does not expect names (e.g., BINDVERSION).")
 	}


### PR DESCRIPTION
This PR adds a new option (`-metadata` / `GlobalConf.MetadataFormat`) that allows to pass additional metadata from the input to the output for each name that is to be resolved. This is very helpful in situations where a single zdns process is fed from multiple sources and one would e.g., like to keep a reference to said source.

When setting `MetadataFormat` to true, the input is expected to be in the form of:
 name,METADATA

So similar to the Alexa format but a normal string is allowed but the order is inverted.
Inverting the format has the advantage that further comma or even a full json line can be easily embedded while keeping the implementation simple.

A new key (`meta_data`) is added to the output containing the data.

Example:

 ```
echo 'www.google.com,{"source": ".com.tld", "reason": "just a test"}' | ./zdns A -metadata -name-servers="8.8.8.8"
{"data":{"answers":[{"answer":"172.217.21.196","class":"IN","name":"www.google.com","ttl":161,"type":"A"}],"protocol":"udp","resolver":"8.8.8.8:53"},"meta_data":"{\"source\": \".com.tld\", \"reason\": \"just a test\"}","name":"www.google.com","status":"NOERROR","timestamp":"2021-01-06T13:59:19+01:00"}
```