### PR TITLE
add DNAME RR handling

### DIFF
--- a/pkg/miekg/modules.go
+++ b/pkg/miekg/modules.go
@@ -72,6 +72,10 @@ func init() {
 	dhcid.SetDNSType(dns.TypeDHCID)
 	zdns.RegisterLookup("DHCID", dhcid)
 
+	dname := new(GlobalLookupFactory)
+	dname.SetDNSType(dns.TypeDNAME)
+	zdns.RegisterLookup("DNAME", dname)
+
 	dnskey := new(GlobalLookupFactory)
 	dnskey.SetDNSType(dns.TypeDNSKEY)
 	zdns.RegisterLookup("DNSKEY", dnskey)


### PR DESCRIPTION
Add support for DNAME resource records ([RFC 6672](https://www.rfc-editor.org/rfc/rfc6672))

I am not aware of a reliable public record to use in automated tests. I've been using a minimal zone file in a local BIND contrainer:

```
$TTL 604800
@                    IN SOA   localhost. root.localhost. ( 2 604800 86400 2419200 604800 )
                     IN NS    localhost.
example.test.local.  IN DNAME example.com.
example2.test.local. IN CNAME example.net.
```

Query results for
```bash
cat <<EOF | ./zdns dname --name-servers 127.0.0.1:10053
example.test.local
example2.test.local
EOF
```

are

```json
{
  "data": {
    "additionals": [],
    "answers": [
      {
        "answer": "example.com.",
        "class": "IN",
        "name": "example.test.local",
        "ttl": 604800,
        "type": "DNAME"
      }
    ],
    "authorities": [],
    "protocol": "udp",
    "resolver": "127.0.0.1:10053"
  },
  "name": "example.test.local",
  "status": "NOERROR",
  "timestamp": "2022-08-20T11:46:47+02:00"
}
```
```json
{
  "data": {
    "answers": [
      {
        "answer": "example.net.",
        "class": "IN",
        "name": "example2.test.local",
        "ttl": 604800,
        "type": "CNAME"
      }
    ],
    "authorities": [],
    "protocol": "udp",
    "resolver": "127.0.0.1:10053"
  },
  "name": "example2.test.local",
  "status": "NOERROR",
  "timestamp": "2022-08-20T11:46:47+02:00"
}
```

which is equivalent to the results by
```bash
dig DNAME example.test.local @127.0.0.1 -p 10053
dig DNAME example2.test.local @127.0.0.1 -p 10053
```
or
```bash
nslookup -type=dname -port=10053 example.test.local 127.0.0.1
nslookup -type=dname -port=10053 example2.test.local 127.0.0.1
```