### PR TITLE
added context check in iterativeLookup, solves cache contention issue

### DIFF
--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -177,6 +177,12 @@ func (r *Resolver) iterativeLookup(ctx context.Context, q Question, nameServer s
 		r.verboseLog(depth+1, "-> Max recursion depth reached")
 		return result, trace, StatusError, errors.New("max recursion depth reached")
 	}
+	// check that context hasn't expired
+	if util.HasCtxExpired(&ctx) {
+		var result SingleQueryResult
+		r.verboseLog(depth+1, "-> Context expired")
+		return result, trace, StatusTimeout, nil
+	}
 	// create iteration context for this iteration step
 	iterationStepCtx, cancel := context.WithTimeout(ctx, r.iterativeTimeout)
 	defer cancel()


### PR DESCRIPTION
Resolves #404 

## Description
More details in #404, but in short `main` saw ZDNS slow to a crawl and `pprof` trace of goroutines showed most were waiting on a cache shard lock. I used `git bisect` to find the first bad version and it fortunately wasn't the large CLI + library split PR ([c192044](https://github.com/zmap/zdns/commit/c19204421de5f3e28c9d88b9d9353148643f0cd8)) but a much smaller commit's change-set.

Turned out, the first bad version was [67026d](https://github.com/zmap/zdns/commit/67026d05e7c5f6e2fd669e810453c23256e37231), where I tried to improve timeout handling. Specifically, [here](https://github.com/zmap/zdns/commit/67026d05e7c5f6e2fd669e810453c23256e37231#diff-da6c0119d3fe12e4acd95e0f214a43a6176396f97ea18956ecfee722d357768fL214-L222) where I removed the timeout check in `cachedRetryingLookup`. I believe what was happening was that as long as we never went to the wire (where we do check the context again)but stayed just hitting the cache, this execution loop would never time out and the thread would be stuck:
![image](https://github.com/user-attachments/assets/8f665f89-1bc9-4eb5-bb65-6cd20c76b040)

By adding a check on the context in `iterativeLookup`, we can break the cycle.

## Testing
Command - `head -n 7000 10k_crux.input | ./zdns A --iterative --threads=100  --timeout=20 --iteration-timeout=20 --output-file="out.log`

Time to Crawl 7k Domains
`v1.1.0`: - 1 min. 50 sec.
`main`: - > 10 mins, gave up at this point. There were 50/7k domains yet to be resolved
`e5e2d8` - This PR: - 1 min 26 secs
