### PR TITLE
Ulimit check is incorrect

### DIFF
--- a/pkg/zdns/ulimit_check.go
+++ b/pkg/zdns/ulimit_check.go
@@ -22,18 +22,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func ulimit_check(max_open_files uint64) {
+func ulimitCheck(maxOpenFiles uint64) {
 	var rLimit syscall.Rlimit
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	if err != nil {
 		log.Fatal("Failed to fetch ulimit ", err)
 	}
 
-	if max_open_files > rLimit.Cur {
-		log.Warn("Current nofile limit (", rLimit.Cur, ") lower than maximum connection count (", max_open_files, "), trying to update.")
+	if maxOpenFiles > rLimit.Cur {
+		log.Warn("Current nofile limit (", rLimit.Cur, ") lower than maximum connection count (", maxOpenFiles, "), trying to update.")
 
-		rLimit.Max = max_open_files
-		rLimit.Cur = max_open_files
+		rLimit.Max = maxOpenFiles
+		rLimit.Cur = maxOpenFiles
 		err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 		if err != nil {
 			log.Fatal("Error setting nofile limit to ", rLimit.Cur, ": ", err)

--- a/pkg/zdns/ulimit_check.go
+++ b/pkg/zdns/ulimit_check.go
@@ -30,7 +30,7 @@ func ulimit_check(max_open_files uint64) {
 	}
 
 	if max_open_files > rLimit.Cur {
-		log.Warn("Current nofile limit (", rLimit.Cur, ") lower than maximum connection count (", max_open_files, "), try to update.")
+		log.Warn("Current nofile limit (", rLimit.Cur, ") lower than maximum connection count (", max_open_files, "), trying to update.")
 
 		rLimit.Max = max_open_files
 		rLimit.Cur = max_open_files

--- a/pkg/zdns/ulimit_check_unknown.go
+++ b/pkg/zdns/ulimit_check_unknown.go
@@ -16,6 +16,6 @@
  */
 package zdns
 
-func ulimit_check(max_open_files uint64) {
+func ulimitCheck(maxOpenFiles uint64) {
 	// fallback for ulimit check on unsupported platform
 }

--- a/pkg/zdns/zdns.go
+++ b/pkg/zdns/zdns.go
@@ -203,6 +203,10 @@ func Run(gc GlobalConf, flags *pflag.FlagSet,
 			log.Fatal("Unable to find default IP address: ", err)
 		} else {
 			gc.LocalAddrs = append(gc.LocalAddrs, conn.LocalAddr().(*net.UDPAddr).IP)
+			err := conn.Close()
+			if err != nil {
+				log.Warn("Unable to close test connection to Google Public DNS: ", err)
+			}
 		}
 	}
 	if *nanoSeconds {

--- a/pkg/zdns/zdns.go
+++ b/pkg/zdns/zdns.go
@@ -220,10 +220,10 @@ func Run(gc GlobalConf, flags *pflag.FlagSet,
 
 	if gc.GoMaxProcs != 0 {
 		runtime.GOMAXPROCS(gc.GoMaxProcs)
-		ulimit_check(uint64(gc.GoMaxProcs * gc.Threads))
-	} else {
-		ulimit_check(uint64(runtime.NumCPU() * gc.Threads))
 	}
+
+	// check ulimit value is high enough and if not, try to fix it
+	ulimit_check(uint64(gc.Threads))
 
 	if gc.UDPOnly && gc.TCPOnly {
 		log.Fatal("TCP Only and UDP Only are conflicting")

--- a/pkg/zdns/zdns.go
+++ b/pkg/zdns/zdns.go
@@ -222,8 +222,10 @@ func Run(gc GlobalConf, flags *pflag.FlagSet,
 		runtime.GOMAXPROCS(gc.GoMaxProcs)
 	}
 
-	// check ulimit value is high enough and if not, try to fix it
-	ulimitCheck(uint64(gc.Threads))
+	// the margin for limit of open files covers different build platforms (linux/darwin), metadata files, or
+	// input and output files etc.
+	// check ulimit if value is high enough and if not, try to fix it
+	ulimitCheck(uint64(gc.Threads + 100))
 
 	if gc.UDPOnly && gc.TCPOnly {
 		log.Fatal("TCP Only and UDP Only are conflicting")

--- a/pkg/zdns/zdns.go
+++ b/pkg/zdns/zdns.go
@@ -223,7 +223,7 @@ func Run(gc GlobalConf, flags *pflag.FlagSet,
 	}
 
 	// check ulimit value is high enough and if not, try to fix it
-	ulimit_check(uint64(gc.Threads))
+	ulimitCheck(uint64(gc.Threads))
 
 	if gc.UDPOnly && gc.TCPOnly {
 		log.Fatal("TCP Only and UDP Only are conflicting")


### PR DESCRIPTION
Hello,

in previous versions, I could run ZDNS with tens of thousands of threads without problem on a server with 64 logical cores. However, now it is impossible because of the added ulimit check that is too strict.

The default ulimit -n value for a newly created bash is 1024. When running zdns with 1000 threads, it now shows a warning:
```
WARN[0000] Current nofile limit (1024) lower than maximum connection count (64000), try to update. 
```
with the calculated maximum connection count at 64,000 (supposedly 64 cores x 1000 threads)

 However, the number of open sockets is 1001:
```bash
printf "google.com\nexample.com"> test.txt; strace -f ./zdns A --threads 1000 --recycle-sockets=true  --input-file test.txt 2>&1 | grep 'socket(AF_INET, SOCK_DGRAM' | wc -l; rm test.txt >/dev/null
```
one socket open to get the local address: https://github.com/zmap/zdns/blob/c8e1d8e2fd7a818dd9e95d5aecf9584c34aaf703/pkg/zdns/zdns.go#L200-L206

and 1000 sockets correspond to one socket open per goroutine. The total number of open files is less than 1024 and zdns should run without problem. 

The problem IMO is coming from the maximum ulimit value:
https://github.com/zmap/zdns/blob/c8e1d8e2fd7a818dd9e95d5aecf9584c34aaf703/pkg/zdns/zdns.go#L217-L222

If I understand well GOMAXPROCS, it determines how many routines can run in parallel but it does not multiply the number of open sockets. 

I propose to set the ulimit value to the number of threads as each thread is supposed to open one socket (reusable or not).