### PR TITLE
Fix for GitHub action - set version on release

### DIFF
--- a/.github/workflows/version_tagging.yml
+++ b/.github/workflows/version_tagging.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           VERSION=${{ github.event.inputs.version }}
           BRANCH_NAME="release/${VERSION}"
+          git pull
           git checkout main
           git checkout -b ${BRANCH_NAME}
           echo "Branch name is ${BRANCH_NAME}"

--- a/.github/workflows/version_tagging.yml
+++ b/.github/workflows/version_tagging.yml
@@ -50,7 +50,8 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "release/${{ github.event.inputs.version }}"
+#          branch: "release/${{ github.event.inputs.version }}"
           title: "Release ${VERSION}"
           body: "This PR updates the version to ${VERSION}. Be sure to tag the release once this PR is merged."
-          base: main
+#          base: main
+          reviewers: ZDNS Maintainers

--- a/.github/workflows/version_tagging.yml
+++ b/.github/workflows/version_tagging.yml
@@ -1,5 +1,4 @@
-name: Release on Demand
-#name: Prepare Release for Tagging and Release
+name: Prepare Release for Tagging and Release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/version_tagging.yml
+++ b/.github/workflows/version_tagging.yml
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "update-code-for-/${{ github.event.inputs.version }}"
           title: "Updates version in code to ${{ github.event.inputs.version }}"
-          body: "This PR updates the version to ${{VERSION}}. Be sure to tag the release once this PR is merged."
+          body: "This PR updates the version to ${{github.event.inputs.version}}. Be sure to tag the release once this PR is merged."
           base: main
           reviewers: ZDNS Maintainers
           commit-message: "Update version to ${VERSION} in src/cli/cli.go"

--- a/.github/workflows/version_tagging.yml
+++ b/.github/workflows/version_tagging.yml
@@ -16,37 +16,37 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Git
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+#      - name: Set up Git
+#        run: |
+#          git config --global user.name "github-actions[bot]"
+#          git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create release branch
-        id: create_branch
-        run: |
-          VERSION=${{ github.event.inputs.version }}
-          BRANCH_NAME="release/${VERSION}"
-          git pull
-          git checkout main
-          git checkout -b ${BRANCH_NAME}
-          echo "Branch name is ${BRANCH_NAME}"
+#      - name: Create release branch
+#        id: create_branch
+#        run: |
+#          VERSION=${{ github.event.inputs.version }}
+#          BRANCH_NAME="release/${VERSION}"
+#          git pull
+#          git checkout main
+#          git checkout -b ${BRANCH_NAME}
+#          echo "Branch name is ${BRANCH_NAME}"
 
       - name: Update version in cli.go
         run: |
           VERSION=${{ github.event.inputs.version }}
           sed -i "s/\tzdnsCLIVersion = \".*\"/\tzdnsCLIVersion = \"${VERSION}\"/g" src/cli/cli.go
 
-      - name: Commit changes
-        run: |
-          VERSION=${{ github.event.inputs.version }}
-          git add src/cli/cli.go
-          git commit -m "Update version to ${VERSION} in src/cli/cli.go"
-
-      - name: Push branch
-        run: |
-          VERSION=${{ github.event.inputs.version }}
-          BRANCH_NAME="release/${VERSION}"
-          git push origin ${BRANCH_NAME}
+#      - name: Commit changes
+#        run: |
+#          VERSION=${{ github.event.inputs.version }}
+#          git add src/cli/cli.go
+#          git commit -m "Update version to ${VERSION} in src/cli/cli.go"
+#
+#      - name: Push branch
+#        run: |
+#          VERSION=${{ github.event.inputs.version }}
+#          BRANCH_NAME="release/${VERSION}"
+#          git push origin ${BRANCH_NAME}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
@@ -57,3 +57,4 @@ jobs:
           body: "This PR updates the version to ${VERSION}. Be sure to tag the release once this PR is merged."
           base: main
           reviewers: ZDNS Maintainers
+          commit-message: "Update version to ${VERSION} in src/cli/cli.go"

--- a/.github/workflows/version_tagging.yml
+++ b/.github/workflows/version_tagging.yml
@@ -1,4 +1,5 @@
 name: Release on Demand
+#name: Prepare Release for Tagging and Release
 
 on:
   workflow_dispatch:
@@ -31,7 +32,7 @@ jobs:
       - name: Update version in cli.go
         run: |
           VERSION=${{ github.event.inputs.version }}
-          sed "s/\tzdnsCLIVersion = \".*\"/\tzdnsCLIVersion = \"${VERSION}\"/g" src/cli/cli.go
+          sed -i "s/\tzdnsCLIVersion = \".*\"/\tzdnsCLIVersion = \"${VERSION}\"/g" src/cli/cli.go
 
       - name: Commit changes
         run: |

--- a/.github/workflows/version_tagging.yml
+++ b/.github/workflows/version_tagging.yml
@@ -23,7 +23,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "update-code-for-/${{ github.event.inputs.version }}"
+          branch: "bot/update-code-for-${{ github.event.inputs.version }}"
           title: "Updates version in code to ${{ github.event.inputs.version }}"
           body: "This PR updates the version to ${{github.event.inputs.version}}. Be sure to tag the release once this PR is merged."
           base: main

--- a/.github/workflows/version_tagging.yml
+++ b/.github/workflows/version_tagging.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           VERSION=${{ github.event.inputs.version }}
           BRANCH_NAME="release/${VERSION}"
+          git checkout main
           git checkout -b ${BRANCH_NAME}
           echo "Branch name is ${BRANCH_NAME}"
 
@@ -50,8 +51,8 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-#          branch: "release/${{ github.event.inputs.version }}"
+          branch: "release/${{ github.event.inputs.version }}"
           title: "Release ${VERSION}"
           body: "This PR updates the version to ${VERSION}. Be sure to tag the release once this PR is merged."
-#          base: main
+          base: main
           reviewers: ZDNS Maintainers

--- a/.github/workflows/version_tagging.yml
+++ b/.github/workflows/version_tagging.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Update version in cli.go
         run: |
           VERSION=${{ github.event.inputs.version }}
-          sed 's/\tzdnsCLIVersion = \".*\"/\tzdnsCLIVersion = \"${VERSION}\"/g' src/cli/cli.go
+          sed "s/\tzdnsCLIVersion = \".*\"/\tzdnsCLIVersion = \"${VERSION}\"/g" src/cli/cli.go
 
       - name: Commit changes
         run: |

--- a/.github/workflows/version_tagging.yml
+++ b/.github/workflows/version_tagging.yml
@@ -15,46 +15,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-#      - name: Set up Git
-#        run: |
-#          git config --global user.name "github-actions[bot]"
-#          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-#      - name: Create release branch
-#        id: create_branch
-#        run: |
-#          VERSION=${{ github.event.inputs.version }}
-#          BRANCH_NAME="release/${VERSION}"
-#          git pull
-#          git checkout main
-#          git checkout -b ${BRANCH_NAME}
-#          echo "Branch name is ${BRANCH_NAME}"
-
       - name: Update version in cli.go
         run: |
           VERSION=${{ github.event.inputs.version }}
           sed -i "s/\tzdnsCLIVersion = \".*\"/\tzdnsCLIVersion = \"${VERSION}\"/g" src/cli/cli.go
-
-#      - name: Commit changes
-#        run: |
-#          VERSION=${{ github.event.inputs.version }}
-#          git add src/cli/cli.go
-#          git commit -m "Update version to ${VERSION} in src/cli/cli.go"
-#
-#      - name: Push branch
-#        run: |
-#          VERSION=${{ github.event.inputs.version }}
-#          BRANCH_NAME="release/${VERSION}"
-#          git push origin ${BRANCH_NAME}
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "release/${{ github.event.inputs.version }}"
-          title: "Release ${VERSION}"
-          body: "This PR updates the version to ${VERSION}. Be sure to tag the release once this PR is merged."
+          branch: "update-code-for-/${{ github.event.inputs.version }}"
+          title: "Updates version in code to ${{ github.event.inputs.version }}"
+          body: "This PR updates the version to ${{VERSION}}. Be sure to tag the release once this PR is merged."
           base: main
           reviewers: ZDNS Maintainers
           commit-message: "Update version to ${VERSION} in src/cli/cli.go"


### PR DESCRIPTION
Was able to test this after the earlier branch was merged into main. Now it's working as desired, you can now create a PR with the updated version using the manual action.