### PR TITLE
Copyright Header Enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ jobs:
   check-license:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       # TODO (spencer): possibly fail if this condition is not met.
       - name: Check for ZDNS License Header
         run: |
@@ -12,7 +14,7 @@ jobs:
             echo 'FOUND .go FILES WITHOUT HEADERS.'
             echo "$NO_HEADERS_FOUND"
           else
-            echo 'not found'
+            echo 'All .go files in repo have an appropriate header'
           fi
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      # TODO (spencer): possibly fail if this condition is not met.
       - name: Check for ZDNS License Header
         run: |
           export NO_HEADERS_FOUND=$(grep -RiL --include="*.go" "ZDNS Copyright .* Regents of the University of Michigan" ./)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,19 @@
 name: CI
 on: [ push, pull_request ]
 jobs:
+  check-license:
+    runs-on: ubuntu-latest
+    steps:
+      # TODO (spencer): possibly fail if this condition is not met.
+      - name: Check for ZDNS License Header
+        run: |
+          export NO_HEADERS_FOUND=$(grep -RiL --include="*.go" "ZDNS Copyright .* Regents of the University of Michigan" ./)
+          if test -n "$NO_HEADERS_FOUND"; then
+            echo 'FOUND .go FILES WITHOUT HEADERS.'
+            echo "$NO_HEADERS_FOUND"
+          else
+            echo 'not found'
+          fi
   build-and-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           if test -n "$NO_HEADERS_FOUND"; then
             echo 'FOUND .go FILES WITHOUT HEADERS.'
             echo "$NO_HEADERS_FOUND"
+            exit 1
           else
             echo 'All .go files in repo have an appropriate header'
           fi

--- a/cachehash/cachehash.go
+++ b/cachehash/cachehash.go
@@ -1,5 +1,5 @@
 /*
- * ZGrab Copyright 2015 Regents of the University of Michigan
+ * ZDNS Copyright 2022 Regents of the University of Michigan
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/cachehash/cachehash_test.go
+++ b/cachehash/cachehash_test.go
@@ -1,5 +1,5 @@
 /*
- * ZGrab Copyright 2015 Regents of the University of Michigan
+ * ZDNS Copyright 2022 Regents of the University of Michigan
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/cachehash/shardedcachehash.go
+++ b/cachehash/shardedcachehash.go
@@ -1,5 +1,5 @@
 /*
- * ZGrab Copyright 2015 Regents of the University of Michigan
+ * ZDNS Copyright 2022 Regents of the University of Michigan
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/cmd/alookup.go
+++ b/cmd/alookup.go
@@ -1,3 +1,16 @@
+/*
+ * ZDNS Copyright 2016 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package cmd
 
 import (

--- a/cmd/alookup.go
+++ b/cmd/alookup.go
@@ -1,16 +1,3 @@
-/*
- * ZDNS Copyright 2016 Regents of the University of Michigan
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy
- * of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
 package cmd
 
 import (

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,3 +1,17 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package util
 
 import (

--- a/iohandlers/filehandlers.go
+++ b/iohandlers/filehandlers.go
@@ -1,3 +1,17 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package iohandlers
 
 import (

--- a/iohandlers/streamhandlers.go
+++ b/iohandlers/streamhandlers.go
@@ -1,3 +1,17 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package iohandlers
 
 import (

--- a/pkg/bindversion/bindversion_test.go
+++ b/pkg/bindversion/bindversion_test.go
@@ -1,11 +1,26 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package bindversion
 
 import (
+	"testing"
+
 	"github.com/zmap/dns"
 	"github.com/zmap/zdns/pkg/miekg"
 	"github.com/zmap/zdns/pkg/zdns"
 	"gotest.tools/v3/assert"
-	"testing"
 )
 
 type QueryRecord struct {

--- a/pkg/dmarc/dmarc_test.go
+++ b/pkg/dmarc/dmarc_test.go
@@ -1,11 +1,26 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package dmarc
 
 import (
+	"testing"
+
 	"github.com/zmap/dns"
 	"github.com/zmap/zdns/pkg/miekg"
 	"github.com/zmap/zdns/pkg/zdns"
 	"gotest.tools/v3/assert"
-	"testing"
 )
 
 type QueryRecord struct {

--- a/pkg/miekg/answers.go
+++ b/pkg/miekg/answers.go
@@ -1,3 +1,17 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package miekg
 
 import (

--- a/pkg/miekg/cache.go
+++ b/pkg/miekg/cache.go
@@ -1,3 +1,17 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package miekg
 
 import (

--- a/pkg/miekg/miekg.go
+++ b/pkg/miekg/miekg.go
@@ -1,3 +1,17 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package miekg
 
 import (

--- a/pkg/miekg/miekg_test.go
+++ b/pkg/miekg/miekg_test.go
@@ -1,3 +1,16 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package miekg
 
 import (

--- a/pkg/miekg/modules.go
+++ b/pkg/miekg/modules.go
@@ -1,3 +1,17 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package miekg
 
 import (

--- a/pkg/miekg/util.go
+++ b/pkg/miekg/util.go
@@ -1,3 +1,17 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package miekg
 
 import (

--- a/pkg/nslookup/nslookup_test.go
+++ b/pkg/nslookup/nslookup_test.go
@@ -1,3 +1,17 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package nslookup
 
 import (

--- a/pkg/spf/spf_test.go
+++ b/pkg/spf/spf_test.go
@@ -1,11 +1,26 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package spf
 
 import (
+	"testing"
+
 	"github.com/zmap/dns"
 	"github.com/zmap/zdns/pkg/miekg"
 	"github.com/zmap/zdns/pkg/zdns"
 	"gotest.tools/v3/assert"
-	"testing"
 )
 
 type QueryRecord struct {


### PR DESCRIPTION
This PR does three things:

- Adds a copyright header to each file that did not have one
- Updates Zgrab in the header of caching files to ZDNS for consistency
- Add a GitHub Actions job to check for the copyright on each new push/pr

The GitHub action uses the regex `"ZDNS Copyright .* Regents of the University of Michigan"` and looks in all Go source files. If it find source files that don't match the regex, then it fails the build.