### PR TITLE
enable EDNS0; Add --dnssec option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,6 +115,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&Class_string, "class", "INET", "DNS class to query. Options: INET, CSNET, CHAOS, HESIOD, NONE, ANY. Default: INET.")
 	rootCmd.PersistentFlags().BoolVar(&NanoSeconds, "nanoseconds", false, "Use nanosecond resolution timestamps")
 	rootCmd.PersistentFlags().StringVar(&ClientSubnet_string, "client-subnet", "", "Client subnet in CIDR format for EDNS0.")
+	rootCmd.PersistentFlags().BoolVar(&GC.Dnssec, "dnssec", false, "Requests DNSSEC records by setting the DNSSEC OK (DO) bit")
 
 	rootCmd.PersistentFlags().Bool("ipv4-lookup", false, "Perform an IPv4 Lookup in modules")
 	rootCmd.PersistentFlags().Bool("ipv6-lookup", false, "Perform an IPv6 Lookup in modules")

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -440,7 +440,7 @@ class Tests(unittest.TestCase):
       }
     ]
 
-    EDNS0_MAPPINGS = {
+    ECS_MAPPINGS = {
         "171.67.68.0/24": "2.3.4.5",
         "131.159.92.0/24": "3.4.5.6",
         "129.127.149.0/24": "1.2.3.4"
@@ -876,7 +876,7 @@ class Tests(unittest.TestCase):
 
     def test_edns0_client_subnet(self):
         name = "ecs-geo.zdns-testing.com"
-        for subnet, ip_addr in self.EDNS0_MAPPINGS.items():
+        for subnet, ip_addr in self.ECS_MAPPINGS.items():
             # Hardcoding a name server that supports ECS; Github's default recursive does not.
             c = f"A --client-subnet {subnet} --name-servers=8.8.8.8:53"
             cmd, res = self.run_zdns(c, name)

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -501,6 +501,12 @@ class Tests(unittest.TestCase):
             del server["ttl"]
         self.assertEqual(recursiveSort(res["data"]["servers"]), recursiveSort(correct["data"]["servers"]))
 
+    def assertEqualTypes(self, res, list):
+        res_types = set()
+        for rr in res["data"]["answers"]:
+            res_types.add(rr["type"])
+        self.assertEqual(sorted(res_types), sorted(list))
+
     def check_json_in_list(self, json_obj, list):
         for obj in list:
             if json_obj == obj:
@@ -883,6 +889,14 @@ class Tests(unittest.TestCase):
             self.assertSuccess(res, cmd)
             correct = [{"type":"A", "class":"IN", "answer": ip_addr, "name":"ecs-geo.zdns-testing.com"}]
             self.assertEqualAnswers(res, correct, cmd)
+
+    def test_dnssec_response(self):
+        # checks if dnssec records are returned
+        c = f"SOA --dnssec --name-servers=8.8.8.8:53"
+        name = "."
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd)
+        self.assertEqualTypes(res, ["SOA", "RRSIG"])
  
 if __name__ == "__main__":
     unittest.main()

--- a/pkg/miekg/answers.go
+++ b/pkg/miekg/answers.go
@@ -71,6 +71,14 @@ type DSAnswer struct {
 	DigestType uint8  `json:"digest_type" groups:"short,normal,long,trace"`
 	Digest     string `json:"digest" groups:"short,normal,long,trace"`
 }
+
+type EDNSAnswer struct {
+	Type    string `json:"type" groups:"short,normal,long,trace"`
+	Version uint8  `json:"version" groups:"short,normal,long,trace"`
+	Flags   string `json:"flags" groups:"short,normal,long,trace"`
+	UDPSize uint16 `json:"udp_size" groups:"short,normal,long,trace"`
+}
+
 type GPOSAnswer struct {
 	Answer
 	Longitude string `json:"preference" groups:"short,normal,long,trace"`
@@ -452,6 +460,23 @@ func makeSVCBAnswer(cAns *dns.SVCB) SVCBAnswer {
 	}
 }
 
+func makeEDNSAnswer(cAns *dns.OPT) EDNSAnswer {
+	opttype := "EDNS"
+	flags := ""
+	if cAns.Do() {
+		flags = "do"
+	}
+	return EDNSAnswer{
+		Type:       opttype + strconv.Itoa(int(cAns.Version())),
+		Version:    cAns.Version(),
+		// RCODE omitted for now as no EDNS0 extension is supported in
+		// lookups for which an RCODE is defined.
+		//Rcode:      dns.RcodeToString[cAns.ExtendedRcode()],
+		Flags:      flags,
+		UDPSize:    cAns.UDPSize(),
+	}
+}
+
 func ParseAnswer(ans dns.RR) interface{} {
 	switch cAns := ans.(type) {
 	// Prioritize common types in expected order
@@ -797,9 +822,7 @@ func ParseAnswer(ans dns.RR) interface{} {
 	case *dns.SVCB:
 		return makeSVCBAnswer(cAns)
 	case *dns.OPT:
-		// ignore OPT pseudo-RR in response for now
-		// TODO parse if needed
-		return nil
+		return makeEDNSAnswer(cAns)
 	default:
 		return struct {
 			Type     string `json:"type"`

--- a/pkg/miekg/answers.go
+++ b/pkg/miekg/answers.go
@@ -796,6 +796,10 @@ func ParseAnswer(ans dns.RR) interface{} {
 		return makeSVCBAnswer(&cAns.SVCB)
 	case *dns.SVCB:
 		return makeSVCBAnswer(cAns)
+	case *dns.OPT:
+		// ignore OPT pseudo-RR in response for now
+		// TODO parse if needed
+		return nil
 	default:
 		return struct {
 			Type     string `json:"type"`

--- a/pkg/miekg/answers.go
+++ b/pkg/miekg/answers.go
@@ -76,7 +76,7 @@ type EDNSAnswer struct {
 	Type    string `json:"type" groups:"short,normal,long,trace"`
 	Version uint8  `json:"version" groups:"short,normal,long,trace"`
 	Flags   string `json:"flags" groups:"short,normal,long,trace"`
-	UDPSize uint16 `json:"udp_size" groups:"short,normal,long,trace"`
+	UDPSize uint16 `json:"udpsize" groups:"short,normal,long,trace"`
 }
 
 type GPOSAnswer struct {

--- a/pkg/miekg/miekg_test.go
+++ b/pkg/miekg/miekg_test.go
@@ -1756,6 +1756,30 @@ func TestParseAnswer(t *testing.T) {
 	if nsec3Answer.TypeBitMap != "A RRSIG" {
 		t.Errorf("Unexpected NSEC3 TypeBitMap. Expected %v, got %v", "A RRSIG", nsec3Answer.TypeBitMap)
 	}
+
+	// OPT record
+	rr = &dns.OPT{
+		Hdr: dns.RR_Header{
+			Name:     ".",
+			Rrtype:   dns.TypeOPT,
+			Class:    1232,
+		},
+	}
+	res = ParseAnswer(rr)
+	ednsAnswer, ok := res.(EDNSAnswer)
+	if !ok {
+		t.Error("Failed to parse OPT record")
+		return
+	}
+	if ednsAnswer.Version != 0 {
+		t.Errorf("Unexpected EDNS Version. Expected %v, got %v", 0, ednsAnswer.Version)
+	}
+	if ednsAnswer.UDPSize != 1232 {
+		t.Errorf("Unexpected EDNS UDP Size. Expected %v, got %v", 0, ednsAnswer.UDPSize)
+	}
+	if ednsAnswer.Flags != "" {
+		t.Errorf("Unexpected EDNS Flags. Expected %v, got %v", 0, ednsAnswer.Flags)
+	}
 }
 
 func verifyAnswer(t *testing.T, answer interface{}, original dns.RR, expectedAnswer interface{}) {

--- a/pkg/zdns/conf.go
+++ b/pkg/zdns/conf.go
@@ -50,6 +50,7 @@ type GlobalConf struct {
 	LocalAddrSpecified   bool
 	LocalAddrs           []net.IP
 	ClientSubnet         *dns.EDNS0_SUBNET
+	Dnssec               bool
 
 	InputHandler  InputHandler
 	OutputHandler OutputHandler


### PR DESCRIPTION
This pull request enables EDNS0 by default with an UDP Size of 1232. This should improve performance slightly as fewer truncated answers are to be expected and so less retries over TCP are required.

It also add the command-line option `--dnssec` for those who want/need DNSSEC records in the answer.

This should resolve the issues:
- https://github.com/zmap/zdns/issues/318
- https://github.com/zmap/zdns/issues/220

It should also make the following pull request obsolete:
- https://github.com/zmap/zdns/pull/221

Note:
- I did not implement OPT pseude-RR parsing and left a TODO. Can be implemented later if someone needs this.
- I noticed that NXDOMAIN responses do not return the SOA record in the authority section. Likewise, no additional DNSSEC records are returned if the `--dnssec` option is used. I guess there is some code which already filters this out. As this pull request does not change the existing behaviour, I did not attempt to change this.