### PR TITLE
fix number of retries in lookup (#256)

### DIFF
--- a/pkg/miekg/miekg.go
+++ b/pkg/miekg/miekg.go
@@ -331,9 +331,9 @@ func (s *Lookup) retryingLookup(q Question, nameServer string, recursive bool) (
 	} else {
 		origTimeout = s.Factory.TCPClient.Timeout
 	}
-	for i := 0; i < s.Factory.Retries+1; i++ {
+	for i := 0; i <= s.Factory.Retries; i++ {
 		result, status, err := s.doLookup(q, nameServer, recursive)
-		if (status != zdns.STATUS_TIMEOUT && status != zdns.STATUS_TEMPORARY) || i+1 == s.Factory.Retries {
+		if (status != zdns.STATUS_TIMEOUT && status != zdns.STATUS_TEMPORARY) || i == s.Factory.Retries {
 			if s.Factory.Client != nil {
 				s.Factory.Client.Timeout = origTimeout
 			}


### PR DESCRIPTION
fixes #256

The loop does not return, because it terminates before the condition is reached. So "retries" actually means "tries" here. This interpretation results in a panic though

We now terminate on last iteration, s.t. "retries" means "retries" again. If the value is set to 0 the loop is executed exactly once.