### PR TITLE
Update nslookup and add UTs

### DIFF
--- a/pkg/alookup/alookup.go
+++ b/pkg/alookup/alookup.go
@@ -15,10 +15,6 @@
 package alookup
 
 import (
-	"errors"
-	"net"
-	"strings"
-
 	"github.com/spf13/pflag"
 	"github.com/zmap/dns"
 	"github.com/zmap/zdns/pkg/miekg"
@@ -44,93 +40,11 @@ func (s *Lookup) DoLookup(name, nameServer string) (interface{}, zdns.Trace, zdn
 	return s.DoTargetedLookup(name, nameServer)
 }
 
-// Verify that A record is indeed IPv4 and AAAA is IPv6
-func verifyAddress(ansType string, ip string) bool {
-	isIpv4 := false
-	isIpv6 := false
-	if net.ParseIP(ip) != nil {
-		isIpv6 = strings.Contains(ip, ":")
-		isIpv4 = !isIpv6
-	}
-	if ansType == "A" {
-		return isIpv4
-	} else if ansType == "AAAA" {
-		return isIpv6
-	}
-	return !isIpv4 && !isIpv6
-}
+// This LookupClient is created to call the actual implementation of DoMiekgLookup
+type LookupClient struct{}
 
-func populateResults(records []interface{}, dnsType uint16, candidateSet map[string][]miekg.Answer, cnameSet map[string][]miekg.Answer, garbage map[string][]miekg.Answer) {
-	for _, a := range records {
-		// filter only valid answers of requested type or CNAME (#163)
-		if ans, ok := a.(miekg.Answer); ok {
-			lowerCaseName := strings.ToLower(ans.Name)
-			// Verify that the answer type matches requested type
-			if verifyAddress(ans.Type, ans.Answer) {
-				ansType := dns.StringToType[ans.Type]
-				if dnsType == ansType {
-					candidateSet[lowerCaseName] = append(candidateSet[lowerCaseName], ans)
-				} else if ok && dns.TypeCNAME == ansType {
-					cnameSet[lowerCaseName] = append(cnameSet[lowerCaseName], ans)
-				} else {
-					garbage[lowerCaseName] = append(garbage[lowerCaseName], ans)
-				}
-			} else {
-				garbage[lowerCaseName] = append(garbage[lowerCaseName], ans)
-			}
-		}
-	}
-}
-
-func (s *Lookup) doLookupProtocol(name, nameServer string, dnsType uint16, candidateSet map[string][]miekg.Answer, cnameSet map[string][]miekg.Answer, origName string, depth int) ([]string, []interface{}, zdns.Status, error) {
-	// avoid infinite loops
-	if name == origName && depth != 0 {
-		return nil, make([]interface{}, 0), zdns.STATUS_ERROR, errors.New("infinite redirection loop")
-	}
-	if depth > 10 {
-		return nil, make([]interface{}, 0), zdns.STATUS_ERROR, errors.New("max recursion depth reached")
-	}
-	// check if the record is already in our cache. if not, perform normal A lookup and
-	// see what comes back. Then iterate over results and if needed, perform further lookups
-	var trace []interface{}
-	garbage := map[string][]miekg.Answer{}
-	if _, ok := candidateSet[name]; !ok {
-		var miekgResult interface{}
-		var status zdns.Status
-		var err error
-		miekgResult, trace, status, err = s.DoMiekgLookup(miekg.Question{Name: name, Type: dnsType}, nameServer)
-		if status != zdns.STATUS_NOERROR || err != nil {
-			return nil, trace, status, err
-		}
-
-		populateResults(miekgResult.(miekg.Result).Answers, dnsType, candidateSet, cnameSet, garbage)
-		populateResults(miekgResult.(miekg.Result).Additional, dnsType, candidateSet, cnameSet, garbage)
-	}
-	// our cache should now have any data that exists about the current name
-	if res, ok := candidateSet[name]; ok && len(res) > 0 {
-		// we have IP addresses to hand back to the user. let's make an easy-to-use array of strings
-		var ips []string
-		for _, answer := range res {
-			ips = append(ips, answer.Answer)
-		}
-		return ips, trace, zdns.STATUS_NOERROR, nil
-	} else if res, ok = cnameSet[name]; ok && len(res) > 0 {
-		// we have a CNAME and need to further recurse to find IPs
-		shortName := strings.ToLower(res[0].Answer[0 : len(res[0].Answer)-1])
-		res, secondTrace, status, err := s.doLookupProtocol(shortName, nameServer, dnsType, candidateSet, cnameSet, origName, depth+1)
-		trace = append(trace, secondTrace...)
-		return res, trace, status, err
-	} else if res, ok = garbage[name]; ok && len(res) > 0 {
-		return nil, trace, zdns.STATUS_ERROR, errors.New("unexpected record type received")
-	} else {
-		// we have no data whatsoever about this name. return an empty recordset to the user
-		var ips []string
-		return ips, trace, zdns.STATUS_NOERROR, nil
-	}
-}
-
-func safeStatus(status zdns.Status) bool {
-	return status == zdns.STATUS_NOERROR
+func (lc LookupClient) ProtocolLookup(s *miekg.Lookup, q miekg.Question, nameServer string) (interface{}, zdns.Trace, zdns.Status, error) {
+	return s.DoMiekgLookup(q, nameServer)
 }
 
 func (s *Lookup) DoTargetedLookup(name, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
@@ -145,27 +59,28 @@ func (s *Lookup) DoTargetedLookup(name, nameServer string) (interface{}, []inter
 	var ipv6Trace []interface{}
 	var ipv4status zdns.Status
 	var ipv6status zdns.Status
+	l := LookupClient{}
 	if lookupIpv4 {
-		ipv4, ipv4Trace, ipv4status, _ = s.doLookupProtocol(name, nameServer, dns.TypeA, candidateSet, cnameSet, name, 0)
+		ipv4, ipv4Trace, ipv4status, _ = s.DoProtocolLookup(l, name, nameServer, dns.TypeA, candidateSet, cnameSet, name, 0)
 		res.IPv4Addresses = make([]string, len(ipv4))
 		copy(res.IPv4Addresses, ipv4)
 	}
 	candidateSet = map[string][]miekg.Answer{}
 	cnameSet = map[string][]miekg.Answer{}
 	if lookupIpv6 {
-		ipv6, ipv6Trace, ipv6status, _ = s.doLookupProtocol(name, nameServer, dns.TypeAAAA, candidateSet, cnameSet, name, 0)
+		ipv6, ipv6Trace, ipv6status, _ = s.DoProtocolLookup(l, name, nameServer, dns.TypeAAAA, candidateSet, cnameSet, name, 0)
 		res.IPv6Addresses = make([]string, len(ipv6))
 		copy(res.IPv6Addresses, ipv6)
 	}
 
 	combinedTrace := append(ipv4Trace, ipv6Trace...)
 
-	// alookup is only expected to return IP addresses. Hence irrespective of the
-	// status returned from miekgdns, we return NO_ANSWER in case of missing IPs
+	// In case we get no IPs and a non-NOERROR status from either
+	// IPv4 or IPv6 lookup, we return that status.
 	if len(res.IPv4Addresses) == 0 && len(res.IPv6Addresses) == 0 {
-		if lookupIpv4 && !safeStatus(ipv4status) {
+		if lookupIpv4 && !miekg.SafeStatus(ipv4status) {
 			return nil, combinedTrace, ipv4status, nil
-		} else if lookupIpv6 && !safeStatus(ipv6status) {
+		} else if lookupIpv6 && !miekg.SafeStatus(ipv6status) {
 			return nil, combinedTrace, ipv6status, nil
 		} else {
 			return nil, combinedTrace, zdns.STATUS_NOERROR, nil

--- a/pkg/alookup/alookup_test.go
+++ b/pkg/alookup/alookup_test.go
@@ -23,30 +23,27 @@ import (
 	"github.com/zmap/zdns/pkg/zdns"
 )
 
-type minimalRes struct {
-	IPv4Addresses []string
-	IPv6Addresses []string
-}
-
-var mockResults = make(map[string]minimalRes)
+var mockResults = make(map[string]miekg.IpResult)
 
 var status = zdns.STATUS_NOERROR
 
-// Mock the actual DoProtocolLookup
-func (s *Lookup) DoProtocolLookup(lc LookupClient, name, nameServer string, dnsType uint16, candidateSet map[string][]miekg.Answer, cnameSet map[string][]miekg.Answer, origName string, depth int) ([]string, []interface{}, zdns.Status, error) {
+func (s *Lookup) DoTargetedLookup(l LookupClient, name, nameServer string, lookupIpv4 bool, lookupIpv6 bool) (interface{}, []interface{}, zdns.Status, error) {
+	retv := miekg.IpResult{}
 	if res, ok := mockResults[name]; ok {
-		if dnsType == dns.TypeA {
-			return res.IPv4Addresses, nil, status, nil
-		} else {
-			return res.IPv6Addresses, nil, status, nil
+		if lookupIpv4 {
+			retv.IPv4Addresses = res.IPv4Addresses
 		}
+		if lookupIpv6 {
+			retv.IPv6Addresses = res.IPv6Addresses
+		}
+		return retv, nil, status, nil
 	} else {
 		return nil, nil, zdns.STATUS_NXDOMAIN, nil
 	}
 }
 
-func InitTest(t *testing.T) (*zdns.GlobalConf, *GlobalLookupFactory, *RoutineLookupFactory, zdns.Lookup) {
-	mockResults = make(map[string]minimalRes)
+func InitTest(t *testing.T) (*GlobalLookupFactory, zdns.Lookup) {
+	mockResults = make(map[string]miekg.IpResult)
 	gc := new(zdns.GlobalConf)
 	gc.NameServers = []string{"127.0.0.1"}
 
@@ -61,107 +58,47 @@ func InitTest(t *testing.T) (*zdns.GlobalConf, *GlobalLookupFactory, *RoutineLoo
 	if l == nil || err != nil {
 		t.Error("Failed to initialize lookup")
 	}
-	return gc, glf, rlf, l
+	return glf, l
 }
 
-func TestOneA(t *testing.T) {
-	_, glf, _, l := InitTest(t)
-	glf.IPv4Lookup = true
-	mockResults["example.com"] = minimalRes{
-		IPv4Addresses: []string{"192.0.2.1"},
-	}
-	res, _, _, _ := l.DoLookup("example.com", "")
-	verifyResult(t, res.(Result), []string{"192.0.2.1"}, nil)
-}
-
-func TestTwoA(t *testing.T) {
-	_, glf, _, l := InitTest(t)
-	glf.IPv4Lookup = true
-	mockResults["example.com"] = minimalRes{
-		IPv4Addresses: []string{"192.0.2.1", "192.0.2.2"},
-	}
-	res, _, _, _ := l.DoLookup("example.com", "")
-	verifyResult(t, res.(Result), []string{"192.0.2.1", "192.0.2.2"}, nil)
-}
-
-func TestQuadAWithoutFlag(t *testing.T) {
-	_, glf, _, l := InitTest(t)
-	glf.IPv4Lookup = true
-	mockResults["example.com"] = minimalRes{
+func TestIPv4Lookup(t *testing.T) {
+	_, l := InitTest(t)
+	mockResults["example.com"] = miekg.IpResult{
 		IPv4Addresses: []string{"192.0.2.1"},
 		IPv6Addresses: []string{"2001:db8::1"},
 	}
 	res, _, _, _ := l.DoLookup("example.com", "")
-	verifyResult(t, res.(Result), []string{"192.0.2.1"}, nil)
+	verifyResult(t, res.(miekg.IpResult), []string{"192.0.2.1"}, nil)
 }
 
-func TestOnlyQuadA(t *testing.T) {
-	_, glf, _, l := InitTest(t)
+func TestIPv6Lookup(t *testing.T) {
+	glf, l := InitTest(t)
 	glf.IPv6Lookup = true
-	mockResults["example.com"] = minimalRes{
-		IPv6Addresses: []string{"2001:db8::1"},
-	}
-	res, _, _, _ := l.DoLookup("example.com", "")
-	verifyResult(t, res.(Result), nil, []string{"2001:db8::1"})
-}
-
-func TestAandQuadA(t *testing.T) {
-	_, glf, _, l := InitTest(t)
-	glf.IPv4Lookup = true
-	glf.IPv6Lookup = true
-	mockResults["example.com"] = minimalRes{
+	mockResults["example.com"] = miekg.IpResult{
 		IPv4Addresses: []string{"192.0.2.1"},
 		IPv6Addresses: []string{"2001:db8::1"},
 	}
 	res, _, _, _ := l.DoLookup("example.com", "")
-	verifyResult(t, res.(Result), []string{"192.0.2.1"}, []string{"2001:db8::1"})
+	verifyResult(t, res.(miekg.IpResult), nil, []string{"2001:db8::1"})
 }
 
-func TestTwoQuadA(t *testing.T) {
-	_, glf, _, l := InitTest(t)
+func TestBothLookup(t *testing.T) {
+	glf, l := InitTest(t)
 	glf.IPv4Lookup = true
 	glf.IPv6Lookup = true
-	mockResults["example.com"] = minimalRes{
-		IPv6Addresses: []string{"2001:db8::1", "2001:db8::2"},
+	mockResults["example.com"] = miekg.IpResult{
+		IPv4Addresses: []string{"192.0.2.1"},
+		IPv6Addresses: []string{"2001:db8::1"},
 	}
 	res, _, _, _ := l.DoLookup("example.com", "")
-	verifyResult(t, res.(Result), nil, []string{"2001:db8::1", "2001:db8::2"})
+	verifyResult(t, res.(miekg.IpResult), []string{"192.0.2.1"}, []string{"2001:db8::1"})
 }
 
-func TestNoResults(t *testing.T) {
-	_, glf, _, l := InitTest(t)
-	glf.IPv4Lookup = true
-	mockResults["example.com"] = minimalRes{}
-	res, _, status, _ := l.DoLookup("example.com", "")
-	if status != zdns.STATUS_NOERROR {
-		t.Errorf("Expected NOERROR status, got %v", status)
-	} else if res != nil {
-		t.Errorf("Expected no results, got %v", res)
+func verifyResult(t *testing.T, res miekg.IpResult, ipv4 []string, ipv6 []string) {
+	if !reflect.DeepEqual(ipv4, res.IPv4Addresses) {
+		t.Errorf("Expected %v, Received %v IPv4 address(es)", ipv4, res.IPv4Addresses)
 	}
-}
-
-func verifyResult(t *testing.T, res Result, ipv4 []string, ipv6 []string) {
-	if ipv4 == nil && res.IPv4Addresses != nil && len(res.IPv4Addresses) > 0 {
-		t.Error("Received IPv4 addresses while none expected")
-	} else if ipv4 != nil {
-		if res.IPv4Addresses == nil || len(res.IPv4Addresses) == 0 {
-			t.Error("Received no IPv4 addresses while expected")
-		} else if len(res.IPv4Addresses) != len(ipv4) {
-			t.Errorf("Received %v IPv4 addresses while %v is expected", len(res.IPv4Addresses), len(ipv4))
-		} else if !reflect.DeepEqual(res.IPv4Addresses, ipv4) {
-			t.Error("Received unexpected IPv4 address(es)")
-		}
-	}
-
-	if ipv6 == nil && res.IPv6Addresses != nil && len(res.IPv6Addresses) > 0 {
-		t.Error("Received IPv6 addresses while none expected")
-	} else if ipv6 != nil {
-		if res.IPv6Addresses == nil || len(res.IPv6Addresses) == 0 {
-			t.Error("Received no IPv6 addresses while expected")
-		} else if len(res.IPv6Addresses) != len(ipv6) {
-			t.Errorf("Received %v IPv6 addresses while %v is expected", len(res.IPv6Addresses), len(ipv6))
-		} else if !reflect.DeepEqual(res.IPv6Addresses, ipv6) {
-			t.Error("Received unexpected IPv6 address(es)")
-		}
+	if !reflect.DeepEqual(ipv6, res.IPv6Addresses) {
+		t.Errorf("Expected %v, Received %v IPv6 address(es)", ipv6, res.IPv6Addresses)
 	}
 }

--- a/pkg/miekg/miekg.go
+++ b/pkg/miekg/miekg.go
@@ -770,15 +770,19 @@ func (s *Lookup) DoTargetedLookup(l LookupClient, name, nameServer string, looku
 
 	if lookupIpv4 {
 		ipv4, ipv4Trace, ipv4status, _ = s.DoIpsLookup(l, name, nameServer, dns.TypeA, candidateSet, cnameSet, name, 0)
-		res.IPv4Addresses = make([]string, len(ipv4))
-		copy(res.IPv4Addresses, ipv4)
+		if len(ipv4) > 0 {
+			res.IPv4Addresses = make([]string, len(ipv4))
+			copy(res.IPv4Addresses, ipv4)
+		}
 	}
 	candidateSet = map[string][]Answer{}
 	cnameSet = map[string][]Answer{}
 	if lookupIpv6 {
 		ipv6, ipv6Trace, ipv6status, _ = s.DoIpsLookup(l, name, nameServer, dns.TypeAAAA, candidateSet, cnameSet, name, 0)
-		res.IPv6Addresses = make([]string, len(ipv6))
-		copy(res.IPv6Addresses, ipv6)
+		if len(ipv6) > 0 {
+			res.IPv6Addresses = make([]string, len(ipv6))
+			copy(res.IPv6Addresses, ipv6)
+		}
 	}
 
 	combinedTrace := append(ipv4Trace, ipv6Trace...)
@@ -791,7 +795,7 @@ func (s *Lookup) DoTargetedLookup(l LookupClient, name, nameServer string, looku
 		} else if lookupIpv6 && !SafeStatus(ipv6status) {
 			return nil, combinedTrace, ipv6status, nil
 		} else {
-			return nil, combinedTrace, zdns.STATUS_NOERROR, nil
+			return res, combinedTrace, zdns.STATUS_NOERROR, nil
 		}
 	}
 	return res, combinedTrace, zdns.STATUS_NOERROR, nil

--- a/pkg/miekg/miekg.go
+++ b/pkg/miekg/miekg.go
@@ -687,29 +687,13 @@ func (s *Lookup) DoMiekgLookup(q Question, nameServer string) (interface{}, zdns
 	}
 }
 
-// Verify that A record is indeed IPv4 and AAAA is IPv6
-func verifyAddress(ansType string, ip string) bool {
-	isIpv4 := false
-	isIpv6 := false
-	if net.ParseIP(ip) != nil {
-		isIpv6 = strings.Contains(ip, ":")
-		isIpv4 = !isIpv6
-	}
-	if ansType == "A" {
-		return isIpv4
-	} else if ansType == "AAAA" {
-		return isIpv6
-	}
-	return !isIpv4 && !isIpv6
-}
-
 func populateResults(records []interface{}, dnsType uint16, candidateSet map[string][]Answer, cnameSet map[string][]Answer, garbage map[string][]Answer) {
 	for _, a := range records {
 		// filter only valid answers of requested type or CNAME (#163)
 		if ans, ok := a.(Answer); ok {
 			lowerCaseName := strings.ToLower(ans.Name)
 			// Verify that the answer type matches requested type
-			if verifyAddress(ans.Type, ans.Answer) {
+			if VerifyAddress(ans.Type, ans.Answer) {
 				ansType := dns.StringToType[ans.Type]
 				if dnsType == ansType {
 					candidateSet[lowerCaseName] = append(candidateSet[lowerCaseName], ans)

--- a/pkg/miekg/miekg_test.go
+++ b/pkg/miekg/miekg_test.go
@@ -1,12 +1,325 @@
 package miekg
 
 import (
-	"github.com/zmap/dns"
-	"gotest.tools/v3/assert"
 	"net"
+	"reflect"
 	"regexp"
+	"strconv"
 	"testing"
+
+	"github.com/zmap/dns"
+	"github.com/zmap/zdns/pkg/zdns"
+	"gotest.tools/v3/assert"
 )
+
+var mockResults = make(map[string]Result)
+
+var status = zdns.STATUS_NOERROR
+
+type MockLookupClient struct{}
+
+func (mc MockLookupClient) ProtocolLookup(s *Lookup, q Question, nameServer string) (interface{}, zdns.Trace, zdns.Status, error) {
+	if res, ok := mockResults[q.Name]; ok {
+		return res, nil, status, nil
+	} else {
+		return nil, nil, zdns.STATUS_NXDOMAIN, nil
+	}
+}
+
+func InitTest(t *testing.T) (*zdns.GlobalConf, Lookup, MockLookupClient) {
+	gc := new(zdns.GlobalConf)
+	gc.NameServers = []string{"127.0.0.1"}
+
+	glf := new(GlobalLookupFactory)
+	glf.GlobalConf = gc
+
+	rlf := new(RoutineLookupFactory)
+	rlf.Factory = glf
+	rlf.Client = new(dns.Client)
+
+	l, err := rlf.MakeLookup()
+	if l == nil || err != nil {
+		t.Error("Failed to initialize lookup")
+	}
+
+	a := Lookup{Factory: rlf}
+	mc := MockLookupClient{}
+
+	return gc, a, mc
+}
+
+func TestCname(t *testing.T) {
+	gc, a, mc := InitTest(t)
+
+	mockResults["cname.example.com"] = Result{
+		Answers: []interface{}{Answer{
+			Ttl:    3600,
+			Type:   "CNAME",
+			Class:  "IN",
+			Name:   "cname.example.com",
+			Answer: "example.com.",
+		}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       DNSFlags{},
+	}
+	mockResults["example.com"] = Result{
+		Answers: []interface{}{Answer{
+			Ttl:    3600,
+			Type:   "A",
+			Class:  "IN",
+			Name:   "example.com",
+			Answer: "192.0.2.1",
+		}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       DNSFlags{},
+	}
+	res, _, _, _ := a.DoProtocolLookup(mc, "cname.example.com", gc.NameServers[0], dns.TypeA, make(map[string][]Answer), make(map[string][]Answer), "cname.example.com", 0)
+	verifyResult(t, res, []string{"192.0.2.1"})
+}
+
+func TestQuadAWithCname(t *testing.T) {
+	gc, a, mc := InitTest(t)
+
+	mockResults["cname.example.com"] = Result{
+		Answers: []interface{}{Answer{
+			Ttl:    3600,
+			Type:   "AAAA",
+			Class:  "IN",
+			Name:   "cname.example.com",
+			Answer: "2001:db8::3",
+		},
+			Answer{
+				Ttl:    3600,
+				Type:   "CNAME",
+				Class:  "IN",
+				Name:   "cname.example.com",
+				Answer: "example.com.",
+			}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       DNSFlags{},
+	}
+
+	res, _, _, _ := a.DoProtocolLookup(mc, "cname.example.com", gc.NameServers[0], dns.TypeAAAA, make(map[string][]Answer), make(map[string][]Answer), "cname.example.com", 0)
+	verifyResult(t, res, []string{"2001:db8::3"})
+}
+
+func TestUnexpectedMxOnly(t *testing.T) {
+	gc, a, mc := InitTest(t)
+	mockResults["example.com"] = Result{
+		Answers: []interface{}{Answer{
+			Ttl:    3600,
+			Type:   "MX",
+			Class:  "IN",
+			Name:   "example.com",
+			Answer: "mail.example.com.",
+		}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       DNSFlags{},
+	}
+
+	res, _, status, _ := a.DoProtocolLookup(mc, "example.com", gc.NameServers[0], dns.TypeAAAA, make(map[string][]Answer), make(map[string][]Answer), "cname.example.com", 0)
+
+	if status != zdns.STATUS_ERROR {
+		t.Errorf("Expected ERROR status, got %v", status)
+	} else if res != nil {
+		t.Errorf("Expected no results, got %v", res)
+	}
+}
+
+func TestMxAndAdditionals(t *testing.T) {
+	gc, a, mc := InitTest(t)
+	mockResults["example.com"] = Result{
+		Answers: []interface{}{Answer{
+			Ttl:    3600,
+			Type:   "MX",
+			Class:  "IN",
+			Name:   "example.com",
+			Answer: "mail.example.com.",
+		}},
+		Additional: []interface{}{Answer{
+			Ttl:    3600,
+			Type:   "A",
+			Class:  "IN",
+			Name:   "example.com",
+			Answer: "192.0.2.3",
+		},
+			Answer{
+				Ttl:    3600,
+				Type:   "AAAA",
+				Class:  "IN",
+				Name:   "example.com",
+				Answer: "2001:db8::4",
+			}},
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       DNSFlags{},
+	}
+
+	res, _, _, _ := a.DoProtocolLookup(mc, "example.com", gc.NameServers[0], dns.TypeA, make(map[string][]Answer), make(map[string][]Answer), "example.com", 0)
+	verifyResult(t, res, []string{"192.0.2.3"})
+
+	res, _, _, _ = a.DoProtocolLookup(mc, "example.com", gc.NameServers[0], dns.TypeAAAA, make(map[string][]Answer), make(map[string][]Answer), "example.com", 0)
+	verifyResult(t, res, []string{"2001:db8::4"})
+}
+
+func TestMismatchIpType(t *testing.T) {
+	gc, a, mc := InitTest(t)
+	mockResults["example.com"] = Result{
+		Answers: []interface{}{Answer{
+			Ttl:    3600,
+			Type:   "A",
+			Class:  "IN",
+			Name:   "example.com",
+			Answer: "2001:db8::4",
+		}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       DNSFlags{},
+	}
+
+	res, _, status, _ := a.DoProtocolLookup(mc, "example.com", gc.NameServers[0], dns.TypeA, make(map[string][]Answer), make(map[string][]Answer), "cname.example.com", 0)
+
+	if status != zdns.STATUS_ERROR {
+		t.Errorf("Expected ERROR status, got %v", status)
+	} else if res != nil {
+		t.Errorf("Expected no results, got %v", res)
+	}
+}
+
+func TestCnameLoops(t *testing.T) {
+	gc, a, mc := InitTest(t)
+	mockResults["cname.example.com"] = Result{
+		Answers: []interface{}{Answer{
+			Ttl:    3600,
+			Type:   "CNAME",
+			Class:  "IN",
+			Name:   "cname.example.com",
+			Answer: "example.com.",
+		}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       DNSFlags{},
+	}
+	mockResults["example.com"] = Result{
+		Answers: []interface{}{Answer{
+			Ttl:    3600,
+			Type:   "CNAME",
+			Class:  "IN",
+			Name:   "example.com",
+			Answer: "cname.example.com.",
+		}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       DNSFlags{},
+	}
+
+	res, _, status, _ := a.DoProtocolLookup(mc, "example.com", gc.NameServers[0], dns.TypeA, make(map[string][]Answer), make(map[string][]Answer), "cname.example.com", 0)
+
+	if status != zdns.STATUS_ERROR {
+		t.Errorf("Expected ERROR status, got %v", status)
+	} else if res != nil {
+		t.Errorf("Expected no results, got %v", res)
+	}
+}
+
+func TestExtendedRecursion(t *testing.T) {
+	gc, a, mc := InitTest(t)
+	// Create a CNAME chain of length > 10
+	for i := 1; i < 12; i++ {
+		mockResults["cname"+strconv.Itoa(i)+".example.com"] = Result{
+			Answers: []interface{}{Answer{
+				Ttl:    3600,
+				Type:   "CNAME",
+				Class:  "IN",
+				Name:   "cname" + strconv.Itoa(i) + ".example.com",
+				Answer: "cname" + strconv.Itoa(i+1) + ".example.com",
+			}},
+			Additional:  nil,
+			Authorities: nil,
+			Protocol:    "",
+			Flags:       DNSFlags{},
+		}
+	}
+
+	res, _, status, _ := a.DoProtocolLookup(mc, "cname1.example.com", gc.NameServers[0], dns.TypeA, make(map[string][]Answer), make(map[string][]Answer), "cname.example.com", 0)
+
+	if status != zdns.STATUS_ERROR {
+		t.Errorf("Expected ERROR status, got %v", status)
+	} else if res != nil {
+		t.Errorf("Expected no results, got %v", res)
+	}
+}
+
+func TestEmptyNonTerminal(t *testing.T) {
+	gc, a, mc := InitTest(t)
+	mockResults["leaf.intermediate.example.com"] = Result{
+		Answers: []interface{}{Answer{
+			Ttl:    3600,
+			Type:   "A",
+			Class:  "IN",
+			Name:   "leaf.intermediate.example.com",
+			Answer: "192.0.2.3",
+		}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       DNSFlags{},
+	}
+	mockResults["intermediate.example.com"] = Result{
+		Answers:     nil,
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       DNSFlags{},
+	}
+	// Verify leaf returns correctly
+	res, _, _, _ := a.DoProtocolLookup(mc, "leaf.intermediate.example.com", gc.NameServers[0], dns.TypeA, make(map[string][]Answer), make(map[string][]Answer), "leaf.intermediate.example.com", 0)
+	verifyResult(t, res, []string{"192.0.2.3"})
+
+	// Verify empty non-terminal returns no answer
+	res, _, status, _ = a.DoProtocolLookup(mc, "intermediate.example.com", gc.NameServers[0], dns.TypeA, make(map[string][]Answer), make(map[string][]Answer), "intermediate.example.com", 0)
+	if status != zdns.STATUS_NOERROR {
+		t.Errorf("Expected STATUS_NOERROR status, got %v", status)
+	} else if res != nil {
+		t.Errorf("Expected no results, got %v", res)
+	}
+}
+
+func TestNXDomain(t *testing.T) {
+	gc, a, mc := InitTest(t)
+	name := "nonexistent.example.com"
+	res, _, status, _ := a.DoProtocolLookup(mc, name, gc.NameServers[0], dns.TypeA, make(map[string][]Answer), make(map[string][]Answer), name, 0)
+	if status != zdns.STATUS_NXDOMAIN {
+		t.Errorf("Expected STATUS_NXDOMAIN status, got %v", status)
+	} else if res != nil {
+		t.Errorf("Expected no results, got %v", res)
+	}
+}
+
+func TestServFail(t *testing.T) {
+	status = zdns.STATUS_SERVFAIL
+	gc, a, mc := InitTest(t)
+	mockResults["example.com"] = Result{}
+	name := "example.com"
+	res, _, final_status, _ := a.DoProtocolLookup(mc, name, gc.NameServers[0], dns.TypeA, make(map[string][]Answer), make(map[string][]Answer), name, 0)
+
+	if final_status != status {
+		t.Errorf("Expected %v status, got %v", status, final_status)
+	} else if res != nil {
+		t.Errorf("Expected no results, got %v", res)
+	}
+}
 
 func TestParseAnswer(t *testing.T) {
 	var rr dns.RR
@@ -24,7 +337,7 @@ func TestParseAnswer(t *testing.T) {
 	}
 
 	res := ParseAnswer(rr)
-	verifyResult(t, res, rr, "192.0.2.1")
+	verifyAnswer(t, res, rr, "192.0.2.1")
 
 	// typical AAAA record
 	rr = &dns.AAAA{
@@ -63,7 +376,7 @@ func TestParseAnswer(t *testing.T) {
 	}
 
 	res = ParseAnswer(rr)
-	verifyResult(t, res, rr, "::")
+	verifyAnswer(t, res, rr, "::")
 
 	// IPv4-Mapped IPv6 address as AAAA record
 	rr = &dns.AAAA{
@@ -78,7 +391,7 @@ func TestParseAnswer(t *testing.T) {
 	}
 
 	res = ParseAnswer(rr)
-	verifyResult(t, res, rr, "::ffff:192.0.2.1")
+	verifyAnswer(t, res, rr, "::ffff:192.0.2.1")
 
 	// IPv4-compatible IPv6 address as AAAA record
 	rr = &dns.AAAA{
@@ -93,7 +406,7 @@ func TestParseAnswer(t *testing.T) {
 	}
 
 	res = ParseAnswer(rr)
-	verifyResult(t, res, rr, "::192.0.2.1")
+	verifyAnswer(t, res, rr, "::192.0.2.1")
 
 	// NAPTR record für aa e.164 phone number (+1-234-555-6789)
 	rr = &dns.NAPTR{
@@ -118,7 +431,7 @@ func TestParseAnswer(t *testing.T) {
 		t.Error("Failed to parse record")
 		return
 	}
-	verifyResult(t, answer.Answer, rr, "")
+	verifyAnswer(t, answer.Answer, rr, "")
 	if answer.Order != 100 {
 		t.Errorf("Unxpected order. Expected %v, got %v", 100, answer.Order)
 	}
@@ -141,7 +454,7 @@ func TestParseAnswer(t *testing.T) {
 	// TODO: test remaining RR types
 }
 
-func verifyResult(t *testing.T, answer interface{}, original dns.RR, expectedAnswer string) {
+func verifyAnswer(t *testing.T, answer interface{}, original dns.RR, expectedAnswer string) {
 	ans, ok := answer.(Answer)
 	if !ok {
 		t.Error("Failed to parse record")
@@ -272,4 +585,10 @@ func TestLookup_DoTxtLookup_5(t *testing.T) {
 	resultString, err := txtRecord.FindTxtRecord(input)
 	assert.NilError(t, err)
 	assert.Equal(t, "google-site-verification=A2WZWCNQHrGV_TWwKh7KHY90UY0SHZo_rnyMJoDaG0s", resultString)
+}
+
+func verifyResult(t *testing.T, resIps []string, expectedIps []string) {
+	if !reflect.DeepEqual(expectedIps, resIps) {
+		t.Errorf("Expected %v, Received %v IP address(es)", expectedIps, resIps)
+	}
 }

--- a/pkg/miekg/util.go
+++ b/pkg/miekg/util.go
@@ -3,6 +3,7 @@ package miekg
 import (
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/zmap/dns"
@@ -99,4 +100,20 @@ func makeVerbosePrefix(depth int, threadID int) string {
 // Check whether the status is safe
 func SafeStatus(status zdns.Status) bool {
 	return status == zdns.STATUS_NOERROR
+}
+
+// Verify that A record is indeed IPv4 and AAAA is IPv6
+func VerifyAddress(ansType string, ip string) bool {
+	isIpv4 := false
+	isIpv6 := false
+	if net.ParseIP(ip) != nil {
+		isIpv6 = strings.Contains(ip, ":")
+		isIpv4 = !isIpv6
+	}
+	if ansType == "A" {
+		return isIpv4
+	} else if ansType == "AAAA" {
+		return isIpv6
+	}
+	return !isIpv4 && !isIpv6
 }

--- a/pkg/miekg/util.go
+++ b/pkg/miekg/util.go
@@ -95,3 +95,8 @@ func checkGlue(server string, depth int, result Result) (Result, zdns.Status) {
 func makeVerbosePrefix(depth int, threadID int) string {
 	return fmt.Sprintf("THREADID %06d,DEPTH %02d", threadID, depth) + ":" + strings.Repeat("  ", 2*depth)
 }
+
+// Check whether the status is safe
+func SafeStatus(status zdns.Status) bool {
+	return status == zdns.STATUS_NOERROR
+}

--- a/pkg/mxlookup/mxlookup.go
+++ b/pkg/mxlookup/mxlookup.go
@@ -68,10 +68,11 @@ func (s *Lookup) LookupIPs(l LookupClient, name, nameServer string, lookupIpv4 b
 	if found {
 		return res.(CachedAddresses), make([]interface{}, 0)
 	}
-	res, trace, _, _ := s.DoTargetedLookup(l, name, nameServer, lookupIpv4, lookupIpv6)
-	retv := CachedAddresses{
-		IPv4Addresses: res.(miekg.IpResult).IPv4Addresses,
-		IPv6Addresses: res.(miekg.IpResult).IPv6Addresses,
+	retv := CachedAddresses{}
+	res, trace, status, _ := s.DoTargetedLookup(l, name, nameServer, lookupIpv4, lookupIpv6)
+	if status == zdns.STATUS_NOERROR && res != nil {
+		retv.IPv4Addresses = res.(miekg.IpResult).IPv4Addresses
+		retv.IPv6Addresses = res.(miekg.IpResult).IPv6Addresses
 	}
 
 	s.Factory.Factory.CHmu.Lock()

--- a/pkg/mxlookup/mxlookup.go
+++ b/pkg/mxlookup/mxlookup.go
@@ -53,11 +53,14 @@ type Lookup struct {
 	miekg.Lookup
 }
 
-func dotName(name string) string {
-	return strings.Join([]string{name, "."}, "")
+// This LookupClient is created to call the actual implementation of DoMiekgLookup
+type LookupClient struct{}
+
+func (lc LookupClient) ProtocolLookup(s *miekg.Lookup, q miekg.Question, nameServer string) (interface{}, zdns.Trace, zdns.Status, error) {
+	return s.DoMiekgLookup(q, nameServer)
 }
 
-func (s *Lookup) LookupIPs(name, nameServer string) (CachedAddresses, zdns.Trace) {
+func (s *Lookup) LookupIPs(l LookupClient, name, nameServer string, lookupIpv4 bool, lookupIpv6 bool) (CachedAddresses, zdns.Trace) {
 	s.Factory.Factory.CHmu.Lock()
 	// XXX this should be changed to a miekglookup
 	res, found := s.Factory.Factory.CacheHash.Get(name)
@@ -65,38 +68,12 @@ func (s *Lookup) LookupIPs(name, nameServer string) (CachedAddresses, zdns.Trace
 	if found {
 		return res.(CachedAddresses), make([]interface{}, 0)
 	}
-	var retv CachedAddresses
-	trace := make([]interface{}, 0)
-	// ipv4
-	if s.Factory.Factory.IPv4Lookup || !s.Factory.Factory.IPv6Lookup {
-		res, secondTrace, status, _ := s.DoMiekgLookup(miekg.Question{Name: name, Type: dns.TypeA}, nameServer)
-		trace = append(trace, secondTrace...)
-		if status == zdns.STATUS_NOERROR {
-			cast, _ := res.(miekg.Result)
-			for _, innerRes := range cast.Answers {
-				castInnerRes, ok := innerRes.(miekg.Answer)
-				if !ok {
-					continue
-				}
-				retv.IPv4Addresses = append(retv.IPv4Addresses, castInnerRes.Answer)
-			}
-		}
+	res, trace, _, _ := s.DoTargetedLookup(l, name, nameServer, lookupIpv4, lookupIpv6)
+	retv := CachedAddresses{
+		IPv4Addresses: res.(miekg.IpResult).IPv4Addresses,
+		IPv6Addresses: res.(miekg.IpResult).IPv6Addresses,
 	}
-	// ipv6
-	if s.Factory.Factory.IPv6Lookup {
-		res, secondTrace, status, _ := s.DoMiekgLookup(miekg.Question{Name: name, Type: dns.TypeAAAA}, nameServer)
-		trace = append(trace, secondTrace...)
-		if status == zdns.STATUS_NOERROR {
-			cast, _ := res.(miekg.Result)
-			for _, innerRes := range cast.Answers {
-				castInnerRes, ok := innerRes.(miekg.Answer)
-				if !ok {
-					continue
-				}
-				retv.IPv6Addresses = append(retv.IPv6Addresses, castInnerRes.Answer)
-			}
-		}
-	}
+
 	s.Factory.Factory.CHmu.Lock()
 	s.Factory.Factory.CacheHash.Add(name, retv)
 	s.Factory.Factory.CHmu.Unlock()
@@ -106,18 +83,21 @@ func (s *Lookup) LookupIPs(name, nameServer string) (CachedAddresses, zdns.Trace
 func (s *Lookup) DoLookup(name, nameServer string) (interface{}, zdns.Trace, zdns.Status, error) {
 	retv := Result{Servers: []MXRecord{}}
 	res, trace, status, err := s.DoMiekgLookup(miekg.Question{Name: name, Type: dns.TypeMX}, nameServer)
-	if status != zdns.STATUS_NOERROR {
-		return retv, trace, status, err
+	if status != zdns.STATUS_NOERROR || err != nil {
+		return nil, trace, status, err
 	}
 	r, ok := res.(miekg.Result)
 	if !ok {
-		panic("could not cast correctly")
+		return nil, trace, status, err
 	}
+	lookupIpv4 := s.Factory.Factory.IPv4Lookup || !s.Factory.Factory.IPv6Lookup
+	lookupIpv6 := s.Factory.Factory.IPv6Lookup
+	l := LookupClient{}
 	for _, ans := range r.Answers {
 		if mxAns, ok := ans.(miekg.PrefAnswer); ok {
 			name = strings.TrimSuffix(mxAns.Answer.Answer, ".")
 			rec := MXRecord{TTL: mxAns.Ttl, Type: mxAns.Type, Class: mxAns.Class, Name: name, Preference: mxAns.Preference}
-			ips, secondTrace := s.LookupIPs(name, nameServer)
+			ips, secondTrace := s.LookupIPs(l, name, nameServer, lookupIpv4, lookupIpv6)
 			rec.IPv4Addresses = ips.IPv4Addresses
 			rec.IPv6Addresses = ips.IPv6Addresses
 			retv.Servers = append(retv.Servers, rec)

--- a/pkg/mxlookup/mxlookup_test.go
+++ b/pkg/mxlookup/mxlookup_test.go
@@ -1,0 +1,232 @@
+/*
+ * ZDNS Copyright 2019 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package mxlookup
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/zmap/dns"
+	"github.com/zmap/zdns/pkg/miekg"
+	"github.com/zmap/zdns/pkg/zdns"
+)
+
+var mxResults = make(map[string]miekg.Result)
+var miekgStatus = zdns.STATUS_NOERROR
+
+// Mock the actual Miekg lookup for querying MX records
+func (s *Lookup) DoMiekgLookup(question miekg.Question, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
+	if res, ok := mxResults[question.Name]; ok {
+		return res, nil, miekgStatus, nil
+	} else {
+		return nil, nil, zdns.STATUS_NXDOMAIN, nil
+	}
+}
+
+var mockResults = make(map[string]miekg.IpResult)
+var protocolStatus = zdns.STATUS_NOERROR
+
+func (s *Lookup) DoTargetedLookup(l LookupClient, name, nameServer string, lookupIpv4 bool, lookupIpv6 bool) (interface{}, []interface{}, zdns.Status, error) {
+	retv := miekg.IpResult{}
+	if res, ok := mockResults[name]; ok {
+		if lookupIpv4 {
+			retv.IPv4Addresses = res.IPv4Addresses
+		}
+		if lookupIpv6 {
+			retv.IPv6Addresses = res.IPv6Addresses
+		}
+		return retv, nil, protocolStatus, nil
+	} else {
+		return nil, nil, zdns.STATUS_NXDOMAIN, nil
+	}
+}
+
+type minimalServerRecords struct {
+	recType       string
+	IPv4Addresses []string
+	IPv6Addresses []string
+}
+
+func InitTest(t *testing.T) (*zdns.GlobalConf, *GlobalLookupFactory, *RoutineLookupFactory, zdns.Lookup) {
+	mxResults = make(map[string]miekg.Result)
+	gc := new(zdns.GlobalConf)
+	gc.NameServers = []string{"127.0.0.1"}
+
+	glf := new(GlobalLookupFactory)
+	glf.GlobalConf = gc
+	glf.IPv4Lookup = false
+	glf.IPv6Lookup = false
+
+	rlf := new(RoutineLookupFactory)
+	rlf.Factory = glf
+	rlf.Client = new(dns.Client)
+
+	l, err := rlf.MakeLookup()
+	if l == nil || err != nil {
+		t.Error("Failed to initialize lookup")
+	}
+
+	if err := glf.Initialize(gc); err != nil {
+		t.Errorf("Factory was unable to initialize: %v", err.Error())
+	}
+	return gc, glf, rlf, l
+}
+
+func TestMxA(t *testing.T) {
+	_, _, _, l := InitTest(t)
+
+	mxResults["example.com"] = miekg.Result{
+		Answers: []interface{}{miekg.PrefAnswer{
+			Answer: miekg.Answer{
+				Ttl:    3600,
+				Type:   "MX",
+				Class:  "IN",
+				Name:   "example.com.",
+				Answer: "mail.example.com.",
+			},
+			Preference: 1,
+		}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+	mockResults["mail.example.com"] = miekg.IpResult{
+		IPv4Addresses: []string{"192.0.2.1"},
+		IPv6Addresses: nil,
+	}
+
+	expectedServersMap := make(map[string]minimalServerRecords)
+	expectedServersMap["mail.example.com"] = minimalServerRecords{
+		recType:       "MX",
+		IPv4Addresses: []string{"192.0.2.1"},
+		IPv6Addresses: nil,
+	}
+	res, _, _, _ := l.DoLookup("example.com", "")
+	verifyResult(t, res.(Result).Servers, expectedServersMap)
+}
+
+func TestTwoMxA(t *testing.T) {
+	_, glf, _, l := InitTest(t)
+	glf.IPv4Lookup = true
+
+	mxResults["example.com"] = miekg.Result{
+		Answers: []interface{}{
+			miekg.PrefAnswer{
+				Answer: miekg.Answer{
+					Ttl:    3600,
+					Type:   "MX",
+					Class:  "IN",
+					Name:   "example.com.",
+					Answer: "mail1.example.com.",
+				},
+				Preference: 1,
+			},
+			miekg.PrefAnswer{
+				Answer: miekg.Answer{
+					Ttl:    3600,
+					Type:   "MX",
+					Class:  "IN",
+					Name:   "example.com.",
+					Answer: "mail2.example.com.",
+				},
+				Preference: 2,
+			},
+		},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+	mockResults["mail1.example.com"] = miekg.IpResult{
+		IPv4Addresses: []string{"192.0.2.1"},
+	}
+	mockResults["mail2.example.com"] = miekg.IpResult{
+		IPv4Addresses: []string{"192.0.2.2"},
+	}
+
+	expectedServersMap := make(map[string]minimalServerRecords)
+	expectedServersMap["mail1.example.com"] = minimalServerRecords{
+		recType:       "MX",
+		IPv4Addresses: []string{"192.0.2.1"},
+		IPv6Addresses: nil,
+	}
+	expectedServersMap["mail2.example.com"] = minimalServerRecords{
+		recType:       "MX",
+		IPv4Addresses: []string{"192.0.2.2"},
+		IPv6Addresses: nil,
+	}
+	res, _, _, _ := l.DoLookup("example.com", "")
+	verifyResult(t, res.(Result).Servers, expectedServersMap)
+}
+
+func TestMxAandQuadA(t *testing.T) {
+	_, glf, _, l := InitTest(t)
+	glf.IPv4Lookup = true
+	glf.IPv6Lookup = true
+
+	mxResults["example.com"] = miekg.Result{
+		Answers: []interface{}{miekg.PrefAnswer{
+			Answer: miekg.Answer{
+				Ttl:    3600,
+				Type:   "MX",
+				Class:  "IN",
+				Name:   "example.com.",
+				Answer: "mail.example.com.",
+			},
+			Preference: 1,
+		}},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+	mockResults["mail.example.com"] = miekg.IpResult{
+		IPv4Addresses: []string{"192.0.2.1"},
+		IPv6Addresses: []string{"2001:db8::1"},
+	}
+
+	expectedServersMap := make(map[string]minimalServerRecords)
+	expectedServersMap["mail.example.com"] = minimalServerRecords{
+		recType:       "MX",
+		IPv4Addresses: []string{"192.0.2.1"},
+		IPv6Addresses: []string{"2001:db8::1"},
+	}
+	res, _, _, _ := l.DoLookup("example.com", "")
+	verifyResult(t, res.(Result).Servers, expectedServersMap)
+}
+
+func verifyResult(t *testing.T, servers []MXRecord, expectedServersMap map[string]minimalServerRecords) {
+	serversLength := len(servers)
+	expectedServersLength := len(expectedServersMap)
+
+	if serversLength != expectedServersLength {
+		t.Errorf("Expected %v servers, found %v", expectedServersLength, serversLength)
+	}
+
+	for _, server := range servers {
+		name := server.Name
+		expectedRecords, ok := expectedServersMap[name]
+		if !ok {
+			t.Errorf("Did not find server %v in expected servers.", name)
+		}
+		if !reflect.DeepEqual(server.IPv4Addresses, expectedRecords.IPv4Addresses) {
+			t.Errorf("IPv4 addresses not matching for %v, expected %v, found %v", name, expectedRecords.IPv4Addresses, server.IPv4Addresses)
+		}
+		if !reflect.DeepEqual(server.IPv6Addresses, expectedRecords.IPv6Addresses) {
+			t.Errorf("IPv6 addresses not matching for %v, expected %v, found %v", name, expectedRecords.IPv6Addresses, server.IPv6Addresses)
+		}
+	}
+}

--- a/pkg/nslookup/nslookup.go
+++ b/pkg/nslookup/nslookup.go
@@ -61,7 +61,7 @@ func (s *Lookup) DoNSLookup(name string, lookupIpv4 bool, lookupIpv6 bool, nameS
 	var retv Result
 	res, trace, status, err := s.DoMiekgLookup(miekg.Question{Name: name, Type: dns.TypeNS}, nameServer)
 	if status != zdns.STATUS_NOERROR || err != nil {
-		return retv, trace, status, nil
+		return retv, trace, status, err
 	}
 	ns := res.(miekg.Result)
 	ipv4s := make(map[string][]string)

--- a/pkg/nslookup/nslookup.go
+++ b/pkg/nslookup/nslookup.go
@@ -37,6 +37,11 @@ type Result struct {
 	Servers []NSRecord `json:"servers,omitempty" groups:"short,normal,long,trace"`
 }
 
+type IpAddresses struct {
+	IPv4Addresses []string
+	IPv6Addresses []string
+}
+
 // Per Connection Lookup ======================================================
 //
 type Lookup struct {
@@ -44,43 +49,35 @@ type Lookup struct {
 	miekg.Lookup
 }
 
-func dotName(name string) string {
-	return strings.Join([]string{name, "."}, "")
+// This LookupClient is created to call the actual implementation of DoMiekgLookup
+type LookupClient struct{}
+
+func (lc LookupClient) ProtocolLookup(s *miekg.Lookup, q miekg.Question, nameServer string) (interface{}, zdns.Trace, zdns.Status, error) {
+	return s.DoMiekgLookup(q, nameServer)
 }
 
-func (s *Lookup) lookupIPs(name string, dnsType uint16, nameServer string) ([]string, zdns.Trace) {
-	var addresses []string
-	res, trace, status, _ := s.DoMiekgLookup(miekg.Question{Name: name, Type: dnsType}, nameServer)
-	if status == zdns.STATUS_NOERROR {
-		if cast, ok := res.(miekg.Result); ok {
-			for _, innerRes := range cast.Answers {
-				if castInnerRes, ok := innerRes.(miekg.Answer); ok {
-					addresses = append(addresses, castInnerRes.Answer)
-				}
-			}
-		}
-	}
-	return addresses, trace
-}
-
-func (s *Lookup) DoNSLookup(name string, lookupIPv4, lookupIPv6 bool, nameServer string) (Result, zdns.Trace, zdns.Status, error) {
+func (s *Lookup) DoNSLookup(name string, lookupIpv4 bool, lookupIpv6 bool, nameServer string) (Result, zdns.Trace, zdns.Status, error) {
+	l := LookupClient{}
 	var retv Result
 	res, trace, status, err := s.DoMiekgLookup(miekg.Question{Name: name, Type: dns.TypeNS}, nameServer)
 	if status != zdns.STATUS_NOERROR || err != nil {
 		return retv, trace, status, nil
 	}
 	ns := res.(miekg.Result)
-	ipv4s := make(map[string]string)
-	ipv6s := make(map[string]string)
+	ipv4s := make(map[string][]string)
+	ipv6s := make(map[string][]string)
 	for _, ans := range ns.Additional {
 		a, ok := ans.(miekg.Answer)
 		if !ok {
 			continue
 		}
-		if a.Type == "A" {
-			ipv4s[a.Name] = a.Answer
-		} else if a.Type == "AAAA" {
-			ipv6s[a.Name] = a.Answer
+		recName := strings.TrimSuffix(a.Name, ".")
+		if miekg.VerifyAddress(a.Type, a.Answer) {
+			if a.Type == "A" {
+				ipv4s[recName] = append(ipv4s[recName], a.Answer)
+			} else if a.Type == "AAAA" {
+				ipv6s[recName] = append(ipv6s[recName], a.Answer)
+			}
 		}
 	}
 	for _, ans := range ns.Answers {
@@ -92,40 +89,51 @@ func (s *Lookup) DoNSLookup(name string, lookupIPv4, lookupIPv6 bool, nameServer
 		if a.Type != "NS" {
 			continue
 		}
+
 		var rec NSRecord
 		rec.Type = a.Type
 		rec.Name = strings.TrimSuffix(a.Answer, ".")
 		rec.TTL = a.Ttl
-		if lookupIPv4 || !lookupIPv6 {
-			var secondTrace []interface{}
-			rec.IPv4Addresses, secondTrace = s.lookupIPs(rec.Name, dns.TypeA, nameServer)
-			trace = append(trace, secondTrace...)
-		} else if ip, ok := ipv4s[rec.Name]; ok {
-			rec.IPv4Addresses = []string{ip}
-		} else {
-			rec.IPv4Addresses = []string{}
+
+		var findIpv4 = false
+		var findIpv6 = false
+
+		if lookupIpv4 {
+			if ips, ok := ipv4s[rec.Name]; ok {
+				rec.IPv4Addresses = ips
+			} else {
+				findIpv4 = true
+			}
 		}
-		if lookupIPv6 {
-			var secondTrace []interface{}
-			rec.IPv6Addresses, secondTrace = s.lookupIPs(rec.Name, dns.TypeAAAA, nameServer)
-			trace = append(trace, secondTrace...)
-		} else if ip, ok := ipv6s[rec.Name]; ok {
-			rec.IPv6Addresses = []string{ip}
-		} else {
-			rec.IPv6Addresses = []string{}
+		if lookupIpv6 {
+			if ips, ok := ipv6s[rec.Name]; ok {
+				rec.IPv6Addresses = ips
+			} else {
+				findIpv6 = true
+			}
 		}
+		if findIpv4 || findIpv6 {
+			res, nextTrace, _, _ := s.DoTargetedLookup(l, rec.Name, nameServer, findIpv4, findIpv6)
+			if res != nil {
+				if findIpv4 {
+					rec.IPv4Addresses = res.(miekg.IpResult).IPv4Addresses
+				}
+				if findIpv6 {
+					rec.IPv6Addresses = res.(miekg.IpResult).IPv6Addresses
+				}
+			}
+			trace = append(trace, nextTrace...)
+		}
+
 		retv.Servers = append(retv.Servers, rec)
 	}
-	if len(retv.Servers) == 0 {
-		return retv, trace, zdns.STATUS_NO_RECORD, nil
-	}
-
 	return retv, trace, zdns.STATUS_NOERROR, nil
-
 }
 
 func (s *Lookup) DoLookup(name, nameServer string) (interface{}, zdns.Trace, zdns.Status, error) {
-	return s.DoNSLookup(name, s.Factory.Factory.IPv4Lookup, s.Factory.Factory.IPv6Lookup, nameServer)
+	lookupIpv4 := s.Factory.Factory.IPv4Lookup || !s.Factory.Factory.IPv6Lookup
+	lookupIpv6 := s.Factory.Factory.IPv6Lookup
+	return s.DoNSLookup(name, lookupIpv4, lookupIpv6, nameServer)
 }
 
 // Per GoRoutine Factory ======================================================

--- a/pkg/nslookup/nslookup_test.go
+++ b/pkg/nslookup/nslookup_test.go
@@ -1,0 +1,360 @@
+package nslookup
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/zmap/dns"
+	"github.com/zmap/zdns/pkg/miekg"
+	"github.com/zmap/zdns/pkg/zdns"
+)
+
+var nsRecords = make(map[string]miekg.Result)
+
+var errCode = zdns.STATUS_NOERROR
+
+// Mock the actual Miekg lookup.
+func (s *Lookup) DoMiekgLookup(question miekg.Question, nameServer string) (interface{}, []interface{}, zdns.Status, error) {
+	if res, ok := nsRecords[question.Name]; ok {
+		return res, nil, errCode, nil
+	} else {
+		return nil, nil, zdns.STATUS_NXDOMAIN, nil
+	}
+}
+
+var mockResults = make(map[string]miekg.IpResult)
+var protocolStatus = zdns.STATUS_NOERROR
+
+func (s *Lookup) DoTargetedLookup(l LookupClient, name, nameServer string, lookupIpv4 bool, lookupIpv6 bool) (interface{}, []interface{}, zdns.Status, error) {
+	retv := miekg.IpResult{}
+	if res, ok := mockResults[name]; ok {
+		if lookupIpv4 {
+			retv.IPv4Addresses = res.IPv4Addresses
+		}
+		if lookupIpv6 {
+			retv.IPv6Addresses = res.IPv6Addresses
+		}
+		return retv, nil, protocolStatus, nil
+	} else {
+		return nil, nil, zdns.STATUS_NXDOMAIN, nil
+	}
+}
+
+type minimalServerRecords struct {
+	IPv4Addresses []string
+	IPv6Addresses []string
+}
+
+func InitTest(t *testing.T) (*zdns.GlobalConf, *GlobalLookupFactory, *RoutineLookupFactory, zdns.Lookup) {
+	nsRecords = make(map[string]miekg.Result)
+	gc := new(zdns.GlobalConf)
+	gc.NameServers = []string{"127.0.0.1"}
+
+	glf := new(GlobalLookupFactory)
+	glf.GlobalConf = gc
+	glf.IPv4Lookup = false
+	glf.IPv6Lookup = false
+
+	rlf := new(RoutineLookupFactory)
+	rlf.Factory = glf
+	rlf.Client = new(dns.Client)
+
+	l, err := rlf.MakeLookup()
+	if l == nil || err != nil {
+		t.Error("Failed to initialize lookup")
+	}
+
+	if err := glf.Initialize(gc); err != nil {
+		t.Errorf("Factory was unable to initialize: %v", err.Error())
+	}
+	return gc, glf, rlf, l
+}
+
+func TestNsAInAdditional(t *testing.T) {
+	_, _, _, l := InitTest(t)
+
+	nsRecords["example.com"] = miekg.Result{
+		Answers: []interface{}{
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "NS",
+				Class:  "IN",
+				Name:   "example.com.",
+				Answer: "ns1.example.com.",
+			},
+		},
+		Additional: []interface{}{
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "A",
+				Class:  "IN",
+				Name:   "ns1.example.com.",
+				Answer: "192.0.2.3",
+			},
+		},
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+
+	expectedServersMap := make(map[string]minimalServerRecords)
+	expectedServersMap["ns1.example.com"] = minimalServerRecords{
+		IPv4Addresses: []string{"192.0.2.3"},
+		IPv6Addresses: nil,
+	}
+	res, _, _, _ := l.DoLookup("example.com", "")
+	verifyResult(t, res.(Result).Servers, expectedServersMap)
+}
+
+func TestTwoNsAInAdditional(t *testing.T) {
+	_, _, _, l := InitTest(t)
+
+	nsRecords["example.com"] = miekg.Result{
+		Answers: []interface{}{
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "NS",
+				Class:  "IN",
+				Name:   "example.com.",
+				Answer: "ns1.example.com.",
+			},
+		},
+		Additional: []interface{}{
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "A",
+				Class:  "IN",
+				Name:   "ns1.example.com.",
+				Answer: "192.0.2.3",
+			},
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "A",
+				Class:  "IN",
+				Name:   "ns1.example.com.",
+				Answer: "192.0.2.4",
+			},
+		},
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+
+	expectedServersMap := make(map[string]minimalServerRecords)
+	expectedServersMap["ns1.example.com"] = minimalServerRecords{
+		IPv4Addresses: []string{"192.0.2.3", "192.0.2.4"},
+		IPv6Addresses: nil,
+	}
+	res, _, _, _ := l.DoLookup("example.com", "")
+	verifyResult(t, res.(Result).Servers, expectedServersMap)
+}
+
+func TestTwoNSInAdditional(t *testing.T) {
+	_, glf, _, l := InitTest(t)
+	glf.IPv4Lookup = true
+
+	nsRecords["example.com"] = miekg.Result{
+		Answers: []interface{}{
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "NS",
+				Class:  "IN",
+				Name:   "example.com.",
+				Answer: "ns1.example.com.",
+			},
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "NS",
+				Class:  "IN",
+				Name:   "example.com.",
+				Answer: "ns2.example.com.",
+			},
+		},
+		Additional: []interface{}{
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "A",
+				Class:  "IN",
+				Name:   "ns1.example.com.",
+				Answer: "192.0.2.3",
+			},
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "A",
+				Class:  "IN",
+				Name:   "ns2.example.com.",
+				Answer: "192.0.2.4",
+			},
+		},
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+
+	expectedServersMap := make(map[string]minimalServerRecords)
+	expectedServersMap["ns1.example.com"] = minimalServerRecords{
+		IPv4Addresses: []string{"192.0.2.3"},
+		IPv6Addresses: nil,
+	}
+	expectedServersMap["ns2.example.com"] = minimalServerRecords{
+		IPv4Addresses: []string{"192.0.2.4"},
+		IPv6Addresses: nil,
+	}
+	res, _, _, _ := l.DoLookup("example.com", "")
+	verifyResult(t, res.(Result).Servers, expectedServersMap)
+}
+
+func TestAandQuadAInAdditional(t *testing.T) {
+	_, glf, _, l := InitTest(t)
+	glf.IPv4Lookup = true
+	glf.IPv6Lookup = true
+
+	nsRecords["example.com"] = miekg.Result{
+		Answers: []interface{}{
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "NS",
+				Class:  "IN",
+				Name:   "example.com.",
+				Answer: "ns1.example.com.",
+			},
+		},
+		Additional: []interface{}{
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "A",
+				Class:  "IN",
+				Name:   "ns1.example.com.",
+				Answer: "192.0.2.3",
+			},
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "AAAA",
+				Class:  "IN",
+				Name:   "ns1.example.com.",
+				Answer: "2001:db8::4",
+			},
+		},
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+
+	expectedServersMap := make(map[string]minimalServerRecords)
+	expectedServersMap["ns1.example.com"] = minimalServerRecords{
+		IPv4Addresses: []string{"192.0.2.3"},
+		IPv6Addresses: []string{"2001:db8::4"},
+	}
+	res, _, _, _ := l.DoLookup("example.com", "")
+	verifyResult(t, res.(Result).Servers, expectedServersMap)
+}
+
+func TestMismatchIpType(t *testing.T) {
+	_, glf, _, l := InitTest(t)
+	glf.IPv4Lookup = true
+	glf.IPv6Lookup = true
+
+	nsRecords["example.com"] = miekg.Result{
+		Answers: []interface{}{
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "NS",
+				Class:  "IN",
+				Name:   "example.com.",
+				Answer: "ns1.example.com.",
+			},
+		},
+		Additional: []interface{}{
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "AAAA",
+				Class:  "IN",
+				Name:   "ns1.example.com.",
+				Answer: "192.0.2.3",
+			},
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "A",
+				Class:  "IN",
+				Name:   "ns1.example.com.",
+				Answer: "2001:db8::4",
+			},
+		},
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+
+	expectedServersMap := make(map[string]minimalServerRecords)
+	expectedServersMap["ns1.example.com"] = minimalServerRecords{
+		IPv4Addresses: nil,
+		IPv6Addresses: nil,
+	}
+	res, _, _, _ := l.DoLookup("example.com", "")
+	verifyResult(t, res.(Result).Servers, expectedServersMap)
+}
+
+func TestAandQuadALookup(t *testing.T) {
+	_, glf, _, l := InitTest(t)
+	glf.IPv4Lookup = true
+	glf.IPv6Lookup = true
+
+	nsRecords["example.com"] = miekg.Result{
+		Answers: []interface{}{
+			miekg.Answer{
+				Ttl:    3600,
+				Type:   "NS",
+				Class:  "IN",
+				Name:   "example.com.",
+				Answer: "ns1.example.com.",
+			},
+		},
+		Additional:  nil,
+		Authorities: nil,
+		Protocol:    "",
+		Flags:       miekg.DNSFlags{},
+	}
+	mockResults["ns1.example.com"] = miekg.IpResult{
+		IPv4Addresses: []string{"192.0.2.3"},
+		IPv6Addresses: []string{"2001:db8::4"},
+	}
+	expectedServersMap := make(map[string]minimalServerRecords)
+	expectedServersMap["ns1.example.com"] = minimalServerRecords{
+		IPv4Addresses: []string{"192.0.2.3"},
+		IPv6Addresses: []string{"2001:db8::4"},
+	}
+	res, _, _, _ := l.DoLookup("example.com", "")
+	verifyResult(t, res.(Result).Servers, expectedServersMap)
+}
+
+func TestNXDomain(t *testing.T) {
+	_, glf, _, l := InitTest(t)
+	glf.IPv4Lookup = true
+	_, _, status, _ := l.DoLookup("nonexistent.example.com", "")
+	if status != zdns.STATUS_NXDOMAIN {
+		t.Errorf("Expected STATUS_NXDOMAIN status, got %v", status)
+	}
+}
+
+func verifyResult(t *testing.T, servers []NSRecord, expectedServersMap map[string]minimalServerRecords) {
+	serversLength := len(servers)
+	expectedServersLength := len(expectedServersMap)
+
+	if serversLength != expectedServersLength {
+		t.Errorf("Expected %v servers, found %v", expectedServersLength, serversLength)
+	}
+
+	for _, server := range servers {
+		name := server.Name
+		expectedRecords, ok := expectedServersMap[name]
+		if !ok {
+			t.Errorf("Did not find server %v in expected servers.", name)
+		}
+		if !reflect.DeepEqual(server.IPv4Addresses, expectedRecords.IPv4Addresses) {
+			t.Errorf("IPv4 addresses not matching for %v, expected %v, found %v", name, expectedRecords.IPv4Addresses, server.IPv4Addresses)
+		}
+		if !reflect.DeepEqual(server.IPv6Addresses, expectedRecords.IPv6Addresses) {
+			t.Errorf("IPv6 addresses not matching for %v, expected %v, found %v", name, expectedRecords.IPv6Addresses, server.IPv6Addresses)
+		}
+	}
+}


### PR DESCRIPTION
This diff does the following

- Adds support for following CNAME paths recursively in NS lookups to get IPs
- Verification of IP address and type match in Additionals section.
- Adds UTs for nslookup