### PR TITLE
Added --client-subnet for setting EDNS0 option in DNS queries

### DIFF
--- a/cmd/alookup.go
+++ b/cmd/alookup.go
@@ -36,7 +36,7 @@ Specifically, alookup acts similar to nslookup and will follow CNAME records.`,
 			&Timeout, &IterationTimeout,
 			&Class_string, &Servers_string,
 			&Config_file, &Localaddr_string,
-			&Localif_string, &NanoSeconds)
+			&Localif_string, &NanoSeconds, &ClientSubnet_string)
 	},
 }
 

--- a/cmd/mxlookup.go
+++ b/cmd/mxlookup.go
@@ -34,7 +34,7 @@ correspond with an exchange record.`,
 			&Timeout, &IterationTimeout,
 			&Class_string, &Servers_string,
 			&Config_file, &Localaddr_string,
-			&Localif_string, &NanoSeconds)
+			&Localif_string, &NanoSeconds, &ClientSubnet_string)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,16 +27,17 @@ import (
 var cfgFile string
 var GC zdns.GlobalConf
 
-//TODO: these options may need to be set as flags or in GC, to standardize.
+// TODO: these options may need to be set as flags or in GC, to standardize.
 var (
-	Servers_string   string
-	Localaddr_string string
-	Localif_string   string
-	Config_file      string
-	Timeout          int
-	IterationTimeout int
-	Class_string     string
-	NanoSeconds      bool
+	Servers_string      string
+	Localaddr_string    string
+	Localif_string      string
+	Config_file         string
+	Timeout             int
+	IterationTimeout    int
+	Class_string        string
+	NanoSeconds         bool
+	ClientSubnet_string string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -56,7 +57,7 @@ ZDNS also includes its own recursive resolution and a cache to further optimize 
 			&Timeout, &IterationTimeout,
 			&Class_string, &Servers_string,
 			&Config_file, &Localaddr_string,
-			&Localif_string, &NanoSeconds)
+			&Localif_string, &NanoSeconds, &ClientSubnet_string)
 	},
 }
 
@@ -113,6 +114,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&IterationTimeout, "iteration-timeout", 4, "timeout for resolving a single iteration in an iterative query")
 	rootCmd.PersistentFlags().StringVar(&Class_string, "class", "INET", "DNS class to query. Options: INET, CSNET, CHAOS, HESIOD, NONE, ANY. Default: INET.")
 	rootCmd.PersistentFlags().BoolVar(&NanoSeconds, "nanoseconds", false, "Use nanosecond resolution timestamps")
+	rootCmd.PersistentFlags().StringVar(&ClientSubnet_string, "client-subnet", "", "Client subnet in CIDR format for EDNS0.")
 
 	rootCmd.PersistentFlags().Bool("ipv4-lookup", false, "Perform an IPv4 Lookup in modules")
 	rootCmd.PersistentFlags().Bool("ipv6-lookup", false, "Perform an IPv6 Lookup in modules")

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -325,7 +325,49 @@ class Tests(unittest.TestCase):
         "class": "IN",
         "name": "large-text.zdns-testing.com",
         "answer": "We present the scanner architecture, experimentally characterize its performance and accuracy, "
-      }
+      },
+      {
+        "type": "TXT",
+        "class": "IN",
+        "name": "large-text.zdns-testing.com",
+        "answer": "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+      },
+      {
+        "type": "TXT",
+        "class": "IN",
+        "name": "large-text.zdns-testing.com",
+        "answer": "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo."
+      },
+      {
+        "type": "TXT",
+        "class": "IN",
+        "name": "large-text.zdns-testing.com",
+        "answer": "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+      },
+      {
+        "type": "TXT",
+        "class": "IN",
+        "name": "large-text.zdns-testing.com",
+        "answer": "Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt."
+      },
+      {
+        "type": "TXT",
+        "class": "IN",
+        "name": "large-text.zdns-testing.com",
+        "answer": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+      },
+      {
+        "type": "TXT",
+        "class": "IN",
+        "name": "large-text.zdns-testing.com",
+        "answer": "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
+      },
+      {
+        "type": "TXT",
+        "class": "IN",
+        "name": "large-text.zdns-testing.com",
+        "answer": "Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem."
+      },
     ]
 
     WWW_CNAME_ANSWERS = [
@@ -417,7 +459,9 @@ class Tests(unittest.TestCase):
                         obj[k] = v.lower()
                     else:
                         _lowercase(v)
-        self.assertEqual(_lowercase(a), _lowercase(b), helptext)
+        _lowercase(a)
+        _lowercase(b)
+        self.assertEqual(a, b, helptext)
 
     def assertEqualNXDOMAIN(self, res, correct):
         self.assertEqual(res["name"], correct["name"])

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -282,7 +282,7 @@ class Tests(unittest.TestCase):
         }
       }
     }
-
+    
     TCP_LARGE_TXT_ANSWERS = [
       {
         "type": "TXT",
@@ -439,6 +439,12 @@ class Tests(unittest.TestCase):
         "certificate": "0c72ac70b745ac19998811b131d662c9ac69dbdbe7cb23e5b514b56664c5d3d6"
       }
     ]
+
+    EDNS0_MAPPINGS = {
+        "171.67.68.0/24": "2.3.4.5",
+        "131.159.92.0/24": "3.4.5.6",
+        "129.127.149.0/24": "1.2.3.4"
+    }
 
     def assertSuccess(self, res, cmd):
         self.assertEqual(res["status"], "NOERROR", cmd)
@@ -869,6 +875,14 @@ class Tests(unittest.TestCase):
         name = "zdns-testing.com"
         self.run_zdns_check_failure(c, name, "Both --local-addr and --local-interface specified.")
 
-
+    def test_edns0_client_subnet(self):
+        name = "ecs-geo.zdns-testing.com"
+        for subnet, ip_addr in self.EDNS0_MAPPINGS.items():
+            c = f"A --client-subnet {subnet}"
+            cmd, res = self.run_zdns(c, name)
+            self.assertSuccess(res, cmd)
+            correct = [{"type":"A", "class":"IN", "answer": ip_addr, "name":"ecs-geo.zdns-testing.com"}]
+            self.assertEqualAnswers(res, correct, cmd)
+ 
 if __name__ == "__main__":
     unittest.main()

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -869,7 +869,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(res["data"]["resolver"], "8.8.8.8:53")
         self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd)
 
-
     def test_local_addr_interface_warning(self):
         c = "A --local-addr 192.168.1.5 --local-interface en0"
         name = "zdns-testing.com"
@@ -878,7 +877,8 @@ class Tests(unittest.TestCase):
     def test_edns0_client_subnet(self):
         name = "ecs-geo.zdns-testing.com"
         for subnet, ip_addr in self.EDNS0_MAPPINGS.items():
-            c = f"A --client-subnet {subnet}"
+            # Hardcoding a name server that supports ECS; Github's default recursive does not.
+            c = f"A --client-subnet {subnet} --name-servers=8.8.8.8:53"
             cmd, res = self.run_zdns(c, name)
             self.assertSuccess(res, cmd)
             correct = [{"type":"A", "class":"IN", "answer": ip_addr, "name":"ecs-geo.zdns-testing.com"}]

--- a/pkg/zdns/conf.go
+++ b/pkg/zdns/conf.go
@@ -17,6 +17,8 @@ package zdns
 import (
 	"net"
 	"time"
+
+	"github.com/zmap/dns"
 )
 
 type GlobalConf struct {
@@ -47,6 +49,7 @@ type GlobalConf struct {
 	RecycleSockets       bool
 	LocalAddrSpecified   bool
 	LocalAddrs           []net.IP
+	ClientSubnet         *dns.EDNS0_SUBNET
 
 	InputHandler  InputHandler
 	OutputHandler OutputHandler


### PR DESCRIPTION
You can pass now `--client-subnet` and specify EDNS0 client subnet (RFC 7871)