### PR TITLE
Add ability for user to select root servers for iterative mode

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -65,7 +65,7 @@ type CLIConf struct {
 	GoMaxProcs           int
 	Verbosity            int
 	TimeFormat           string
-	NameServers          []string
+	NameServers          []string // recursive resolvers if not in iterative mode, root servers if in iterative mode
 	LookupAllNameServers bool
 	TCPOnly              bool
 	UDPOnly              bool

--- a/src/cli/config_validation.go
+++ b/src/cli/config_validation.go
@@ -85,7 +85,7 @@ func populateNetworkingConfig(gc *CLIConf) error {
 	// To prevent this, we'll check if we're in iterative mode, the user hasn't passed in the local addr/nameservers directly to ZDNS,
 	// and the OS' configured NS's are loopback.  If so, we'll set the nameservers to be our default non-loopback recursive resolvers.
 	// This prevents the edge case described above and has no effect on iterative queries since we just use the root nameservers.
-	if gc.IterativeResolution && !gc.LocalAddrSpecified && areOSNameserversLoopback(gc) {
+	if gc.IterativeResolution && !gc.LocalAddrSpecified && areOSNameserversLoopback(gc) && len(gc.NameServersString) == 0 {
 		log.Debug("OS external resolution nameservers are loopback and iterative mode is enabled. " +
 			"Using default non-loopback nameservers to prevent resolution failure edge case")
 		gc.NameServers = util.GetDefaultResolvers()

--- a/src/cli/config_validation.go
+++ b/src/cli/config_validation.go
@@ -75,7 +75,6 @@ func populateNetworkingConfig(gc *CLIConf) error {
 		log.Info("using local interface: ", gc.LocalIfaceString)
 	}
 
-	// TODO this now needs re-work
 	// If we're in iterative mode, we always start the DNS resolution iterative process at the root DNS servers.
 	// However, the ZDNS resolver library we'll create doesn't know that all queries will be iterative, it's designed to be able to do
 	// both iterative queries and use a recursive resolver with the same config. While usually fine, there's an edge case here

--- a/src/cli/config_validation.go
+++ b/src/cli/config_validation.go
@@ -75,6 +75,7 @@ func populateNetworkingConfig(gc *CLIConf) error {
 		log.Info("using local interface: ", gc.LocalIfaceString)
 	}
 
+	// TODO this now needs re-work
 	// If we're in iterative mode, we always start the DNS resolution iterative process at the root DNS servers.
 	// However, the ZDNS resolver library we'll create doesn't know that all queries will be iterative, it's designed to be able to do
 	// both iterative queries and use a recursive resolver with the same config. While usually fine, there's an edge case here

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -176,9 +176,8 @@ func populateResolverConfig(gc *CLIConf, flags *pflag.FlagSet) *zdns.ResolverCon
 		config.RootNameServers = zdns.RootServersV4[:]
 	} else if !gc.IterativeResolution && len(gc.NameServers) != 0 {
 		config.ExternalNameServers = gc.NameServers
-	} else {
-		// Resolver will populate the external name servers with either the OS default or the ZDNS default if none exist
 	}
+	// Else: Resolver will populate the external name servers with either the OS default or the ZDNS default if none exist
 	config.LookupAllNameServers = gc.LookupAllNameServers
 	config.FollowCNAMEs = gc.FollowCNAMEs
 

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -170,10 +170,14 @@ func populateResolverConfig(gc *CLIConf, flags *pflag.FlagSet) *zdns.ResolverCon
 	config.Timeout = time.Second * time.Duration(gc.Timeout)
 	config.IterativeTimeout = time.Second * time.Duration(gc.IterationTimeout)
 	// copy nameservers to resolver config
-	if gc.IterativeResolution {
+	if gc.IterativeResolution && len(gc.NameServers) != 0 {
 		config.RootNameServers = gc.NameServers
-	} else {
+	} else if gc.IterativeResolution {
+		config.RootNameServers = zdns.RootServersV4[:]
+	} else if !gc.IterativeResolution && len(gc.NameServers) != 0 {
 		config.ExternalNameServers = gc.NameServers
+	} else {
+		// Resolver will populate the external name servers with either the OS default or the ZDNS default if none exist
 	}
 	config.LookupAllNameServers = gc.LookupAllNameServers
 	config.FollowCNAMEs = gc.FollowCNAMEs

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -170,7 +170,11 @@ func populateResolverConfig(gc *CLIConf, flags *pflag.FlagSet) *zdns.ResolverCon
 	config.Timeout = time.Second * time.Duration(gc.Timeout)
 	config.IterativeTimeout = time.Second * time.Duration(gc.IterationTimeout)
 	// copy nameservers to resolver config
-	config.ExternalNameServers = gc.NameServers
+	if gc.IterativeResolution {
+		config.RootNameServers = gc.NameServers
+	} else {
+		config.ExternalNameServers = gc.NameServers
+	}
 	config.LookupAllNameServers = gc.LookupAllNameServers
 	config.FollowCNAMEs = gc.FollowCNAMEs
 


### PR DESCRIPTION
## Description
A user may want to select a set of root name servers other than the full 13 `.` roots, either to only use one root or to test against a different server. This PR adds that.

## Testing
### When selecting a root server, ZDNS uses it
```
$ echo "cloudflare.com" | ./zdns A --iterative --name-servers="198.41.0.4" --verbosity=5

INFO[0000] using local addresses: [192.168.1.243]       
INFO[0000] for non-iterative lookups, using external nameservers: 198.41.0.4:53 
INFO[0000] for iterative lookups, using nameservers: 198.41.0.4:53 
DEBU[0000] DEPTH 00:[MIEKG-IN: starting a C/DNAME following lookup for  cloudflare.com  ( 1 )] 
DEBU[0000] DEPTH 01:    [MIEKG-IN: following iterative lookup for  cloudflare.com  ( 1 )] 
DEBU[0000] DEPTH 01:    [iterative lookup for  cloudflare.com  ( 1 ) against  198.41.0.4:53  layer  .] 
DEBU[0000] DEPTH 02:        [Cached retrying lookup. Name:  {1 1 cloudflare.com} , Layer:  . , Nameserver:  198.41.0.4:53] 
DEBU[0000] DEPTH 03:            [Cache request for:  cloudflare.com  ( 1 )] 
```
Notice how we start the lookup against the 1 root provided.

### Normal usage isn't broken
```
$ echo "cloudflare.com" | ./zdns A --iterative --verbosity=5

INFO[0000] using local addresses: [192.168.1.243]       
INFO[0000] for non-iterative lookups, using external nameservers: 192.168.1.1:53 
INFO[0000] for iterative lookups, using nameservers: 198.41.0.4:53, 170.247.170.2:53, 192.33.4.12:53, 199.7.91.13:53, 192.203.230.10:53, 192.5.5.241:53, 192.112.36.4:53, 198.97.190.53:53, 192.36.148.17:53, 192.58.128.30:53, 193.0.14.129:53, 199.7.83.42:53, 202.12.27.33:53 
DEBU[0000] DEPTH 00:[MIEKG-IN: starting a C/DNAME following lookup for  cloudflare.com  ( 1 )] 
DEBU[0000] DEPTH 01:    [MIEKG-IN: following iterative lookup for  cloudflare.com  ( 1 )] 
DEBU[0000] DEPTH 01:    [iterative lookup for  cloudflare.com  ( 1 ) against  202.12.27.33:53  layer  .] 
DEBU[0000] DEPTH 02:        [Cached retrying lookup. Name:  {1 1 cloudflare.com} , Layer:  . , Nameserver:  202.12.27.33:53] 
```