### PR TITLE
Check ulimit on supported plattforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-zdns
 .*
 *.iml
 *.code-workspace

--- a/pkg/zdns/ulimit_check.go
+++ b/pkg/zdns/ulimit_check.go
@@ -1,0 +1,8 @@
+//go:build !linux && !darwin
+// +build !linux,!darwin
+
+package zdns
+
+func ulimit_check(max_open_files uint64) {
+	// fallback for ulimit check on unsupported platform
+}

--- a/pkg/zdns/ulimit_check.go
+++ b/pkg/zdns/ulimit_check.go
@@ -1,6 +1,19 @@
 //go:build !linux && !darwin
 // +build !linux,!darwin
 
+/*
+ * ZDNS Copyright 2020 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package zdns
 
 func ulimit_check(max_open_files uint64) {

--- a/pkg/zdns/ulimit_check_linux.go
+++ b/pkg/zdns/ulimit_check_linux.go
@@ -1,0 +1,30 @@
+//go:build linux || darwin
+// +build linux darwin
+
+package zdns
+
+import (
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func ulimit_check(max_open_files uint64) {
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		log.Fatal("Failed to fetch ulimit ", err)
+	}
+
+	if max_open_files > rLimit.Cur {
+		log.Warn("Current nofile limit (", rLimit.Cur, ") lower than maximum connection count (", max_open_files, "), try to update.")
+
+		rLimit.Max = max_open_files
+		rLimit.Cur = max_open_files
+		err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+		if err != nil {
+			log.Fatal("Error setting nofile limit to ", rLimit.Cur, ": ", err)
+		}
+		log.Info("Updated nofile limit to ", rLimit.Cur)
+	}
+}

--- a/pkg/zdns/ulimit_check_linux.go
+++ b/pkg/zdns/ulimit_check_linux.go
@@ -1,6 +1,19 @@
 //go:build linux || darwin
 // +build linux darwin
 
+/*
+ * ZDNS Copyright 2020 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package zdns
 
 import (

--- a/pkg/zdns/zdns.go
+++ b/pkg/zdns/zdns.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -185,9 +186,32 @@ func Run(gc GlobalConf, flags *pflag.FlagSet,
 	if gc.GoMaxProcs < 0 {
 		log.Fatal("Invalid argument for --go-processes. Must be >1.")
 	}
+
+	var max_open_files uint64
+
 	if gc.GoMaxProcs != 0 {
 		runtime.GOMAXPROCS(gc.GoMaxProcs)
+		max_open_files = uint64(gc.GoMaxProcs * gc.Threads)
+	} else {
+		max_open_files = uint64(runtime.NumCPU() * gc.Threads)
 	}
+
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		log.Fatal("Failed to fetch ulimit ", err)
+	}
+
+	if max_open_files > rLimit.Cur {
+		log.Warn("Current nofile limit (", rLimit.Cur, ") lower than maximum connection count (", max_open_files, "), try to update.")
+		rLimit.Cur = max_open_files
+		err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+		if err != nil {
+			log.Fatal("Error setting nofile limit to ", rLimit.Cur, ": ", err)
+		}
+		log.Info("Update nofile to ", rLimit.Cur)
+	}
+
 	if gc.UDPOnly && gc.TCPOnly {
 		log.Fatal("TCP Only and UDP Only are conflicting")
 	}


### PR DESCRIPTION
Add check if maximum connections of go processes * threads settings exceed ulimit of current session. 
Increase limit if possible. Only added on darwin + linux.