### PR TITLE
added nslookup cmd to CLI for visibility

### DIFF
--- a/cmd/nslookup.go
+++ b/cmd/nslookup.go
@@ -1,0 +1,47 @@
+/*
+ * ZDNS Copyright 2024 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package cmd
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/zmap/zdns/internal/util"
+	"github.com/zmap/zdns/pkg/zdns"
+)
+
+// nslookupCmd represents the nslookup command
+var nslookupCmd = &cobra.Command{
+	Use:   "nslookup",
+	Short: "Run a more exhaustive nslookup",
+	Long:  `nslookup will additionally do an A/AAAA lookup for the IP addresses that correspond with name server records.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		GC.Module = strings.ToUpper("nslookup")
+		zdns.Run(GC, cmd.Flags(),
+			&Timeout, &IterationTimeout,
+			&Class_string, &Servers_string,
+			&Config_file, &Localaddr_string,
+			&Localif_string, &NanoSeconds, &ClientSubnet_string, &NSID)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(nslookupCmd)
+
+	nslookupCmd.PersistentFlags().Bool("ipv4-lookup", false, "perform A lookups for each NS server")
+	nslookupCmd.PersistentFlags().Bool("ipv6-lookup", false, "perform AAAA record lookups for each NS server")
+
+	util.BindFlags(nslookupCmd, viper.GetViper(), util.EnvPrefix)
+}


### PR DESCRIPTION
## Description
Looking at the `--help` text for `zdns` gives the impression that there are a couple unique modules (`alookup`, `mxlookup`,...) and any other dns type you just use the type name (`NS`, `DMARC`, ...). However, the NSLookup module is registered explicitly with `NSLOOKUP`. Therefore, without looking thru the code it's impossible to know that you should use `./zdns nslookup` to call it.

## Changes
- add a `nslookup` cmd to `./zdns` to make invoking `nslookup` more clear thru the `./help` text