### PR TITLE
Perform all config validation in Resolver to avoid code duplication/mess

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -25,6 +25,7 @@ import (
 	"github.com/zmap/dns"
 
 	"github.com/zmap/zdns/src/internal/util"
+	"github.com/zmap/zdns/src/zdns"
 )
 
 const (
@@ -163,7 +164,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&GC.NameServersString, "name-servers", "", "List of DNS servers to use. Can be passed as comma-delimited string or via @/path/to/file. If no port is specified, defaults to 53.")
 	rootCmd.PersistentFlags().StringVar(&GC.LocalAddrString, "local-addr", "", "comma-delimited list of local addresses to use, serve as the source IP for outbound queries")
 	rootCmd.PersistentFlags().StringVar(&GC.LocalIfaceString, "local-interface", "", "local interface to use")
-	rootCmd.PersistentFlags().StringVar(&GC.ConfigFilePath, "conf-file", "/etc/resolv.conf", "config file for DNS servers")
+	rootCmd.PersistentFlags().StringVar(&GC.ConfigFilePath, "conf-file", zdns.DefaultNameServerConfigFile, "config file for DNS servers")
 	rootCmd.PersistentFlags().IntVar(&GC.Timeout, "timeout", 15, "timeout for resolving a individual name, in seconds")
 	rootCmd.PersistentFlags().IntVar(&GC.IterationTimeout, "iteration-timeout", 4, "timeout for a single iterative step in an iterative query, in seconds. Only applicable with --iterative")
 	rootCmd.PersistentFlags().StringVar(&GC.ClassString, "class", "INET", "DNS class to query. Options: INET, CSNET, CHAOS, HESIOD, NONE, ANY.")

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -60,23 +60,22 @@ type CLIConf struct {
 	IncludeInOutput string
 	OutputGroups    []string
 
-	MaxDepth                int
-	CacheSize               int
-	GoMaxProcs              int
-	Verbosity               int
-	TimeFormat              string
-	NameServers             []string
-	UsingLoopbackNameServer bool // whether we're using the loopback address as a name-server
-	LookupAllNameServers    bool
-	TCPOnly                 bool
-	UDPOnly                 bool
-	RecycleSockets          bool
-	LocalAddrSpecified      bool
-	LocalAddrs              []net.IP
-	ClientSubnet            *dns.EDNS0_SUBNET
-	UseNSID                 bool
-	Dnssec                  bool
-	CheckingDisabled        bool
+	MaxDepth             int
+	CacheSize            int
+	GoMaxProcs           int
+	Verbosity            int
+	TimeFormat           string
+	NameServers          []string
+	LookupAllNameServers bool
+	TCPOnly              bool
+	UDPOnly              bool
+	RecycleSockets       bool
+	LocalAddrSpecified   bool
+	LocalAddrs           []net.IP
+	ClientSubnet         *dns.EDNS0_SUBNET
+	UseNSID              bool
+	Dnssec               bool
+	CheckingDisabled     bool
 
 	InputFilePath     string
 	OutputFilePath    string

--- a/src/cli/config_validation.go
+++ b/src/cli/config_validation.go
@@ -33,7 +33,6 @@ func validateNetworkingConfig(gc *CLIConf) error {
 		return errors.New("--local-addr and --local-interface cannot both be specified")
 	}
 
-	// Note: we rely on the value of gc.UsingLoopbackNameServer set here, so this must be called first before other validation
 	if err := validateNameServers(gc); err != nil {
 		return errors.Wrap(err, "name servers did not pass validation")
 	}
@@ -74,7 +73,6 @@ func validateNetworkingConfig(gc *CLIConf) error {
 		}
 		log.Info("using local interface: ", gc.LocalIfaceString)
 	}
-
 	return nil
 }
 

--- a/src/cli/config_validation.go
+++ b/src/cli/config_validation.go
@@ -69,12 +69,6 @@ func validateNetworkingConfig(gc *CLIConf) error {
 			if err != nil {
 				return fmt.Errorf("unable to parse IP address from interface %s: %v", gc.LocalIfaceString, err)
 			}
-			if ip.To4() == nil {
-				// skip IPv6 addresses
-				// TODO - we'll need to update this when we add IPv6 support
-				log.Infof("interface %s has IPv6 address %s, skipping since unsupported", gc.LocalIfaceString, ip.String())
-				continue
-			}
 			gc.LocalAddrs = append(gc.LocalAddrs, ip)
 			gc.LocalAddrSpecified = true
 		}

--- a/src/cli/config_validation.go
+++ b/src/cli/config_validation.go
@@ -58,7 +58,6 @@ func validateNetworkingConfig(gc *CLIConf) error {
 				return fmt.Errorf("invalid argument for --local-addr (%v). Must be a comma-separated list of valid IP addresses", la)
 			}
 		}
-		log.Info("using local address: ", GC.LocalAddrString)
 		gc.LocalAddrSpecified = true
 	}
 
@@ -102,20 +101,6 @@ func validateNetworkingConfig(gc *CLIConf) error {
 		gc.LocalAddrs = []net.IP{net.ParseIP(loopbackAddrString)}
 		gc.LocalAddrSpecified = true
 	}
-
-	if !gc.LocalAddrSpecified {
-		// Find non-loopback local address for use in any socket connections
-		conn, err := net.Dial("udp", "8.8.8.8:53")
-		if err != nil {
-			return fmt.Errorf("unable to find default IP address: %v", err)
-		}
-		gc.LocalAddrs = append(gc.LocalAddrs, conn.LocalAddr().(*net.UDPAddr).IP)
-		err = conn.Close()
-		if err != nil {
-			log.Warn("unable to close test connection to Google Public DNS: ", err)
-		}
-	}
-	log.Infof("using local address(es): %v", gc.LocalAddrs)
 	return nil
 }
 

--- a/src/cli/config_validation.go
+++ b/src/cli/config_validation.go
@@ -23,17 +23,15 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/dns"
-
-	"github.com/zmap/zdns/src/internal/util"
 )
 
-func validateNetworkingConfig(gc *CLIConf) error {
+func populateNetworkingConfig(gc *CLIConf) error {
 	// mutually exclusive CLI options
 	if gc.LocalIfaceString != "" && gc.LocalAddrString != "" {
 		return errors.New("--local-addr and --local-interface cannot both be specified")
 	}
 
-	if err := validateNameServers(gc); err != nil {
+	if err := populateNameServers(gc); err != nil {
 		return errors.Wrap(err, "name servers did not pass validation")
 	}
 
@@ -106,7 +104,7 @@ func validateClientSubnetString(gc *CLIConf) error {
 	return nil
 }
 
-func validateNameServers(gc *CLIConf) error {
+func populateNameServers(gc *CLIConf) error {
 	if gc.LookupAllNameServers && gc.NameServersString != "" {
 		log.Fatal("name servers cannot be specified in --all-nameservers mode.")
 	}
@@ -128,16 +126,6 @@ func validateNameServers(gc *CLIConf) error {
 			ns = strings.Split(strings.Trim(string(f), "\n"), "\n")
 		} else {
 			ns = strings.Split(gc.NameServersString, ",")
-		}
-		for i, s := range ns {
-			nsWithPort, err := util.AddDefaultPortToDNSServerName(s)
-			if err != nil {
-				log.Fatalf("unable to parse name server: %s", s)
-			}
-			ns[i] = nsWithPort
-		}
-		if len(ns) == 0 {
-			return fmt.Errorf("no valid name servers specified: %v", ns)
 		}
 		gc.NameServers = ns
 	}

--- a/src/cli/config_validation_test.go
+++ b/src/cli/config_validation_test.go
@@ -25,14 +25,14 @@ func TestValidateNetworkingConfig(t *testing.T) {
 			LocalAddrString:  "1.1.1.1",
 			LocalIfaceString: "eth0",
 		}
-		err := validateNetworkingConfig(gc)
+		err := populateNetworkingConfig(gc)
 		require.NotNil(t, err, "Expected an error but got nil")
 	})
 	t.Run("Using invalid interface", func(t *testing.T) {
 		gc := &CLIConf{
 			LocalIfaceString: "invalid_interface",
 		}
-		err := validateNetworkingConfig(gc)
+		err := populateNetworkingConfig(gc)
 		require.NotNil(t, err, "Expected an error but got nil")
 	})
 
@@ -40,7 +40,7 @@ func TestValidateNetworkingConfig(t *testing.T) {
 		gc := &CLIConf{
 			NameServersString: "1.1.1.1",
 		}
-		err := validateNetworkingConfig(gc)
+		err := populateNetworkingConfig(gc)
 		require.Nil(t, err, "Expected no error but got %v", err)
 		require.Equal(t, "1.1.1.1:53", gc.NameServers[0], "Expected port 53 to be appended to nameserver")
 	})
@@ -48,7 +48,7 @@ func TestValidateNetworkingConfig(t *testing.T) {
 		gc := &CLIConf{
 			NameServersString: "127.0.0.1:5353",
 		}
-		err := validateNetworkingConfig(gc)
+		err := populateNetworkingConfig(gc)
 		require.Nil(t, err, "Expected no error but got %v", err)
 		require.Equal(t, "127.0.0.1:5353", gc.NameServers[0], "Expected user supplied port to not be changed")
 	})

--- a/src/cli/config_validation_test.go
+++ b/src/cli/config_validation_test.go
@@ -43,7 +43,6 @@ func TestValidateNetworkingConfig(t *testing.T) {
 		err := validateNetworkingConfig(gc)
 		require.Nil(t, err, "Expected no error but got %v", err)
 		require.Equal(t, "1.1.1.1:53", gc.NameServers[0], "Expected port 53 to be appended to nameserver")
-		require.False(t, gc.UsingLoopbackNameServer, "Expected UsingLoopbackNameServer to be false")
 	})
 	t.Run("Using nameserver with port", func(t *testing.T) {
 		gc := &CLIConf{

--- a/src/cli/config_validation_test.go
+++ b/src/cli/config_validation_test.go
@@ -14,10 +14,7 @@
 package cli
 
 import (
-	"net"
 	"testing"
-
-	log "github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/require"
 )
@@ -39,15 +36,6 @@ func TestValidateNetworkingConfig(t *testing.T) {
 		require.NotNil(t, err, "Expected an error but got nil")
 	})
 
-	t.Run("Using loopback nameserver and no specified local address", func(t *testing.T) {
-		gc := &CLIConf{
-			NameServersString: "127.0.0.53",
-		}
-		err := validateNetworkingConfig(gc)
-		require.Nil(t, err, "Expected no error but got %v", err)
-		require.Equal(t, loopbackAddrString, gc.LocalAddrs[0].String())
-		require.True(t, gc.UsingLoopbackNameServer, "Expected UsingLoopbackNameServer to be true")
-	})
 	t.Run("Using nameserver with no port", func(t *testing.T) {
 		gc := &CLIConf{
 			NameServersString: "1.1.1.1",
@@ -64,60 +52,5 @@ func TestValidateNetworkingConfig(t *testing.T) {
 		err := validateNetworkingConfig(gc)
 		require.Nil(t, err, "Expected no error but got %v", err)
 		require.Equal(t, "127.0.0.1:5353", gc.NameServers[0], "Expected user supplied port to not be changed")
-	})
-	t.Run("Using a loopback and non-loopback nameserver", func(t *testing.T) {
-		gc := &CLIConf{
-			NameServersString: "127.0.0.53,1.1.1.1",
-		}
-		err := validateNetworkingConfig(gc)
-		require.NotNil(t, err, "Expected an error but got nil")
-	})
-	t.Run("Loopback interface and nameserver mismatch", func(t *testing.T) {
-		// get both a loopback and non-loopback interface
-		ifaces, err := net.Interfaces()
-		require.Nil(t, err, "Expected no error but got %v", err)
-		var nonLoopbackIface string
-		var loopbackIface string
-		for _, iface := range ifaces {
-			if iface.Flags&net.FlagLoopback == 0 {
-				nonLoopbackIface = iface.Name
-			} else {
-				loopbackIface = iface.Name
-			}
-		}
-		log.Infof("using non-loopback interface: %s", nonLoopbackIface)
-		log.Infof("using loopback interface: %s", loopbackIface)
-		t.Run("loopback interface with non-loopback nameserver", func(t *testing.T) {
-			gc := &CLIConf{
-				NameServersString: "1.1.1.1",
-				LocalIfaceString:  loopbackIface,
-			}
-			err = validateNetworkingConfig(gc)
-			require.NotNil(t, err, "Expected an error but got nil")
-		})
-		t.Run("non-loopback interface with loopback nameserver", func(t *testing.T) {
-			gc := &CLIConf{
-				NameServersString: "127.0.0.1",
-				LocalIfaceString:  nonLoopbackIface,
-			}
-			err = validateNetworkingConfig(gc)
-			require.NotNil(t, err, "Expected an error but got nil")
-		})
-		t.Run("loopback interface with loopback nameserver", func(t *testing.T) {
-			gc := &CLIConf{
-				NameServersString: "127.0.0.53",
-				LocalIfaceString:  loopbackIface,
-			}
-			err = validateNetworkingConfig(gc)
-			require.Nil(t, err, "Expected no error but got %v", err)
-		})
-		t.Run("non-loopback interface with non-loopback nameserver", func(t *testing.T) {
-			gc := &CLIConf{
-				NameServersString: "1.1.1.1",
-				LocalIfaceString:  nonLoopbackIface,
-			}
-			err = validateNetworkingConfig(gc)
-			require.Nil(t, err, "Expected no error but got %v", err)
-		})
 	})
 }

--- a/src/cli/config_validation_test.go
+++ b/src/cli/config_validation_test.go
@@ -35,21 +35,12 @@ func TestValidateNetworkingConfig(t *testing.T) {
 		err := populateNetworkingConfig(gc)
 		require.NotNil(t, err, "Expected an error but got nil")
 	})
-
-	t.Run("Using nameserver with no port", func(t *testing.T) {
-		gc := &CLIConf{
-			NameServersString: "1.1.1.1",
-		}
-		err := populateNetworkingConfig(gc)
-		require.Nil(t, err, "Expected no error but got %v", err)
-		require.Equal(t, "1.1.1.1:53", gc.NameServers[0], "Expected port 53 to be appended to nameserver")
-	})
 	t.Run("Using nameserver with port", func(t *testing.T) {
 		gc := &CLIConf{
-			NameServersString: "127.0.0.1:5353",
+			NameServersString: "127.0.0.1:53",
 		}
 		err := populateNetworkingConfig(gc)
 		require.Nil(t, err, "Expected no error but got %v", err)
-		require.Equal(t, "127.0.0.1:5353", gc.NameServers[0], "Expected user supplied port to not be changed")
+		require.Equal(t, "127.0.0.1:53", gc.NameServers[0], "Expected user supplied port to not be changed")
 	})
 }

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -100,9 +100,9 @@ func populateCLIConfig(gc *CLIConf, flags *pflag.FlagSet) *CLIConf {
 		log.Fatal("Unknown record class specified. Valid valued are INET (default), CSNET, CHAOS, HESIOD, NONE, ANY")
 	}
 
-	err := validateNetworkingConfig(gc)
+	err := populateNetworkingConfig(gc)
 	if err != nil {
-		log.Fatalf("networking config did not pass validation: %v", err)
+		log.Fatalf("could not populate networking config: %v", err)
 	}
 
 	if gc.UseNanoseconds {

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -188,6 +188,7 @@ func populateResolverConfig(gc *CLIConf, flags *pflag.FlagSet) *zdns.ResolverCon
 	config.ExternalNameServers = gc.NameServers
 	config.LocalAddrs = gc.LocalAddrs
 	config.DNSSecEnabled = gc.Dnssec
+	config.DNSConfigFilePath = gc.ConfigFilePath
 
 	config.LogLevel = log.Level(gc.Verbosity)
 

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -204,6 +204,12 @@ func populateResolverConfig(gc *CLIConf, flags *pflag.FlagSet) *zdns.ResolverCon
 func Run(gc CLIConf, flags *pflag.FlagSet) {
 	gc = *populateCLIConfig(&gc, flags)
 	resolverConfig := populateResolverConfig(&gc, flags)
+	err := resolverConfig.PopulateAndValidate()
+	if err != nil {
+		log.Fatal("could not populate defaults and validate resolver config: ", err)
+	}
+	// Log any information about the resolver configuration, according to log level
+	resolverConfig.PrintInfo()
 	lookupModule, err := GetLookupModule(gc.Module)
 	if err != nil {
 		log.Fatal("could not get lookup module: ", err)

--- a/src/internal/util/util.go
+++ b/src/internal/util/util.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -54,6 +55,26 @@ func AddDefaultPortToDNSServerName(inAddr string) (string, error) {
 	}
 
 	return net.JoinHostPort(ip.String(), port), nil
+}
+
+func SplitHostPort(inaddr string) (net.IP, int, error) {
+	host, port, err := net.SplitHostPort(inaddr)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil, 0, errors.Wrap(err, "invalid IP address")
+	}
+
+	portInt, err := strconv.Atoi(port)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "invalid port")
+	}
+
+	return ip, portInt, nil
+
 }
 
 // Reference: https://github.com/carolynvs/stingoftheviper/blob/main/main.go

--- a/src/modules/bindversion/bindversion_test.go
+++ b/src/modules/bindversion/bindversion_test.go
@@ -46,7 +46,7 @@ func (ml MockLookup) DoSingleDstServerLookup(r *zdns.Resolver, question zdns.Que
 func InitTest(t *testing.T) *zdns.Resolver {
 	mockResults = make(map[string]*zdns.SingleQueryResult)
 	rc := zdns.ResolverConfig{
-		ExternalNameServers: []string{"127.0.0.1"},
+		ExternalNameServers: []string{"1.1.1.1"},
 		LookupClient:        MockLookup{}}
 	r, err := zdns.InitResolver(&rc)
 	assert.NilError(t, err)
@@ -65,7 +65,7 @@ func TestBindVersionLookup_Valid_1(t *testing.T) {
 	assert.Equal(t, queries[0].q.Class, uint16(dns.ClassCHAOS))
 	assert.Equal(t, queries[0].q.Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].q.Name, "VERSION.BIND")
-	assert.Equal(t, queries[0].NameServer, "1.2.3.4")
+	assert.Equal(t, queries[0].NameServer, "1.2.3.4:53")
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).BindVersion, "Nominum Vantio 5.4.1.0")
@@ -81,7 +81,7 @@ func TestBindVersionLookup_NotValid_1(t *testing.T) {
 	assert.Equal(t, queries[0].q.Class, uint16(dns.ClassCHAOS))
 	assert.Equal(t, queries[0].q.Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].q.Name, "VERSION.BIND")
-	assert.Equal(t, queries[0].NameServer, "1.2.3.4")
+	assert.Equal(t, queries[0].NameServer, "1.2.3.4:53")
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).BindVersion, "")

--- a/src/modules/dmarc/dmarc_test.go
+++ b/src/modules/dmarc/dmarc_test.go
@@ -46,7 +46,7 @@ func (ml MockLookup) DoSingleDstServerLookup(r *zdns.Resolver, question zdns.Que
 func InitTest(t *testing.T) *zdns.Resolver {
 	mockResults = make(map[string]*zdns.SingleQueryResult)
 	rc := zdns.ResolverConfig{
-		ExternalNameServers: []string{zdns.LoopbackAddrString},
+		ExternalNameServers: []string{"127.0.0.1:53"},
 		LookupClient:        MockLookup{}}
 	r, err := zdns.InitResolver(&rc)
 	assert.NilError(t, err)
@@ -68,7 +68,7 @@ func TestDmarcLookup_Valid_1(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
+	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Dmarc, "v=DMARC1; p=none; rua=mailto:postmaster@censys.io")
@@ -89,7 +89,7 @@ func TestDmarcLookup_Valid_2(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
+	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Dmarc, "V=DMARC1; p=none; rua=mailto:postmaster@censys.io")
@@ -110,7 +110,7 @@ func TestDmarcLookup_Valid_3(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
+	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Dmarc, "v\t\t\t=\t\t  DMARC1\t\t; p=none; rua=mailto:postmaster@censys.io")
@@ -131,7 +131,7 @@ func TestDmarcLookup_NotValid_1(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
+	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Dmarc, "")
@@ -152,7 +152,7 @@ func TestDmarcLookup_NotValid_2(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
+	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Dmarc, "")
@@ -173,7 +173,7 @@ func TestDmarcLookup_NotValid_3(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
+	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Dmarc, "")

--- a/src/modules/dmarc/dmarc_test.go
+++ b/src/modules/dmarc/dmarc_test.go
@@ -46,7 +46,7 @@ func (ml MockLookup) DoSingleDstServerLookup(r *zdns.Resolver, question zdns.Que
 func InitTest(t *testing.T) *zdns.Resolver {
 	mockResults = make(map[string]*zdns.SingleQueryResult)
 	rc := zdns.ResolverConfig{
-		ExternalNameServers: []string{"127.0.0.1"},
+		ExternalNameServers: []string{zdns.LoopbackAddrString},
 		LookupClient:        MockLookup{}}
 	r, err := zdns.InitResolver(&rc)
 	assert.NilError(t, err)
@@ -68,7 +68,7 @@ func TestDmarcLookup_Valid_1(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1")
+	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Dmarc, "v=DMARC1; p=none; rua=mailto:postmaster@censys.io")
@@ -89,7 +89,7 @@ func TestDmarcLookup_Valid_2(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1")
+	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Dmarc, "V=DMARC1; p=none; rua=mailto:postmaster@censys.io")
@@ -110,7 +110,7 @@ func TestDmarcLookup_Valid_3(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1")
+	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Dmarc, "v\t\t\t=\t\t  DMARC1\t\t; p=none; rua=mailto:postmaster@censys.io")
@@ -131,7 +131,7 @@ func TestDmarcLookup_NotValid_1(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1")
+	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Dmarc, "")
@@ -152,7 +152,7 @@ func TestDmarcLookup_NotValid_2(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1")
+	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Dmarc, "")
@@ -173,7 +173,7 @@ func TestDmarcLookup_NotValid_3(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1")
+	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Dmarc, "")

--- a/src/modules/spf/spf_test.go
+++ b/src/modules/spf/spf_test.go
@@ -47,7 +47,7 @@ func InitTest(t *testing.T) *zdns.Resolver {
 	mockResults = make(map[string]*zdns.SingleQueryResult)
 	queries = make([]QueryRecord, 0)
 	rc := zdns.ResolverConfig{
-		ExternalNameServers: []string{"127.0.0.1"},
+		ExternalNameServers: []string{zdns.LoopbackAddrString},
 		LookupClient:        MockLookup{}}
 	r, err := zdns.InitResolver(&rc)
 	assert.NilError(t, err)
@@ -69,7 +69,7 @@ func TestLookup_DoTxtLookup_Valid_1(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1")
+	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Spf, "v=spf1 mx include:_spf.google.com -all")
@@ -89,7 +89,7 @@ func TestLookup_DoTxtLookup_Valid_2(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1")
+	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Spf, "V=SpF1 mx include:_spf.google.com -all")
@@ -109,7 +109,7 @@ func TestLookup_DoTxtLookup_NotValid_1(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1")
+	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Spf, "")
@@ -129,7 +129,7 @@ func TestLookup_DoTxtLookup_NotValid_2(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1")
+	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Spf, "")
@@ -144,7 +144,7 @@ func TestLookup_DoTxtLookup_NoTXT(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "example.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1")
+	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
 
 	assert.Equal(t, zdns.StatusNoAnswer, status)
 	assert.Equal(t, res.(Result).Spf, "")

--- a/src/modules/spf/spf_test.go
+++ b/src/modules/spf/spf_test.go
@@ -47,7 +47,7 @@ func InitTest(t *testing.T) *zdns.Resolver {
 	mockResults = make(map[string]*zdns.SingleQueryResult)
 	queries = make([]QueryRecord, 0)
 	rc := zdns.ResolverConfig{
-		ExternalNameServers: []string{zdns.LoopbackAddrString},
+		ExternalNameServers: []string{"127.0.0.1:53"},
 		LookupClient:        MockLookup{}}
 	r, err := zdns.InitResolver(&rc)
 	assert.NilError(t, err)
@@ -69,7 +69,7 @@ func TestLookup_DoTxtLookup_Valid_1(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
-	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
+	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Spf, "v=spf1 mx include:_spf.google.com -all")
@@ -89,7 +89,7 @@ func TestLookup_DoTxtLookup_Valid_2(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
-	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
+	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Spf, "V=SpF1 mx include:_spf.google.com -all")
@@ -109,7 +109,7 @@ func TestLookup_DoTxtLookup_NotValid_1(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
-	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
+	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Spf, "")
@@ -129,7 +129,7 @@ func TestLookup_DoTxtLookup_NotValid_2(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
-	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
+	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Spf, "")
@@ -144,7 +144,7 @@ func TestLookup_DoTxtLookup_NoTXT(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "example.com")
-	assert.Equal(t, queries[0].NameServer, zdns.LoopbackAddrString)
+	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoAnswer, status)
 	assert.Equal(t, res.(Result).Spf, "")

--- a/src/zdns/lookup_test.go
+++ b/src/zdns/lookup_test.go
@@ -623,7 +623,7 @@ func TestOneA(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -651,7 +651,7 @@ func TestTwoA(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -686,7 +686,7 @@ func TestQuadAWithoutFlag(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -722,7 +722,7 @@ func TestOnlyQuadA(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -752,7 +752,7 @@ func TestAandQuadA(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -788,7 +788,7 @@ func TestTwoQuadA(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -825,7 +825,7 @@ func TestNoResults(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -847,7 +847,7 @@ func TestCname(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "cname.example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -893,7 +893,7 @@ func TestQuadAWithCname(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "cname.example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -928,7 +928,7 @@ func TestUnexpectedMxOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -962,7 +962,7 @@ func TestMxAndAdditionals(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -1004,7 +1004,7 @@ func TestMismatchIpType(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -1038,7 +1038,7 @@ func TestCnameLoops(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "cname1.example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -1089,7 +1089,7 @@ func TestExtendedRecursion(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	// Create a CNAME chain of length > 10
 	for i := 1; i < 12; i++ {
 		domainNSRecord := domainNS{
@@ -1128,7 +1128,7 @@ func TestEmptyNonTerminal(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "leaf.intermediate.example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -1171,7 +1171,7 @@ func TestNXDomain(t *testing.T) {
 	config := InitTest(t)
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	res, _, status, _ := resolver.DoTargetedLookup("nonexistent.example.com", ns1, IPv4OrIPv6, false)
 	if status != StatusNXDomain {
 		t.Errorf("Expected StatusNXDomain status, got %v", status)
@@ -1189,7 +1189,7 @@ func TestAandQuadADedup(t *testing.T) {
 	domain1 := "cname1.example.com"
 	domain2 := "cname2.example.com"
 	domain3 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 	domainNS2 := domainNS{domain: domain2, ns: ns1}
 	domainNS3 := domainNS{domain: domain3, ns: ns1}
@@ -1285,7 +1285,7 @@ func TestServFail(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{}
@@ -1322,7 +1322,7 @@ func TestNsAInAdditional(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -1365,7 +1365,7 @@ func TestTwoNSInAdditional(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -1426,7 +1426,7 @@ func TestAandQuadAInAdditional(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -1476,7 +1476,7 @@ func TestNsMismatchIpType(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -1526,7 +1526,7 @@ func TestAandQuadALookup(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -1586,7 +1586,7 @@ func TestNsNXDomain(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 
 	_, _, status, _ := resolver.DoNSLookup("nonexistentexample.com", ns1, false)
 
@@ -1599,7 +1599,7 @@ func TestNsServFail(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{}
@@ -1617,7 +1617,7 @@ func TestErrorInTargetedLookup(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
 	mockResults[domainNS1] = SingleQueryResult{
@@ -1646,15 +1646,16 @@ func TestErrorInTargetedLookup(t *testing.T) {
 // Test One NS with one IP with only ipv4-lookup
 func TestAllNsLookupOneNs(t *testing.T) {
 	config := InitTest(t)
+	config.LocalAddrs = []net.IP{net.ParseIP(LoopbackAddrString)}
 	config.IPVersionMode = IPv4OrIPv6
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domain1 := "example.com"
 	nsDomain1 := "ns1.example.com"
-	ipv4_1 := "192.0.2.1"
-	ipv6_1 := "2001:db8::3"
+	ipv4_1 := "127.0.0.2"
+	ipv6_1 := "::1"
 
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 	mockResults[domainNS1] = SingleQueryResult{
@@ -1690,7 +1691,7 @@ func TestAllNsLookupOneNs(t *testing.T) {
 
 	ns2 := net.JoinHostPort(ipv4_1, "53")
 	domainNS2 := domainNS{domain: domain1, ns: ns2}
-	ipv4_2 := "192.0.2.1"
+	ipv4_2 := "127.0.0.3"
 	mockResults[domainNS2] = SingleQueryResult{
 		Answers: []interface{}{
 			Answer{
@@ -1709,7 +1710,7 @@ func TestAllNsLookupOneNs(t *testing.T) {
 
 	ns3 := net.JoinHostPort(ipv6_1, "53")
 	domainNS3 := domainNS{domain: domain1, ns: ns3}
-	ipv4_3 := "192.0.2.2"
+	ipv4_3 := "127.0.0.4"
 	mockResults[domainNS3] = SingleQueryResult{
 		Answers: []interface{}{
 			Answer{
@@ -1757,11 +1758,11 @@ func TestAllNsLookupOneNsMultipleIps(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domain1 := "example.com"
 	nsDomain1 := "ns1.example.com"
-	ipv4_1 := "192.0.2.1"
-	ipv4_2 := "192.0.2.2"
+	ipv4_1 := "127.0.0.2"
+	ipv4_2 := "127.0.0.3"
 
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 	mockResults[domainNS1] = SingleQueryResult{
@@ -1797,8 +1798,8 @@ func TestAllNsLookupOneNsMultipleIps(t *testing.T) {
 
 	ns2 := net.JoinHostPort(ipv4_1, "53")
 	domainNS2 := domainNS{domain: domain1, ns: ns2}
-	ipv4_3 := "192.0.2.3"
-	ipv6_1 := "2001:db8::1"
+	ipv4_3 := "127.0.0.4"
+	ipv6_1 := "::1"
 	mockResults[domainNS2] = SingleQueryResult{
 		Answers: []interface{}{
 			Answer{
@@ -1824,8 +1825,8 @@ func TestAllNsLookupOneNsMultipleIps(t *testing.T) {
 
 	ns3 := net.JoinHostPort(ipv4_2, "53")
 	domainNS3 := domainNS{domain: domain1, ns: ns3}
-	ipv4_4 := "192.0.2.4"
-	ipv6_2 := "2001:db8::2"
+	ipv4_4 := "127.0.0.5"
+	ipv6_2 := "::2"
 	mockResults[domainNS3] = SingleQueryResult{
 		Answers: []interface{}{
 			Answer{
@@ -1880,12 +1881,12 @@ func TestAllNsLookupTwoNs(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domain1 := "example.com"
 	nsDomain1 := "ns1.example.com"
 	nsDomain2 := "ns2.example.com"
-	ipv4_1 := "192.0.2.1"
-	ipv4_2 := "192.0.2.2"
+	ipv4_1 := "127.0.0.2"
+	ipv4_2 := "127.0.0.3"
 
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 	mockResults[domainNS1] = SingleQueryResult{
@@ -1928,7 +1929,7 @@ func TestAllNsLookupTwoNs(t *testing.T) {
 
 	ns2 := net.JoinHostPort(ipv4_1, "53")
 	domainNS2 := domainNS{domain: domain1, ns: ns2}
-	ipv4_3 := "192.0.2.3"
+	ipv4_3 := "127.0.0.4"
 	mockResults[domainNS2] = SingleQueryResult{
 		Answers: []interface{}{
 			Answer{
@@ -1947,7 +1948,7 @@ func TestAllNsLookupTwoNs(t *testing.T) {
 
 	ns3 := net.JoinHostPort(ipv4_2, "53")
 	domainNS3 := domainNS{domain: domain1, ns: ns3}
-	ipv4_4 := "192.0.2.4"
+	ipv4_4 := "127.0.0.5"
 	mockResults[domainNS3] = SingleQueryResult{
 		Answers: []interface{}{
 			Answer{
@@ -1996,11 +1997,11 @@ func TestAllNsLookupErrorInOne(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domain1 := "example.com"
 	nsDomain1 := "ns1.example.com"
-	ipv4_1 := "192.0.2.1"
-	ipv4_2 := "192.0.2.2"
+	ipv4_1 := "127.0.0.2"
+	ipv4_2 := "127.0.0.3"
 
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 	mockResults[domainNS1] = SingleQueryResult{
@@ -2036,8 +2037,8 @@ func TestAllNsLookupErrorInOne(t *testing.T) {
 
 	ns2 := net.JoinHostPort(ipv4_1, "53")
 	domainNS2 := domainNS{domain: domain1, ns: ns2}
-	ipv4_3 := "192.0.2.3"
-	ipv6_1 := "2001:db8::1"
+	ipv4_3 := "127.0.0.4"
+	ipv6_1 := "::1"
 	mockResults[domainNS2] = SingleQueryResult{
 		Answers: []interface{}{
 			Answer{
@@ -2096,7 +2097,7 @@ func TestAllNsLookupNXDomain(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	q := Question{
 		Type:  dns.TypeNS,
 		Class: dns.ClassINET,
@@ -2116,7 +2117,7 @@ func TestAllNsLookupServFail(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := net.JoinHostPort(config.ExternalNameServers[0], "53")
+	ns1 := config.ExternalNameServers[0]
 	domain1 := "example.com"
 	domainNS1 := domainNS{domain: domain1, ns: ns1}
 
@@ -2136,7 +2137,7 @@ func TestAllNsLookupServFail(t *testing.T) {
 }
 
 func TestInvalidInputsLookup(t *testing.T) {
-	config := NewResolverConfig()
+	config := InitTest(t)
 	config.LocalAddrs = []net.IP{net.ParseIP("127.0.0.1")}
 	config.ExternalNameServers = []string{"127.0.0.1:53"}
 	resolver, err := InitResolver(config)
@@ -2148,11 +2149,8 @@ func TestInvalidInputsLookup(t *testing.T) {
 	}
 
 	t.Run("no port attached to nameserver", func(t *testing.T) {
-		result, trace, status, err := resolver.ExternalLookup(&q, "127.0.0.53")
-		assert.Nil(t, result)
-		assert.Nil(t, trace)
-		assert.Equal(t, StatusIllegalInput, status)
-		assert.NotNil(t, err)
+		_, _, _, err := resolver.ExternalLookup(&q, "127.0.0.53")
+		assert.Nil(t, err)
 	})
 	t.Run("using a loopback local addr with non-loopback nameserver", func(t *testing.T) {
 		result, trace, status, err := resolver.ExternalLookup(&q, "1.1.1.1:53")

--- a/src/zdns/lookup_test.go
+++ b/src/zdns/lookup_test.go
@@ -2138,6 +2138,7 @@ func TestAllNsLookupServFail(t *testing.T) {
 func TestInvalidInputsLookup(t *testing.T) {
 	config := NewResolverConfig()
 	config.LocalAddrs = []net.IP{net.ParseIP("127.0.0.1")}
+	config.ExternalNameServers = []string{"127.0.0.1:53"}
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 	q := Question{

--- a/src/zdns/nslookup.go
+++ b/src/zdns/nslookup.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/zmap/dns"
 )
 
@@ -41,10 +40,6 @@ type NSResult struct {
 
 // DoNSLookup performs a DNS NS lookup on the given name against the given name server.
 func (r *Resolver) DoNSLookup(lookupName, nameServer string, isIterative bool) (*NSResult, Trace, Status, error) {
-	if !isIterative && len(nameServer) == 0 {
-		nameServer = r.randomExternalNameServer()
-		log.Info("no name server provided for external NS lookup, using random external name server: ", nameServer)
-	}
 	if len(lookupName) == 0 {
 		return nil, nil, "", errors.New("no name provided for NS lookup")
 	}

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -409,7 +409,6 @@ func (r *Resolver) ExternalLookup(q *Question, dstServer string) (*SingleQueryRe
 	if dstServer != dstServerWithPort {
 		log.Info("no port provided for external lookup, using default port 53")
 	}
-	dstServer = dstServerWithPort
 	dstServerIP, _, err := util.SplitHostPort(dstServerWithPort)
 	if err != nil {
 		return nil, nil, StatusIllegalInput, fmt.Errorf("could not parse name server (%s): %w", dstServer, err)
@@ -419,6 +418,8 @@ func (r *Resolver) ExternalLookup(q *Question, dstServer string) (*SingleQueryRe
 		return nil, nil, StatusIllegalInput, errors.New("cannot mix loopback and non-loopback addresses")
 
 	}
+	// dstServer has been validated and has a port
+	dstServer = dstServerWithPort
 	lookup, trace, status, err := r.lookupClient.DoSingleDstServerLookup(r, *q, dstServer, false)
 	return lookup, trace, status, err
 }

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -319,7 +319,7 @@ func InitResolver(config *ResolverConfig) (*Resolver, error) {
 		c = new(Cache)
 		c.Init(defaultCacheSize)
 	}
-	// copy relevent all values from config to resolver
+	// copy relevant all values from config to resolver
 	r := &Resolver{
 		cache:        c,
 		lookupClient: config.LookupClient,

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -230,7 +230,8 @@ func (rc *ResolverConfig) validateLoopbackConsistency() error {
 		log.Warn("nameservers are loopback, setting local address to loopback to match")
 		rc.LocalAddrs = []net.IP{net.ParseIP(LoopbackAddrString)}
 	} else if noneNameserversLoopback && allLocalAddrsLoopback {
-		return fmt.Errorf("using loopback local addresses with non-loopback nameservers is not supported")
+		return fmt.Errorf("using loopback local addresses with non-loopback nameservers is not supported. " +
+			"Consider setting nameservers to loopback addresses assuming you have a local DNS server")
 	}
 	return nil
 }

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -399,8 +399,16 @@ func (r *Resolver) ExternalLookup(q *Question, dstServer string) (*SingleQueryRe
 
 	if dstServer == "" {
 		dstServer = r.randomExternalNameServer()
+		log.Info("no name server provided for external lookup, using  random external name server: ", dstServer)
 	}
-	lookup, trace, status, err := r.lookupClient.DoSingleDstServerLookup(r, *q, dstServer, false)
+	dstServerWithPort, err := util.AddDefaultPortToDNSServerName(dstServer)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("could not parse name server (%s): %w", dstServer, err)
+	}
+	if dstServer != dstServerWithPort {
+		log.Info("no port provided for external lookup, using default port 53")
+	}
+	lookup, trace, status, err := r.lookupClient.DoSingleDstServerLookup(r, *q, dstServerWithPort, false)
 	return lookup, trace, status, err
 }
 

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -113,6 +113,7 @@ func (rc *ResolverConfig) PopulateAndValidate() error {
 			return errors.New("local address cannot be nil")
 		}
 		if addr.To4() == nil && addr.To16() == nil {
+			// Attempting to cast the LocalAddr to both IPv4/IPv6 has failed, so it's not a valid IP address
 			return fmt.Errorf("invalid local address: %v", addr)
 		}
 	}

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// TODO - we'll need to update this when we add IPv6 support
-	LoopbackAddrString    = "127.0.0.1:53"
+	LoopbackAddrString    = "127.0.0.1"
 	googleDNSResolverAddr = "8.8.8.8:53"
 
 	defaultTimeout               = 15 * time.Second // timeout for resolving a single name
@@ -204,8 +204,10 @@ func (rc *ResolverConfig) validateLoopbackConsistency() error {
 	// Both nameservers and local addresses are completely loopback or non-loopback
 	// if using loopback nameservers, override local addresses to be loopback and warn user
 	if allNameserversLoopback && noneLocalAddrsLoopback {
-		rc.LocalAddrs = []net.IP{net.ParseIP(LoopbackAddrString)}
 		log.Warn("nameservers are loopback, setting local address to loopback to match")
+		rc.LocalAddrs = []net.IP{net.ParseIP(LoopbackAddrString)}
+	} else if noneNameserversLoopback && allLocalAddrsLoopback {
+		return fmt.Errorf("using loopback local addresses with non-loopback nameservers is not supported")
 	}
 	return nil
 }

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -16,11 +16,12 @@ package zdns
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"math/rand"
 	"net"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/dns"
@@ -98,7 +99,7 @@ func (rc *ResolverConfig) PopulateAndValidate() error {
 		return fmt.Errorf("invalid IP version mode: %s", reason)
 	}
 	if rc.Cache != nil && rc.CacheSize != 0 {
-		return fmt.Errorf("cannot use both cache and cacheSize")
+		return errors.New("cannot use both cache and cacheSize")
 	}
 
 	// Check that all nameservers/local addresses are valid
@@ -230,7 +231,7 @@ func (rc *ResolverConfig) validateLoopbackConsistency() error {
 		log.Warn("nameservers are loopback, setting local address to loopback to match")
 		rc.LocalAddrs = []net.IP{net.ParseIP(LoopbackAddrString)}
 	} else if noneNameserversLoopback && allLocalAddrsLoopback {
-		return fmt.Errorf("using loopback local addresses with non-loopback nameservers is not supported. " +
+		return errors.New("using loopback local addresses with non-loopback nameservers is not supported. " +
 			"Consider setting nameservers to loopback addresses assuming you have a local DNS server")
 	}
 	return nil

--- a/src/zdns/resolver_test.go
+++ b/src/zdns/resolver_test.go
@@ -1,0 +1,107 @@
+/*
+* ZDNS Copyright 2024 Regents of the University of Michigan
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy
+* of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+* implied. See the License for the specific language governing
+* permissions and limitations under the License.
+ */
+
+package zdns
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolverConfig_PopulateAndValidate(t *testing.T) {
+	t.Run("Using loopback nameserver and no specified local address", func(t *testing.T) {
+		rc := &ResolverConfig{
+			ExternalNameServers: []string{"127.0.0.53:53"},
+		}
+		err := rc.PopulateAndValidate()
+		require.Nil(t, err, "Expected no error but got %v", err)
+		require.Equal(t, LoopbackAddrString, rc.LocalAddrs[0].String())
+	})
+
+	t.Run("Using nameserver with no port", func(t *testing.T) {
+		rc := &ResolverConfig{
+			ExternalNameServers: []string{"1.1.1.1"},
+		}
+		err := rc.PopulateAndValidate()
+		require.Nil(t, err)
+		require.Equal(t, "1.1.1.1:53", rc.ExternalNameServers[0], "Expected port 53 to be appended to nameserver")
+	})
+	t.Run("Using nameserver with port", func(t *testing.T) {
+		rc := &ResolverConfig{
+			ExternalNameServers: []string{"1.1.1.1:64"},
+		}
+		err := rc.PopulateAndValidate()
+		require.Nil(t, err)
+		require.Equal(t, "1.1.1.1:64", rc.ExternalNameServers[0], "Expected nameserver to remain unchanged")
+	})
+	t.Run("Using local address with no port", func(t *testing.T) {
+		rc := &ResolverConfig{
+			LocalAddrs: []net.IP{net.ParseIP("192.168.1.1")},
+		}
+		err := rc.PopulateAndValidate()
+		require.Nil(t, err)
+		require.Equal(t, "192.168.1.1", rc.LocalAddrs[0].String(), "Expected local address to be unchanged")
+	})
+
+	t.Run("Mixing loopback and non-loopback nameservers results in error", func(t *testing.T) {
+		rc := &ResolverConfig{
+			ExternalNameServers: []string{"127.0.0.1:53", "8.8.8.8:53"},
+		}
+		err := rc.PopulateAndValidate()
+		require.NotNil(t, err, "Mixing loopback and non-loopback nameservers should result in an error")
+	})
+
+	t.Run("Using non-loopback nameservers with loopback local address results in nameserver being overwritten", func(t *testing.T) {
+		rc := &ResolverConfig{
+			ExternalNameServers: []string{"8.8.8.8:53"},
+			LocalAddrs:          []net.IP{net.ParseIP("127.0.0.1")},
+		}
+		err := rc.PopulateAndValidate()
+		require.NotNil(t, err, "Using non-loopback nameservers with loopback local address should result in an error")
+	})
+
+	t.Run("Using loopback nameservers with non-loopback local address results in local address being overwritten", func(t *testing.T) {
+		rc := &ResolverConfig{
+			ExternalNameServers: []string{"127.0.0.1:53"},
+			LocalAddrs:          []net.IP{net.ParseIP("192.168.0.1")},
+		}
+		err := rc.PopulateAndValidate()
+		require.Nil(t, err)
+		require.Equal(t, LoopbackAddrString, rc.LocalAddrs[0].String(), "Expected local address to be overwritten with loopback address")
+	})
+
+	t.Run("Valid non-loopback nameservers and local addresses", func(t *testing.T) {
+		rc := &ResolverConfig{
+			ExternalNameServers: []string{"8.8.8.8:53", "8.8.4.4:53"},
+			LocalAddrs:          []net.IP{net.ParseIP("192.168.0.1"), net.ParseIP("192.168.0.2")},
+		}
+		err := rc.PopulateAndValidate()
+		require.Nil(t, err, "Valid non-loopback nameservers and local addresses should not result in an error")
+		require.Equal(t, "8.8.8.8:53", rc.ExternalNameServers[0], "Expected nameserver to remain unchanged")
+		require.Equal(t, "192.168.0.1", rc.LocalAddrs[0].String(), "Expected local address to remain unchanged")
+	})
+
+	t.Run("Valid loopback nameservers and local addresses", func(t *testing.T) {
+		rc := &ResolverConfig{
+			ExternalNameServers: []string{"127.0.0.1:53", "127.0.0.2:53"},
+			LocalAddrs:          []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("127.0.0.2")},
+		}
+		err := rc.PopulateAndValidate()
+		require.Nil(t, err, "Valid loopback nameservers and local addresses should not result in an error")
+		require.Equal(t, LoopbackAddrString, rc.LocalAddrs[0].String(), "Expected local address to be overwritten with loopback address")
+		require.Equal(t, "127.0.0.1:53", rc.ExternalNameServers[0], "Expected nameserver to remain unchanged")
+	})
+}


### PR DESCRIPTION
While working on adding IPv6 support, I realized I was performing config validation both in the CLI and then again in the Resolver. This basically means we need to have the same validation in two places, and practically it meant that there was little validation for the Resolver library, since most lived in the CLI alone. Adding IPv6 validation to this just became a mess for updating in both places.

To simplify, I've moved most validation into the Resolver in a new `PopulateAndValidate` function on a ResolverConfig. Some things are specific to the CLI (ensuring that the `--local-interface` exists), but everything else should be moved over.

Care will need to be made that any validation failure is easily understandable/actionable to both CLI users and library users, but this seems like the right approach to minimize code duplication.

## Changes
- Remove most validation from the CLI and moved into new `PopulateAndValidate`
- Fix up unit tests that implicitly mixed loopback local addresses and non-loopback nameservers. It didn't affect their testing ability but the new Validate function fails when attempting to instantiate a Resolver with the poorly formed ResolverConfig
- Added unit tests to the PopulateAndValidate fn