### PR TITLE
Make test workflow manually trigger-able from Github and update TLSA cert in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 jobs:
   check-license:
     runs-on: ubuntu-latest

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -39,7 +39,7 @@ def recursiveSort(obj):
 
 class Tests(unittest.TestCase):
     maxDiff = None
-    ZDNS_EXECUTABLE = "./zdns"
+    ZDNS_EXECUTABLE = "../zdns"
 
     def run_zdns_check_failure(self, flags, name, expected_err, executable=ZDNS_EXECUTABLE):
         flags = flags + " --threads=10"
@@ -429,7 +429,7 @@ class Tests(unittest.TestCase):
             "cert_usage": 3,
             "selector": 1,
             "matching_type": 1,
-            "certificate": "0c72ac70b745ac19998811b131d662c9ac69dbdbe7cb23e5b514b56664c5d3d6"
+            "certificate": "c1e715b41a893a35c8310e746552a6cd51ebaeadb2bf01d6e38e773f7adebe90"
         }
     ]
 

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -39,7 +39,7 @@ def recursiveSort(obj):
 
 class Tests(unittest.TestCase):
     maxDiff = None
-    ZDNS_EXECUTABLE = "../zdns"
+    ZDNS_EXECUTABLE = "./zdns"
 
     def run_zdns_check_failure(self, flags, name, expected_err, executable=ZDNS_EXECUTABLE):
         flags = flags + " --threads=10"


### PR DESCRIPTION
## Description

Noticed the `TLSA` tests was failing, this PR fixes that.

- Thought it'd be nice to be able to re-run a workflow to run the integration tests in Github not just on a PR but in main manually
- Updated cert specified in the `TLSA` record integration test

Proof the real cert has been updated:
```
$ dig -t TLSA _25._tcp.mail.ietf.org

; <<>> DiG 9.18.24-0ubuntu0.23.10.1-Ubuntu <<>> -t TLSA _25._tcp.mail.ietf.org
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 39317
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;_25._tcp.mail.ietf.org.		IN	TLSA

;; ANSWER SECTION:
_25._tcp.mail.ietf.org.	225	IN	TLSA	3 1 1 C1E715B41A893A35C8310E746552A6CD51EBAEADB2BF01D6E38E773F 7ADEBE90
```