### PR TITLE
fix and complete nsec(3) answer

### DIFF
--- a/pkg/miekg/answers.go
+++ b/pkg/miekg/answers.go
@@ -134,6 +134,8 @@ type NSEC3Answer struct {
 	Flags         uint8  `json:"flags" groups:"short,normal,long,trace"`
 	Iterations    uint16 `json:"iterations" groups:"short,normal,long,trace"`
 	Salt          string `json:"salt" groups:"short,normal,long,trace"`
+	NextDomain    string `json:"next_domain" groups:"short,normal,long,trace"`
+	TypeBitMap    string `json:"type_bit_map" groups:"short,normal,long,trace"`
 }
 
 type NSEC3ParamAnswer struct {
@@ -389,7 +391,7 @@ func sprintTxtOctet(s string) string {
 func makeBitString(bm []uint16) string {
 	retv := ""
 	for _, v := range bm {
-		retv += strconv.Itoa(int(v))
+		retv += dns.Type(v).String()
 	}
 	return retv
 }
@@ -645,6 +647,8 @@ func ParseAnswer(ans dns.RR) interface{} {
 			Flags:         cAns.Flags,
 			Iterations:    cAns.Iterations,
 			Salt:          cAns.Salt,
+			NextDomain:    cAns.NextDomain,
+			TypeBitMap:    makeBitString(cAns.TypeBitMap),
 		}
 	case *dns.NSEC3PARAM:
 		return NSEC3Answer{

--- a/pkg/miekg/answers.go
+++ b/pkg/miekg/answers.go
@@ -391,7 +391,11 @@ func sprintTxtOctet(s string) string {
 func makeBitString(bm []uint16) string {
 	retv := ""
 	for _, v := range bm {
-		retv += dns.Type(v).String()
+		if retv == "" {
+			retv += dns.Type(v).String()
+		} else {
+			retv += " " + dns.Type(v).String()
+		}
 	}
 	return retv
 }

--- a/pkg/miekg/miekg_test.go
+++ b/pkg/miekg/miekg_test.go
@@ -1689,6 +1689,73 @@ func TestParseAnswer(t *testing.T) {
 	}
 	res = ParseAnswer(rr)
 	verifyAnswer(t, res, rr, "example.com\t3600\tIN\tSPF\t\"v=spf1 mx include:_spf.google.com -all\"")
+
+	// NSEC record
+	rr = &dns.NSEC{
+		Hdr: dns.RR_Header{
+			Name:     "example.com",
+			Rrtype:   dns.TypeNSEC,
+			Class:    dns.ClassINET,
+			Ttl:      3600,
+			Rdlength: 0,
+		},
+		NextDomain: "www.example.com.",
+		TypeBitMap: []uint16{dns.TypeRRSIG, dns.TypeNSEC, dns.TypeDNSKEY},
+	}
+	res = ParseAnswer(rr)
+	nsecAnswer, ok := res.(NSECAnswer)
+	if !ok {
+		t.Error("Failed to parse NSEC record")
+		return
+	}
+	verifyAnswer(t, nsecAnswer.Answer, rr, "")
+	if nsecAnswer.NextDomain != "www.example.com" {
+		t.Errorf("Unexpected NSEC NextDomain. Expected %v, got %v", "www.example.com", nsecAnswer.NextDomain)
+	}
+	if nsecAnswer.TypeBitMap != "RRSIG NSEC DNSKEY" {
+		t.Errorf("Unexpected NSEC TypeBitMap. Expected %v, got %v", "RRSIG NSEC DNSKEY", nsecAnswer.TypeBitMap)
+	}
+
+	// NSEC3 record
+	rr = &dns.NSEC3{
+		Hdr: dns.RR_Header{
+			Name:     "onib9mgub9h0rml3cdf5bgrj59dkjhvk.example.com", // example.com
+			Rrtype:   dns.TypeNSEC3,
+			Class:    dns.ClassINET,
+			Ttl:      3600,
+			Rdlength: 0,
+		},
+		Hash: 1,
+		Flags: 0,
+		Iterations: 0,
+		Salt: "",
+		NextDomain: "MIFDNDT3NFF3OD53O7TLA1HRFF95JKUK", // www.example.com
+		TypeBitMap: []uint16{dns.TypeA, dns.TypeRRSIG},
+	}
+	res = ParseAnswer(rr)
+	nsec3Answer, ok := res.(NSEC3Answer)
+	if !ok {
+		t.Error("Failed to parse NSEC3 record")
+	}
+	verifyAnswer(t, nsec3Answer.Answer, rr, "")
+	if nsec3Answer.HashAlgorithm != 1 {
+		t.Errorf("Unexpected NSEC3 HashAlgorithm. Expected %v, got %v", 1, nsec3Answer.HashAlgorithm)
+	}
+	if nsec3Answer.Flags != 0 {
+		t.Errorf("Unexpected NSEC3 Flags. Expected %v, got %v", 0, nsec3Answer.Flags)
+	}
+	if nsec3Answer.Iterations != 0 {
+		t.Errorf("Unexpected NSEC3 Iterations. Expected %v, got %v", 0, nsec3Answer.Iterations)
+	}
+	if nsec3Answer.Salt != "" {
+		t.Errorf("Unexpected NSEC3 Salt. Expected %v, got %v", "", nsec3Answer.Salt)
+	}
+	if nsec3Answer.NextDomain != "MIFDNDT3NFF3OD53O7TLA1HRFF95JKUK" {
+		t.Errorf("Unexpected NSEC3 NextDomain. Expected %v, got %v", "MIFDNDT3NFF3OD53O7TLA1HRFF95JKUK", nsec3Answer.NextDomain)
+	}
+	if nsec3Answer.TypeBitMap != "A RRSIG" {
+		t.Errorf("Unexpected NSEC3 TypeBitMap. Expected %v, got %v", "A RRSIG", nsec3Answer.TypeBitMap)
+	}
 }
 
 func verifyAnswer(t *testing.T, answer interface{}, original dns.RR, expectedAnswer interface{}) {


### PR DESCRIPTION
fixes type_bit_map parsing (int to string), example:
echo se. | ./zdns NSEC | jq .

completes nsec3 answer with missing next_domain and type_bit_map, example:
echo ch. | ./zdns NSEC3 | jq .