### PR TITLE
Fix bugs in alookup

### DIFF
--- a/modules/alookup/alookup.go
+++ b/modules/alookup/alookup.go
@@ -137,12 +137,12 @@ func (s *Lookup) DoTargetedLookup(name, nameServer string) (interface{}, []inter
 		copy(res.IPv6Addresses, ipv6)
 	}
 
-	ipv4Trace = append(ipv4Trace, ipv6Trace...)
+	combinedTrace := append(ipv4Trace, ipv6Trace...)
 
 	if len(res.IPv4Addresses) == 0 && len(res.IPv6Addresses) == 0 {
-		return nil, ipv4Trace, zdns.STATUS_NO_ANSWER, nil
+		return nil, combinedTrace, zdns.STATUS_NO_ANSWER, nil
 	}
-	return res, ipv4Trace, zdns.STATUS_NOERROR, nil
+	return res, combinedTrace, zdns.STATUS_NOERROR, nil
 }
 
 // Per GoRoutine Factory ======================================================

--- a/modules/alookup/alookup_test.go
+++ b/modules/alookup/alookup_test.go
@@ -210,13 +210,14 @@ func TestDoLookup(t *testing.T) {
 	}
 
 	res, _, status, _ := l.DoLookup("example.com", "")
+
 	if status != zdns.STATUS_NO_ANSWER {
 		t.Errorf("Expected NO_ANSWER status, got %v", status)
 	} else if res != nil {
-		t.Error("Received results where expected none")
+		t.Errorf("Expected no results, got %v", res)
 	}
 
-	// Case 3: unexpected MX record in answer section, but valid A record in additionals
+	// Case 9: unexpected MX record in answer section, but valid A record in additionals
 	mockResults["example.com"] = miekg.Result{
 		Answers: []interface{}{miekg.Answer{
 			Ttl:    3600,
@@ -246,6 +247,22 @@ func TestDoLookup(t *testing.T) {
 
 	res, _, _, _ = l.DoLookup("example.com", "")
 	verifyResult(t, res.(Result), []string{"192.0.2.3"}, []string{"2001:db8::4"})
+
+	// Case 10: No results returned
+	mockResults["example.com"] = miekg.Result{
+		Answers:     nil,
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+
+	res, _, status, _ = l.DoLookup("example.com", "")
+	if status != zdns.STATUS_NO_ANSWER {
+		t.Errorf("Expected NO_ANSWER status, got %v", status)
+	} else if res != nil {
+		t.Errorf("Expected no results, got %v", res)
+	}
 }
 
 func verifyResult(t *testing.T, res Result, ipv4 []string, ipv6 []string) {
@@ -261,12 +278,12 @@ func verifyResult(t *testing.T, res Result, ipv4 []string, ipv6 []string) {
 		}
 	}
 
-	if ipv6 == nil && res.IPv6Addresses != nil && len(res.IPv4Addresses) > 0 {
+	if ipv6 == nil && res.IPv6Addresses != nil && len(res.IPv6Addresses) > 0 {
 		t.Error("Received no IPv6 addresses while expected")
 	} else if ipv6 != nil {
 		if res.IPv6Addresses == nil || len(res.IPv6Addresses) == 0 {
 			t.Error("Received no IPv6 addresses while expected")
-		} else if len(res.IPv4Addresses) != len(ipv4) {
+		} else if len(res.IPv6Addresses) != len(ipv6) {
 			t.Errorf("Received %v IPv6 addresses while %v is expected", len(res.IPv6Addresses), len(ipv6))
 		} else if !reflect.DeepEqual(res.IPv6Addresses, ipv6) {
 			t.Error("Received unexpected IPv6 address(es)")


### PR DESCRIPTION
This diff does the following for `alookup`

- Rename trace as combined when adding both traces
- Add log for results in case of error of NO_ANSWER
- Adds a UT to test when no results are returned by the tool
- Fixes some bugs in verification of results