### PR TITLE
Fix duplicate IPv4 & IPv6 records in Alookup

### DIFF
--- a/pkg/miekg/miekg.go
+++ b/pkg/miekg/miekg.go
@@ -822,6 +822,7 @@ func (s *Lookup) DoTargetedLookup(l LookupClient, name, nameServer string, looku
 	if lookupIpv4 {
 		ipv4, ipv4Trace, ipv4status, _ = s.DoIpsLookup(l, name, nameServer, dns.TypeA, candidateSet, cnameSet, name, 0)
 		if len(ipv4) > 0 {
+			ipv4 = Unique(ipv4)
 			res.IPv4Addresses = make([]string, len(ipv4))
 			copy(res.IPv4Addresses, ipv4)
 		}
@@ -831,6 +832,7 @@ func (s *Lookup) DoTargetedLookup(l LookupClient, name, nameServer string, looku
 	if lookupIpv6 {
 		ipv6, ipv6Trace, ipv6status, _ = s.DoIpsLookup(l, name, nameServer, dns.TypeAAAA, candidateSet, cnameSet, name, 0)
 		if len(ipv6) > 0 {
+			ipv6 = Unique(ipv6)
 			res.IPv6Addresses = make([]string, len(ipv6))
 			copy(res.IPv6Addresses, ipv6)
 		}

--- a/pkg/miekg/util.go
+++ b/pkg/miekg/util.go
@@ -131,3 +131,16 @@ func VerifyAddress(ansType string, ip string) bool {
 	}
 	return !isIpv4 && !isIpv6
 }
+
+func Unique(a []string) []string {
+	seen := make(map[string]bool)
+	j := 0
+	for _, v := range a {
+		if !seen[v] {
+			seen[v] = true
+			a[j] = v
+			j++
+		}
+	}
+	return a[:j]
+}


### PR DESCRIPTION
This change deduplicates IP addresses returned in the `DoTargetedLookup` function. Fixes #319.
