### PR TITLE
Fix all ns mode

### DIFF
--- a/pkg/miekg/miekg.go
+++ b/pkg/miekg/miekg.go
@@ -945,7 +945,8 @@ func (s *Lookup) DoLookupAllNameservers(l LookupClient, name, nameServer string)
 	for _, nserver := range nsResults.Servers {
 		// Use all the ipv4 and ipv6 addresses of each nameserver
 		nameserver := nserver.Name
-		ips := append(nserver.IPv4Addresses, nserver.IPv6Addresses...)
+		// TODO(#304): Figure out how to lookup via IPv6 addresses as well
+		ips := nserver.IPv4Addresses
 		for _, ip := range ips {
 			curServer = net.JoinHostPort(ip, "53")
 			res, trace, status, _ := l.ProtocolLookup(s, Question{Name: name, Type: s.DNSType, Class: s.DNSClass}, curServer)

--- a/pkg/miekg/miekg.go
+++ b/pkg/miekg/miekg.go
@@ -214,14 +214,14 @@ func (s *RoutineLookupFactory) Initialize(c *zdns.GlobalConf) {
 			LocalAddr: &net.UDPAddr{IP: s.LocalAddr},
 		}
 		if c.RecycleSockets {
-		    // create PacketConn for use throughout thread's life
-		    conn, err := net.ListenUDP("udp", &net.UDPAddr{s.LocalAddr, 0, ""})
-		    if err != nil {
-		        log.Fatal("unable to create socket", err)
-		    }
-		    s.Conn = new(dns.Conn)
-		    s.Conn.Conn = conn
-	    }
+			// create PacketConn for use throughout thread's life
+			conn, err := net.ListenUDP("udp", &net.UDPAddr{s.LocalAddr, 0, ""})
+			if err != nil {
+				log.Fatal("unable to create socket", err)
+			}
+			s.Conn = new(dns.Conn)
+			s.Conn.Conn = conn
+		}
 	}
 	if !c.UDPOnly {
 		s.TCPClient = new(dns.Client)
@@ -320,10 +320,10 @@ func DoLookupWorker(udp *dns.Client, tcp *dns.Client, conn *dns.Conn, q Question
 	if udp != nil {
 		res.Protocol = "udp"
 		if conn != nil {
-		    dst, _ := net.ResolveUDPAddr("udp", nameServer)
-		    r, _, err = udp.ExchangeWithConnTo(m, conn, dst)
+			dst, _ := net.ResolveUDPAddr("udp", nameServer)
+			r, _, err = udp.ExchangeWithConnTo(m, conn, dst)
 		} else {
-		    r, _, err = udp.Exchange(m, nameServer)
+			r, _, err = udp.Exchange(m, nameServer)
 		}
 		// if record comes back truncated, but we have a TCP connection, try again with that
 		if r != nil && (r.Truncated || r.Rcode == dns.RcodeBadTrunc) {
@@ -809,6 +809,7 @@ func (s *Lookup) DoIpsLookup(lc LookupClient, name string, nameServer string, dn
 }
 
 func (s *Lookup) DoTargetedLookup(l LookupClient, name, nameServer string, lookupIpv4 bool, lookupIpv6 bool) (interface{}, []interface{}, zdns.Status, error) {
+	name = strings.ToLower(name)
 	res := IpResult{}
 	candidateSet := map[string][]Answer{}
 	cnameSet := map[string][]Answer{}

--- a/pkg/miekg/miekg_test.go
+++ b/pkg/miekg/miekg_test.go
@@ -940,7 +940,9 @@ func TestErrorInTargetedLookup(t *testing.T) {
 	assert.Equal(t, status, protocolStatus[domain_ns_1])
 }
 
-// Test One NS with one IP with only ipv4-lookup
+// Test One NS with one IP with only ipv4-lookup. Note that
+// currently we do lookup only via IPv4 NS addresses and hence
+// IPv6 NS addresses are ignored.
 func TestAllNsLookupOneNs(t *testing.T) {
 	gc, a, mc := InitTest(t)
 
@@ -1001,35 +1003,11 @@ func TestAllNsLookupOneNs(t *testing.T) {
 		Flags:       DNSFlags{},
 	}
 
-	ns3 := net.JoinHostPort(ipv6_1, "53")
-	domain_ns_3 := domain_ns{domain: domain1, ns: ns3}
-	ipv4_3 := "192.0.2.2"
-	mockResults[domain_ns_3] = Result{
-		Answers: []interface{}{
-			Answer{
-				Ttl:    3600,
-				Type:   "A",
-				Class:  "IN",
-				Name:   "example.com.",
-				Answer: ipv4_3,
-			},
-		},
-		Additional:  nil,
-		Authorities: nil,
-		Protocol:    "",
-		Flags:       DNSFlags{},
-	}
-
 	expectedRes := []ExtendedResult{
 		{
 			Nameserver: ns_domain1,
 			Status:     zdns.STATUS_NOERROR,
 			Res:        mockResults[domain_ns_2],
-		},
-		{
-			Nameserver: ns_domain1,
-			Status:     zdns.STATUS_NOERROR,
-			Res:        mockResults[domain_ns_3],
 		},
 	}
 


### PR DESCRIPTION
This diff does the following.

- Updates the all-nameservers mode to lookup only via IPv4 nameserver addresses.
- Adds a TODO to add lookup via IPv6 NS once that is figured out.

Test:

```
» echo "google.com" | ./zdns A --retries=10 --all-nameservers  | python -m json.tool
{
    "data": {
        "results": [
            {
                "nameserver": "ns4.google.com",
                "result": {
                    "answers": [
                        {
                            "answer": "142.251.32.46",
                            "class": "IN",
                            "name": "google.com",
                            "ttl": 300,
                            "type": "A"
                        }
                    ],
                    "protocol": "udp",
                    "resolver": "216.239.38.10:53"
                },
                "status": "NOERROR"
            },
            {
                "nameserver": "ns3.google.com",
                "result": {
                    "answers": [
                        {
                            "answer": "142.251.32.46",
                            "class": "IN",
                            "name": "google.com",
                            "ttl": 300,
                            "type": "A"
                        }
                    ],
                    "protocol": "udp",
                    "resolver": "216.239.36.10:53"
                },
                "status": "NOERROR"
            },
            {
                "nameserver": "ns1.google.com",
                "result": {
                    "answers": [
                        {
                            "answer": "142.251.32.46",
                            "class": "IN",
                            "name": "google.com",
                            "ttl": 300,
                            "type": "A"
                        }
                    ],
                    "protocol": "udp",
                    "resolver": "216.239.32.10:53"
                },
                "status": "NOERROR"
            },
            {
                "nameserver": "ns2.google.com",
                "result": {
                    "answers": [
                        {
                            "answer": "142.251.32.46",
                            "class": "IN",
                            "name": "google.com",
                            "ttl": 300,
                            "type": "A"
                        }
                    ],
                    "protocol": "udp",
                    "resolver": "216.239.34.10:53"
                },
                "status": "NOERROR"
            }
        ]
    },
    "name": "google.com",
    "status": "NOERROR",
    "timestamp": "2022-04-28T11:38:48-07:00"
}
```