### PR TITLE
Adding support for SVCB and HTTPS RRs

### DIFF
--- a/modules/miekg/answers.go
+++ b/modules/miekg/answers.go
@@ -195,6 +195,13 @@ type SRVAnswer struct {
 	Target   string `json:"target" groups:"short,normal,long,trace"`
 }
 
+type SVCBAnswer struct {
+	Answer
+	Priority  uint16                 `json:"priority" groups:"short,normal,long,trace"`
+	Target    string                 `json:"target" groups:"short,normal,long,trace"`
+	SVCParams map[string]interface{} `json:"svcparams,omitempty" groups:"short,normal,long,trace"`
+}
+
 type TKEYAnswer struct {
 	Answer
 	Algorithm  string `json:"algorithm" groups:"short,normal,long,trace"`
@@ -382,6 +389,47 @@ func makeBaseAnswer(hdr *dns.RR_Header, answer string) Answer {
 		RrClass: hdr.Class,
 		Name:    strings.TrimSuffix(hdr.Name, "."),
 		Answer:  answer}
+}
+
+func makeSVCBAnswer(cAns *dns.SVCB) SVCBAnswer {
+	var params map[string]interface{}
+	if len(cAns.Value) > 0 {
+		params = make(map[string]interface{})
+		for _, ikv := range cAns.Value {
+			// this could be reduced by adding, e.g., a new Data()
+			// method to the miekg/dns SVCBKeyValue interface
+			switch kv := ikv.(type) {
+			case *dns.SVCBMandatory:
+				keys := make([]string, len(kv.Code))
+				for i, e := range kv.Code {
+					keys[i] = e.String()
+				}
+				params[ikv.Key().String()] = keys
+			case *dns.SVCBAlpn:
+				params[ikv.Key().String()] = kv.Alpn
+			case *dns.SVCBNoDefaultAlpn:
+				params[ikv.Key().String()] = true
+			case *dns.SVCBPort:
+				params[ikv.Key().String()] = kv.Port
+			case *dns.SVCBIPv4Hint:
+				params[ikv.Key().String()] = kv.Hint
+			case *dns.SVCBECHConfig:
+				params[ikv.Key().String()] = kv.ECH
+			case *dns.SVCBIPv6Hint:
+				params[ikv.Key().String()] = kv.Hint
+			case *dns.SVCBLocal: //SVCBLocal is the default case for unknown keys
+				params[ikv.Key().String()] = kv.Data
+			default: //should not happen
+				params["unknown"] = true
+			}
+		}
+	}
+	return SVCBAnswer{
+		Answer:    makeBaseAnswer(&cAns.Hdr, ""),
+		Priority:  cAns.Priority,
+		Target:    cAns.Target,
+		SVCParams: params,
+	}
 }
 
 func ParseAnswer(ans dns.RR) interface{} {
@@ -722,6 +770,10 @@ func ParseAnswer(ans dns.RR) interface{} {
 			Answer:     makeBaseAnswer(&cAns.Hdr, cAns.Fqdn),
 			Preference: cAns.Preference,
 		}
+	case *dns.HTTPS:
+		return makeSVCBAnswer(&cAns.SVCB)
+	case *dns.SVCB:
+		return makeSVCBAnswer(cAns)
 	default:
 		return struct {
 			Type     string `json:"type"`

--- a/modules/miekg/modules.go
+++ b/modules/miekg/modules.go
@@ -94,6 +94,10 @@ func init() {
 	hip.SetDNSType(dns.TypeHIP)
 	zdns.RegisterLookup("HIP", hip)
 
+	https := new(GlobalLookupFactory)
+	https.SetDNSType(dns.TypeHTTPS)
+	zdns.RegisterLookup("HTTPS", https)
+
 	isdn := new(GlobalLookupFactory)
 	isdn.SetDNSType(dns.TypeISDN)
 	zdns.RegisterLookup("ISDN", isdn)
@@ -237,6 +241,10 @@ func init() {
 	srv := new(GlobalLookupFactory)
 	srv.SetDNSType(dns.TypeSRV)
 	zdns.RegisterLookup("SRV", srv)
+
+	svcb := new(GlobalLookupFactory)
+	svcb.SetDNSType(dns.TypeSVCB)
+	zdns.RegisterLookup("SVCB", svcb)
 
 	talink := new(GlobalLookupFactory)
 	talink.SetDNSType(dns.TypeTALINK)


### PR DESCRIPTION
This PR adds support for the HTTPS and SVCB RRs as is discussed in #236

I tried to follow the syntax of the other non-trivial RRs.
The different svcparams are mapped to a dictionary of type `{svcparamskey: svcparamsvalue, ...}` under `svcparams`, which is left out when there are no svcparams, as for example in AliasMode.

Example:
```
$ echo www.cloudflare.com | ./zdns HTTPS --name-servers=1.1.1.1
{"data":{"answers":[{"class":"IN","name":"cloudflare.com","priority":1,"svcparams":{"alpn":["h3-29","h3-28","h3-27","h2"],"ipv4hint":["104.16.132.229","104.16.133.229"],"ipv6hint":["2606:4700::6810:84e5","2606:4700::6810:85e5"]},"target":".","ttl":300,"type":"HTTPS"}],"protocol":"udp","resolver":"1.1.1.1:53"},"name":"cloudflare.com","status":"NOERROR","timestamp":"2021-01-14T14:53:00+01:00"}
```