### PR TITLE
fix issue when OS' nameserver is loopback with --iterative

### DIFF
--- a/benchmark/main.go
+++ b/benchmark/main.go
@@ -93,7 +93,7 @@ func main() {
 		log.Panicf("failed to set ZDNS_PPROF environment variable: %v", err)
 	}
 
-	cmd := exec.Command("../zdns", "A", "--iterative", "--verbosity=3", "--name-servers=1.1.1.1,8.8.8.8", "--threads=100")
+	cmd := exec.Command("../zdns", "A", "--iterative", "--verbosity=3", "--threads=100")
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/src/cli/config_validation.go
+++ b/src/cli/config_validation.go
@@ -31,8 +31,8 @@ func populateNetworkingConfig(gc *CLIConf) error {
 		return errors.New("--local-addr and --local-interface cannot both be specified")
 	}
 
-	if err := populateNameServers(gc); err != nil {
-		return errors.Wrap(err, "name servers did not pass validation")
+	if err := parseNameServers(gc); err != nil {
+		return errors.Wrap(err, "name servers could not be parsed")
 	}
 
 	if err := validateClientSubnetString(gc); err != nil {
@@ -105,7 +105,7 @@ func validateClientSubnetString(gc *CLIConf) error {
 	return nil
 }
 
-func populateNameServers(gc *CLIConf) error {
+func parseNameServers(gc *CLIConf) error {
 	if gc.LookupAllNameServers && gc.NameServersString != "" {
 		log.Fatal("name servers cannot be specified in --all-nameservers mode.")
 	}

--- a/src/cli/config_validation.go
+++ b/src/cli/config_validation.go
@@ -23,8 +23,6 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/dns"
-
-	"github.com/zmap/zdns/src/zdns"
 )
 
 func populateNetworkingConfig(gc *CLIConf) error {
@@ -75,30 +73,6 @@ func populateNetworkingConfig(gc *CLIConf) error {
 	}
 
 	return nil
-}
-
-// areOSNameserversLoopback returns true if the OS' configured nameservers (in /etc/resolv.conf by default) are loopback addresses
-func areOSNameserversLoopback(gc *CLIConf) bool {
-	nses, err := zdns.GetDNSServers(gc.ConfigFilePath)
-	if err != nil {
-		log.Fatalf("Error getting OS nameservers: %s", err.Error())
-	}
-	for _, ns := range nses {
-		ipString, _, err := net.SplitHostPort(ns)
-		if err != nil {
-			// might be missing a port
-			ipString = ns
-		}
-		ip := net.ParseIP(ipString)
-		if ip == nil {
-			log.Fatalf("Error parsing OS nameserver IP: %s", ns)
-		}
-		if ip.IsLoopback() {
-			return true
-		}
-
-	}
-	return false
 }
 
 func validateClientSubnetString(gc *CLIConf) error {

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -174,8 +174,8 @@ func populateResolverConfig(gc *CLIConf, flags *pflag.FlagSet) *zdns.ResolverCon
 		// While this is a bit of a hack to set both the root and external name servers to the same values, the CLI
 		// can only be used in either recursive or iterative mode. If we don't do this and leave one or the other empty,
 		// the resolver will attempt to auto-populate with the OS/ZDNS defaults. If these defaults and the user-provided
-		// values have a loopback mismatch (some are loopback, others aren't), this causes issues.
-		// By setting them both here, we prevent that auto-populate.
+		// values have a loopback mismatch (some are loopback, others aren't), the config won't pass loopback mismatch
+		// validation. By setting them both here, we prevent that auto-populate issue.
 		config.RootNameServers = gc.NameServers
 		config.ExternalNameServers = gc.NameServers
 	} else if gc.IterativeResolution {

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -176,17 +176,6 @@ func populateResolverConfig(gc *CLIConf, flags *pflag.FlagSet) *zdns.ResolverCon
 
 	config.Timeout = time.Second * time.Duration(gc.Timeout)
 	config.IterativeTimeout = time.Second * time.Duration(gc.IterationTimeout)
-	config, err = populateNameServers(gc, config)
-	if err != nil {
-		log.Fatal("could not populate name servers: ", err)
-	}
-	// User/OS defaults could contain duplicates, remove
-	config.ExternalNameServers = util.RemoveDuplicates(config.ExternalNameServers)
-	config.RootNameServers = util.RemoveDuplicates(config.RootNameServers)
-	config, err = populateLocalAddresses(gc, config)
-	if err != nil {
-		log.Fatal("could not populate local addresses: ", err)
-	}
 	config.LookupAllNameServers = gc.LookupAllNameServers
 	config.FollowCNAMEs = gc.FollowCNAMEs
 
@@ -212,6 +201,18 @@ func populateResolverConfig(gc *CLIConf, flags *pflag.FlagSet) *zdns.ResolverCon
 		if err := config.Blacklist.ParseFromFile(gc.BlacklistFilePath); err != nil {
 			log.Fatal("unable to parse blacklist file: ", err)
 		}
+	}
+	// This must occur after setting the DNSConfigFilePath above, so that ZDNS knows where to fetch the DNS Config
+	config, err = populateNameServers(gc, config)
+	if err != nil {
+		log.Fatal("could not populate name servers: ", err)
+	}
+	// User/OS defaults could contain duplicates, remove
+	config.ExternalNameServers = util.RemoveDuplicates(config.ExternalNameServers)
+	config.RootNameServers = util.RemoveDuplicates(config.RootNameServers)
+	config, err = populateLocalAddresses(gc, config)
+	if err != nil {
+		log.Fatal("could not populate local addresses: ", err)
 	}
 	return config
 }

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -17,6 +17,8 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"github.com/pkg/errors"
+	"net"
 	"os"
 	"runtime"
 	"strconv"
@@ -34,6 +36,10 @@ import (
 	blacklist "github.com/zmap/zdns/src/internal/safeblacklist"
 	"github.com/zmap/zdns/src/internal/util"
 	"github.com/zmap/zdns/src/zdns"
+)
+
+const (
+	googleDNSResolverAddr = "8.8.8.8:53"
 )
 
 type routineMetadata struct {
@@ -169,20 +175,17 @@ func populateResolverConfig(gc *CLIConf, flags *pflag.FlagSet) *zdns.ResolverCon
 
 	config.Timeout = time.Second * time.Duration(gc.Timeout)
 	config.IterativeTimeout = time.Second * time.Duration(gc.IterationTimeout)
-	// copy nameservers to resolver config
-	if len(gc.NameServers) != 0 {
-		// While this is a bit of a hack to set both the root and external name servers to the same values, the CLI
-		// can only be used in either recursive or iterative mode. If we don't do this and leave one or the other empty,
-		// the resolver will attempt to auto-populate with the OS/ZDNS defaults. If these defaults and the user-provided
-		// values have a loopback mismatch (some are loopback, others aren't), the config won't pass loopback mismatch
-		// validation. By setting them both here, we prevent that auto-populate issue.
-		config.RootNameServers = gc.NameServers
-		config.ExternalNameServers = gc.NameServers
-	} else if gc.IterativeResolution {
-		config.ExternalNameServers = zdns.RootServersV4[:]
-		config.RootNameServers = zdns.RootServersV4[:]
+	config, err = populateNameServers(gc, config)
+	if err != nil {
+		log.Fatal("could not populate name servers: ", err)
 	}
-	// Else: Resolver will populate the external name servers with either the OS default or the ZDNS default if none exist
+	// User/OS defaults could contain duplicates, remove
+	config.ExternalNameServers = util.RemoveDuplicates(config.ExternalNameServers)
+	config.RootNameServers = util.RemoveDuplicates(config.RootNameServers)
+	config, err = populateLocalAddresses(gc, config)
+	if err != nil {
+		log.Fatal("could not populate local addresses: ", err)
+	}
 	config.LookupAllNameServers = gc.LookupAllNameServers
 	config.FollowCNAMEs = gc.FollowCNAMEs
 
@@ -198,7 +201,6 @@ func populateResolverConfig(gc *CLIConf, flags *pflag.FlagSet) *zdns.ResolverCon
 	config.MaxDepth = gc.MaxDepth
 	config.CheckingDisabledBit = gc.CheckingDisabled
 	config.ShouldRecycleSockets = gc.RecycleSockets
-	config.LocalAddrs = gc.LocalAddrs
 	config.DNSSecEnabled = gc.Dnssec
 	config.DNSConfigFilePath = gc.ConfigFilePath
 
@@ -213,12 +215,99 @@ func populateResolverConfig(gc *CLIConf, flags *pflag.FlagSet) *zdns.ResolverCon
 	return config
 }
 
+func populateNameServers(gc *CLIConf, config *zdns.ResolverConfig) (*zdns.ResolverConfig, error) {
+	// Nameservers are populated in this order:
+	// 1. If user provided nameservers, use those
+	// 2. (External Only) If we can get the OS' default recursive resolver nameservers, use those
+	// 3. Use ZDNS defaults
+
+	// Additionally, both Root and External nameservers must be populated, since the Resolver doesn't know we'll only
+	// be performing either iterative or recursive lookups, not both.
+
+	if len(gc.NameServers) != 0 {
+		// User provided name servers, use them.
+		// Check that the nameservers have a port and append one if necessary
+		portValidatedNSs := make([]string, 0, len(gc.NameServers))
+		// check that the nameservers have a port and append one if necessary
+		for _, ns := range gc.NameServers {
+			portNS, err := util.AddDefaultPortToDNSServerName(ns)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse name server: %s", ns)
+			}
+			portValidatedNSs = append(portValidatedNSs, portNS)
+		}
+		config.ExternalNameServers = portValidatedNSs
+		config.RootNameServers = portValidatedNSs
+		return config, nil
+	}
+	// User did not provide nameservers
+	if !gc.IterativeResolution {
+		// Try to get the OS' default recursive resolver nameservers
+		ns, err := zdns.GetDNSServers(config.DNSConfigFilePath)
+		if err != nil {
+			ns = util.GetDefaultResolvers()
+			log.Warn("Unable to parse resolvers file. Using ZDNS defaults: ", strings.Join(ns, ", "))
+		}
+		config.ExternalNameServers = ns
+		config.RootNameServers = ns
+		return config, nil
+	}
+	// User did not provide nameservers and we're doing iterative resolution, use ZDNS defaults
+	config.ExternalNameServers = zdns.RootServersV4[:]
+	config.RootNameServers = zdns.RootServersV4[:]
+	return config, nil
+}
+
+func populateLocalAddresses(gc *CLIConf, config *zdns.ResolverConfig) (*zdns.ResolverConfig, error) {
+	// Local Addresses are populated in this order:
+	// 1. If user provided local addresses, use those
+	// 2. If the config's nameservers are loopback, use the local loopback address
+	// 3. Otherwise, try to connect to Google's recursive resolver and take the IP address we use for the connection
+	if len(gc.LocalAddrs) != 0 {
+		// if user provided a local address, that takes precedent
+		config.LocalAddrs = gc.LocalAddrs
+		return config, nil
+	}
+	// if the nameservers are loopback, use the loopback address
+	if len(config.ExternalNameServers) == 0 {
+		// this shouldn't happen
+		return nil, errors.New("name servers must be set before populating local addresses")
+	}
+	anyNameServersLoopack := false
+	for _, ns := range util.Concat(config.ExternalNameServers, config.RootNameServers) {
+		ip, _, err := util.SplitHostPort(ns)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not split host and port for nameserver: %s", ns)
+		}
+		if ip.IsLoopback() {
+			anyNameServersLoopack = true
+			break
+		}
+	}
+	if anyNameServersLoopack {
+		// set local address so name servers are reachable
+		config.LocalAddrs = []net.IP{net.ParseIP(zdns.LoopbackAddrString)}
+	} else {
+		// localAddr not set, so we need to find the default IP address
+		conn, err := net.Dial("udp", googleDNSResolverAddr)
+		if err != nil {
+			return nil, fmt.Errorf("unable to find default IP address to open socket: %w", err)
+		}
+		config.LocalAddrs = []net.IP{conn.LocalAddr().(*net.UDPAddr).IP}
+		// cleanup socket
+		if err = conn.Close(); err != nil {
+			log.Error("unable to close test connection to Google public DNS: ", err)
+		}
+	}
+	return config, nil
+}
+
 func Run(gc CLIConf, flags *pflag.FlagSet) {
 	gc = *populateCLIConfig(&gc, flags)
 	resolverConfig := populateResolverConfig(&gc, flags)
-	err := resolverConfig.PopulateAndValidate()
+	err := resolverConfig.Validate()
 	if err != nil {
-		log.Fatal("could not populate defaults and validate resolver config: ", err)
+		log.Fatalf("resolver config did not pass validation: %v", err)
 	}
 	// Log any information about the resolver configuration, according to log level
 	resolverConfig.PrintInfo()
@@ -303,12 +392,12 @@ func Run(gc CLIConf, flags *pflag.FlagSet) {
 		} else {
 			f, err = os.OpenFile(gc.MetadataFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, util.DefaultFilePermissions)
 			if err != nil {
-				log.Fatal("unable to open metadata file:", err.Error())
+				log.Fatalf("unable to open metadata file: %v", err)
 			}
 			defer func(f *os.File) {
 				err = f.Close()
 				if err != nil {
-					log.Error("unable to close metadata file:", err.Error())
+					log.Errorf("unable to close metadata file:", err)
 				}
 			}(f)
 		}

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -25,10 +25,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/hashicorp/go-version"
 	"github.com/liip/sheriff"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/zmap/dns"
@@ -198,7 +197,7 @@ func populateResolverConfig(gc *CLIConf, flags *pflag.FlagSet) *zdns.ResolverCon
 
 	if gc.BlacklistFilePath != "" {
 		config.Blacklist = blacklist.New()
-		if err := config.Blacklist.ParseFromFile(gc.BlacklistFilePath); err != nil {
+		if err = config.Blacklist.ParseFromFile(gc.BlacklistFilePath); err != nil {
 			log.Fatal("unable to parse blacklist file: ", err)
 		}
 	}

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -17,7 +17,6 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"net"
 	"os"
 	"runtime"
@@ -25,6 +24,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/hashicorp/go-version"
 	"github.com/liip/sheriff"
@@ -397,7 +398,7 @@ func Run(gc CLIConf, flags *pflag.FlagSet) {
 			defer func(f *os.File) {
 				err = f.Close()
 				if err != nil {
-					log.Errorf("unable to close metadata file:", err)
+					log.Errorf("unable to close metadata file: %v", err)
 				}
 			}(f)
 		}

--- a/src/internal/util/util.go
+++ b/src/internal/util/util.go
@@ -168,3 +168,8 @@ func Concat[S ~[]E, E any](slices ...S) S {
 	}
 	return newSlice
 }
+
+// IsIPv6 checks if the given IP address is an IPv6 address.
+func IsIPv6(ip *net.IP) bool {
+	return ip != nil && ip.To4() == nil && ip.To16() != nil
+}

--- a/src/modules/axfr/axfr_test.go
+++ b/src/modules/axfr/axfr_test.go
@@ -91,9 +91,12 @@ func InitTest() (*AxfrLookupModule, *zdns.Resolver) {
 	nsStatus = zdns.StatusNoError
 
 	cc := new(cli.CLIConf)
-	cc.NameServers = []string{"127.0.0.1"}
 
 	rc := new(zdns.ResolverConfig)
+	rc.RootNameServers = []string{"127.0.0.53:53"}
+	rc.ExternalNameServers = []string{"127.0.0.53:53"}
+	rc.LocalAddrs = []net.IP{net.ParseIP("127.0.0.1")}
+
 	flagSet := new(pflag.FlagSet)
 	flagSet.Bool("ipv4-lookup", false, "Use IPv4")
 	flagSet.Bool("ipv6-lookup", false, "Use IPv6")

--- a/src/modules/bindversion/bindversion_test.go
+++ b/src/modules/bindversion/bindversion_test.go
@@ -15,6 +15,7 @@
 package bindversion
 
 import (
+	"net"
 	"testing"
 
 	"github.com/zmap/dns"
@@ -46,7 +47,9 @@ func (ml MockLookup) DoSingleDstServerLookup(r *zdns.Resolver, question zdns.Que
 func InitTest(t *testing.T) *zdns.Resolver {
 	mockResults = make(map[string]*zdns.SingleQueryResult)
 	rc := zdns.ResolverConfig{
-		ExternalNameServers: []string{"1.1.1.1"},
+		ExternalNameServers: []string{"1.1.1.1:53"},
+		RootNameServers:     []string{"1.1.1.1:53"},
+		LocalAddrs:          []net.IP{net.ParseIP("192.168.1.1")},
 		LookupClient:        MockLookup{}}
 	r, err := zdns.InitResolver(&rc)
 	assert.NilError(t, err)

--- a/src/modules/dmarc/dmarc_test.go
+++ b/src/modules/dmarc/dmarc_test.go
@@ -15,6 +15,7 @@
 package dmarc
 
 import (
+	"net"
 	"testing"
 
 	"github.com/zmap/dns"
@@ -47,6 +48,8 @@ func InitTest(t *testing.T) *zdns.Resolver {
 	mockResults = make(map[string]*zdns.SingleQueryResult)
 	rc := zdns.ResolverConfig{
 		ExternalNameServers: []string{"127.0.0.1:53"},
+		RootNameServers:     []string{"127.0.0.53:53"},
+		LocalAddrs:          []net.IP{net.ParseIP("127.0.0.1")},
 		LookupClient:        MockLookup{}}
 	r, err := zdns.InitResolver(&rc)
 	assert.NilError(t, err)

--- a/src/modules/spf/spf_test.go
+++ b/src/modules/spf/spf_test.go
@@ -15,6 +15,7 @@
 package spf
 
 import (
+	"net"
 	"testing"
 
 	"github.com/zmap/dns"
@@ -48,6 +49,8 @@ func InitTest(t *testing.T) *zdns.Resolver {
 	queries = make([]QueryRecord, 0)
 	rc := zdns.ResolverConfig{
 		ExternalNameServers: []string{"127.0.0.1:53"},
+		RootNameServers:     []string{"127.0.0.53:53"},
+		LocalAddrs:          []net.IP{net.ParseIP("127.0.0.1")},
 		LookupClient:        MockLookup{}}
 	r, err := zdns.InitResolver(&rc)
 	assert.NilError(t, err)

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -65,14 +65,6 @@ func (r *Resolver) doSingleDstServerLookup(q Question, nameServer string, isIter
 	if nameServer == "" {
 		return nil, nil, StatusIllegalInput, errors.New("no nameserver specified")
 	}
-	// nameserver must be reachable from the local address
-	nameServerIP := net.ParseIP(nameServerIPString)
-	if nameServerIP == nil {
-		return nil, nil, StatusIllegalInput, fmt.Errorf("could not parse nameserver IP: %s", nameServerIPString)
-	}
-	if nameServerIP.IsLoopback() != r.localAddr.IsLoopback() {
-		return nil, nil, StatusIllegalInput, fmt.Errorf("nameserver %s must be reachable from the local address %s, ie. both must be loopback or not loopback", nameServerIPString, r.localAddr.String())
-	}
 
 	// Stop if we hit a nameserver we don't want to hit
 	if r.blacklist != nil {

--- a/src/zdns/lookup_test.go
+++ b/src/zdns/lookup_test.go
@@ -58,7 +58,9 @@ func InitTest(t *testing.T) *ResolverConfig {
 
 	mc := MockLookupClient{}
 	config := NewResolverConfig()
-	config.ExternalNameServers = []string{"127.0.0.1"}
+	config.ExternalNameServers = []string{"127.0.0.1:53"}
+	config.RootNameServers = []string{"127.0.0.1:53"}
+	config.LocalAddrs = []net.IP{net.ParseIP("127.0.0.1")}
 	config.LookupClient = mc
 
 	return config

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -388,14 +388,16 @@ func (r *Resolver) ExternalLookup(q *Question, dstServer string) (*SingleQueryRe
 	}
 	dstServerWithPort, err := util.AddDefaultPortToDNSServerName(dstServer)
 	if err != nil {
-		return nil, nil, StatusIllegalInput, fmt.Errorf("could not parse name server (%s): %w", dstServer, err)
+		// TODO update below when adding IPv6, add ex. IPv6
+		return nil, nil, StatusIllegalInput, fmt.Errorf("could not parse name server (%s): %w. Correct format IPv4 (1.1.1.1:53)", dstServer, err)
 	}
 	if dstServer != dstServerWithPort {
 		log.Info("no port provided for external lookup, using default port 53")
 	}
 	dstServerIP, _, err := util.SplitHostPort(dstServerWithPort)
 	if err != nil {
-		return nil, nil, StatusIllegalInput, fmt.Errorf("could not parse name server (%s): %w", dstServer, err)
+		// TODO update below when adding IPv6, add ex. IPv6
+		return nil, nil, StatusIllegalInput, fmt.Errorf("could not parse name server (%s): %w. Correct format IPv4 (1.1.1.1:53)", dstServer, err)
 	}
 	// check that local address and dstServer's don't have a loopback mismatch
 	if r.localAddr.IsLoopback() != dstServerIP.IsLoopback() {

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -33,8 +33,7 @@ import (
 
 const (
 	// TODO - we'll need to update this when we add IPv6 support
-	LoopbackAddrString    = "127.0.0.1"
-	googleDNSResolverAddr = "8.8.8.8:53"
+	LoopbackAddrString = "127.0.0.1"
 
 	defaultTimeout               = 15 * time.Second // timeout for resolving a single name
 	defaultIterativeTimeout      = 4 * time.Second  // timeout for single iteration in an iterative query
@@ -86,22 +85,9 @@ type ResolverConfig struct {
 	CheckingDisabledBit bool
 }
 
-// PopulateAndValidate checks if the ResolverConfig is valid and populates any missing fields with default values.
-func (rc *ResolverConfig) PopulateAndValidate() error {
-	// when creating multiple resolvers, each will call this function against the same config.
-	rc.Lock()
-	defer rc.Unlock()
-
-	// populate any missing values in resolver config
-	if err := rc.populateResolverConfig(); err != nil {
-		return errors.Wrap(err, "could not populate resolver config")
-	}
-
-	// Potentially, a name-server could be listed multiple times by either the user or in the OS's respective /etc/resolv.conf
-	// De-dupe
-	rc.ExternalNameServers = util.RemoveDuplicates(rc.ExternalNameServers)
-	rc.RootNameServers = util.RemoveDuplicates(rc.RootNameServers)
-
+// Validate checks if the ResolverConfig is valid, returns an error describing the issue if it is not.
+// This function should not modify the config
+func (rc *ResolverConfig) Validate() error {
 	if isValid, reason := rc.TransportMode.isValid(); !isValid {
 		return fmt.Errorf("invalid transport mode: %s", reason)
 	}
@@ -112,26 +98,74 @@ func (rc *ResolverConfig) PopulateAndValidate() error {
 		return errors.New("cannot use both cache and cacheSize")
 	}
 
-	// Check that all nameservers/local addresses are valid
+	// External Nameservers
+	if len(rc.ExternalNameServers) == 0 {
+		return errors.New("must have at least one external name server")
+	}
+
 	for _, ns := range rc.ExternalNameServers {
-		if _, _, err := net.SplitHostPort(ns); err != nil {
-			return fmt.Errorf("invalid external name server: %s", ns)
+		ipString, _, err := net.SplitHostPort(ns)
+		if err != nil {
+			return fmt.Errorf("could not parse external name server (%s), must be valid IP and have port appended, ex: 1.2.3.4:53", ns)
 		}
+		ip := net.ParseIP(ipString)
+		if ip == nil {
+			return fmt.Errorf("could not parse external name server (%s), must be valid IP and have port appended, ex: 1.2.3.4:53", ns)
+		}
+	}
+	// Check Root Servers
+	if len(rc.RootNameServers) == 0 {
+		return errors.New("must have at least one root name server")
 	}
 	for _, ns := range rc.RootNameServers {
-		if _, _, err := net.SplitHostPort(ns); err != nil {
-			return fmt.Errorf("invalid root name server: %s", ns)
+		ipString, _, err := net.SplitHostPort(ns)
+		if err != nil {
+			return fmt.Errorf("could not parse root name server (%s), must be valid IP and have port appended, ex: 1.2.3.4:53", ns)
+		}
+		ip := net.ParseIP(ipString)
+		if ip == nil {
+			return fmt.Errorf("could not parse root name server (%s), must be valid IP and have port appended, ex: 1.2.3.4:53", ns)
 		}
 	}
-	for _, addr := range rc.LocalAddrs {
-		if addr == nil {
+
+	// TODO - Remove when we add IPv6 support
+	for _, ns := range rc.RootNameServers {
+		// we know ns passed validation above
+		ip := net.ParseIP(ns)
+		if util.IsIPv6(&ip) {
+			return fmt.Errorf("IPv6 root nameservers are not supported: %s", ns)
+		}
+	}
+	for _, ns := range rc.ExternalNameServers {
+		// we know ns passed validation above
+		ip := net.ParseIP(ns)
+		if util.IsIPv6(&ip) {
+			return fmt.Errorf("IPv6 extenral nameservers are not supported: %s", ns)
+		}
+	}
+	// TODO end IPv6 section
+
+	// Local Addresses
+	if len(rc.LocalAddrs) == 0 {
+		return errors.New("must have a local address to send traffic from")
+	}
+
+	for _, ip := range rc.LocalAddrs {
+		if ip == nil {
 			return errors.New("local address cannot be nil")
 		}
-		if addr.To4() == nil && addr.To16() == nil {
-			// Attempting to cast the LocalAddr to both IPv4/IPv6 has failed, so it's not a valid IP address
-			return fmt.Errorf("invalid local address: %v", addr)
+		if ip.To4() == nil && ip.To16() == nil {
+			return fmt.Errorf("invalid local address: %v", ip)
 		}
 	}
+
+	// TODO - Remove when we add IPv6 support
+	for _, addr := range rc.LocalAddrs {
+		if util.IsIPv6(&addr) {
+			return fmt.Errorf("IPv6 local addresses are not supported: %v", rc.LocalAddrs)
+		}
+	}
+	// TODO end IPv6 section
 
 	if err := rc.validateLoopbackConsistency(); err != nil {
 		return errors.Wrap(err, "could not validate loopback consistency")
@@ -140,139 +174,37 @@ func (rc *ResolverConfig) PopulateAndValidate() error {
 	return nil
 }
 
-func (rc *ResolverConfig) populateResolverConfig() error {
-	// External Nameservers
-	if len(rc.ExternalNameServers) == 0 {
-		// if nameservers aren't set, use OS' default
-		ns, err := GetDNSServers(rc.DNSConfigFilePath)
-		if err != nil {
-			ns = util.GetDefaultResolvers()
-			log.Warn("Unable to parse resolvers file. Using ZDNS defaults: ", strings.Join(ns, ", "))
-		}
-		rc.ExternalNameServers = ns
-	} else {
-		portValidatedNSs := make([]string, 0, len(rc.ExternalNameServers))
-		// check that the nameservers have a port and append one if necessary
-		for _, ns := range rc.ExternalNameServers {
-			portNS, err := util.AddDefaultPortToDNSServerName(ns)
-			if err != nil {
-				return fmt.Errorf("could not parse name server: %s", ns)
-			}
-			portValidatedNSs = append(portValidatedNSs, portNS)
-		}
-		rc.ExternalNameServers = portValidatedNSs
-	}
-	if len(rc.RootNameServers) != 0 {
-		portValidatedNSs := make([]string, 0, len(rc.RootNameServers))
-		// check that the nameservers have a port and append one if necessary
-		for _, ns := range rc.RootNameServers {
-			portNS, err := util.AddDefaultPortToDNSServerName(ns)
-			if err != nil {
-				return fmt.Errorf("could not parse root name server: %s", ns)
-			}
-			portValidatedNSs = append(portValidatedNSs, portNS)
-		}
-		rc.RootNameServers = portValidatedNSs
-
-	}
-	// TODO - Remove when we add IPv6 support
-	ipv4NameServers := make([]string, 0, len(rc.ExternalNameServers))
-	for _, ns := range rc.ExternalNameServers {
-		ip, _, err := util.SplitHostPort(ns)
-		if err != nil {
-			return fmt.Errorf("could not split host and port for nameserver: %s", ns)
-		}
-		if ip.To4() != nil {
-			ipv4NameServers = append(ipv4NameServers, ns)
-		}
-	}
-	rc.ExternalNameServers = ipv4NameServers
-
-	// Local Addresses
-	if len(rc.LocalAddrs) == 0 {
-		// localAddr not set, so we need to find the default IP address
-		conn, err := net.Dial("udp", googleDNSResolverAddr)
-		if err != nil {
-			return fmt.Errorf("unable to find default IP address to open socket: %w", err)
-		}
-		rc.LocalAddrs = append(rc.LocalAddrs, conn.LocalAddr().(*net.UDPAddr).IP)
-		// cleanup socket
-		if err = conn.Close(); err != nil {
-			log.Error("unable to close test connection to Google public DNS: ", err)
-		}
-	}
-
-	// TODO - Remove when we add IPv6 support
-	ipv4LocalAddrs := make([]net.IP, 0, len(rc.LocalAddrs))
-	for _, addr := range rc.LocalAddrs {
-		if addr.To4() != nil {
-			ipv4LocalAddrs = append(ipv4LocalAddrs, addr)
-		} else {
-			log.Info("ignoring non-IPv4 local address: ", addr)
-		}
-	}
-	rc.LocalAddrs = ipv4LocalAddrs
-	return nil
-}
-
 // validateLoopbackConsistency checks that the following is true
-// - if using a loopback nameserver, all nameservers are loopback and vice-versa
-// - if using a loopback local address, all local addresses are loopback and vice-versa
 // - either all nameservers AND all local addresses are loopback, or none are
 func (rc *ResolverConfig) validateLoopbackConsistency() error {
-
-	// check if all nameservers are loopback or non-loopback
-	allNameserversLoopback := true
-	noneNameserversLoopback := true
+	allIPsLength := len(rc.LocalAddrs) + len(rc.RootNameServers) + len(rc.ExternalNameServers)
+	allIPs := make([]net.IP, 0, allIPsLength)
+	allIPs = append(allIPs, rc.LocalAddrs...)
 	for _, ns := range rc.ExternalNameServers {
 		ip, _, err := util.SplitHostPort(ns)
 		if err != nil {
-			return errors.Wrapf(err, "could not split host and port for nameserver: %s", ns)
+			return errors.Wrapf(err, "could not split host and port for external nameserver: %s", ns)
 		}
-		if ip.IsLoopback() {
-			noneNameserversLoopback = false
-		} else {
-			allNameserversLoopback = false
-		}
+		allIPs = append(allIPs, ip)
 	}
 	for _, ns := range rc.RootNameServers {
 		ip, _, err := util.SplitHostPort(ns)
 		if err != nil {
-			return errors.Wrapf(err, "could not split host and port for nameserver: %s", ns)
+			return errors.Wrapf(err, "could not split host and port for root nameserver: %s", ns)
 		}
+		allIPs = append(allIPs, ip)
+	}
+	allIPsLoopback := true
+	noneIPsLoopback := true
+	for _, ip := range allIPs {
 		if ip.IsLoopback() {
-			noneNameserversLoopback = false
+			noneIPsLoopback = false
 		} else {
-			allNameserversLoopback = false
+			allIPsLoopback = false
 		}
 	}
-	loopbackNameserverMismatch := allNameserversLoopback == noneNameserversLoopback
-	if len(rc.ExternalNameServers)+len(rc.RootNameServers) > 0 && loopbackNameserverMismatch {
-		return fmt.Errorf("cannot mix loopback and non-loopback nameservers: %v", append(append([]string{}, rc.ExternalNameServers...), rc.RootNameServers...))
-	}
-
-	allLocalAddrsLoopback := true
-	noneLocalAddrsLoopback := true
-	// check if all local addresses are loopback or non-loopback
-	for _, addr := range rc.LocalAddrs {
-		if addr.IsLoopback() {
-			noneLocalAddrsLoopback = false
-		} else {
-			allLocalAddrsLoopback = false
-		}
-	}
-	if len(rc.LocalAddrs) > 0 && allLocalAddrsLoopback == noneLocalAddrsLoopback {
-		return fmt.Errorf("cannot mix loopback and non-loopback local addresses: %v", rc.LocalAddrs)
-	}
-
-	// Both nameservers and local addresses are completely loopback or non-loopback
-	// if using loopback nameservers, override local addresses to be loopback and warn user
-	if allNameserversLoopback && noneLocalAddrsLoopback {
-		log.Warn("nameservers are loopback, setting local address to loopback to match")
-		rc.LocalAddrs = []net.IP{net.ParseIP(LoopbackAddrString)}
-	} else if noneNameserversLoopback && allLocalAddrsLoopback {
-		return errors.New("using loopback local addresses with non-loopback nameservers is not supported. " +
-			"Consider setting nameservers to loopback addresses assuming you have a local DNS server")
+	if allIPsLoopback == noneIPsLoopback {
+		return fmt.Errorf("cannot mix loopback and non-loopback local addresses (%v) and name servers (%v)", rc.LocalAddrs, util.Concat(rc.ExternalNameServers, rc.RootNameServers))
 	}
 	return nil
 }
@@ -349,7 +281,7 @@ type Resolver struct {
 // It is safe to create multiple Resolvers with the same ResolverConfig but each resolver should perform only one lookup at a time.
 // Returns a Resolver ptr and any error that occurred
 func InitResolver(config *ResolverConfig) (*Resolver, error) {
-	if err := config.PopulateAndValidate(); err != nil {
+	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid resolver config: %w", err)
 	}
 	var c *Cache

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -131,14 +131,20 @@ func (rc *ResolverConfig) Validate() error {
 	// TODO - Remove when we add IPv6 support
 	for _, ns := range rc.RootNameServers {
 		// we know ns passed validation above
-		ip := net.ParseIP(ns)
+		ip, _, err := util.SplitHostPort(ns)
+		if err != nil {
+			return errors.Wrapf(err, "could not split host and port for root nameserver: %s", ns)
+		}
 		if util.IsIPv6(&ip) {
 			return fmt.Errorf("IPv6 root nameservers are not supported: %s", ns)
 		}
 	}
 	for _, ns := range rc.ExternalNameServers {
 		// we know ns passed validation above
-		ip := net.ParseIP(ns)
+		ip, _, err := util.SplitHostPort(ns)
+		if err != nil {
+			return errors.Wrapf(err, "could not split host and port for external nameserver: %s", ns)
+		}
 		if util.IsIPv6(&ip) {
 			return fmt.Errorf("IPv6 extenral nameservers are not supported: %s", ns)
 		}

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -242,7 +242,7 @@ func (rc *ResolverConfig) validateLoopbackConsistency() error {
 	}
 	loopbackNameserverMismatch := allNameserversLoopback == noneNameserversLoopback
 	if len(rc.ExternalNameServers)+len(rc.RootNameServers) > 0 && loopbackNameserverMismatch {
-		return fmt.Errorf("cannot mix loopback and non-loopback nameservers: %v", rc.ExternalNameServers)
+		return fmt.Errorf("cannot mix loopback and non-loopback nameservers: %v", append(append([]string{}, rc.ExternalNameServers...), rc.RootNameServers...))
 	}
 
 	allLocalAddrsLoopback := true

--- a/src/zdns/resolver_test.go
+++ b/src/zdns/resolver_test.go
@@ -16,125 +16,98 @@ package zdns
 
 import (
 	"net"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestResolverConfig_PopulateAndValidate(t *testing.T) {
-	t.Run("Using loopback nameserver and no specified local address", func(t *testing.T) {
+func TestResolverConfig_Validate(t *testing.T) {
+	t.Run("Valid config with external/root name servers and local addr", func(t *testing.T) {
 		rc := &ResolverConfig{
 			ExternalNameServers: []string{"127.0.0.53:53"},
-		}
-		err := rc.PopulateAndValidate()
-		require.Nil(t, err, "Expected no error but got %v", err)
-		require.Equal(t, LoopbackAddrString, rc.LocalAddrs[0].String())
-	})
-
-	t.Run("Using nameserver with no port", func(t *testing.T) {
-		rc := &ResolverConfig{
-			ExternalNameServers: []string{"1.1.1.1"},
-		}
-		err := rc.PopulateAndValidate()
-		require.Nil(t, err)
-		require.Equal(t, "1.1.1.1:53", rc.ExternalNameServers[0], "Expected port 53 to be appended to nameserver")
-	})
-	t.Run("Using nameserver with port", func(t *testing.T) {
-		rc := &ResolverConfig{
-			ExternalNameServers: []string{"1.1.1.1:64"},
-		}
-		err := rc.PopulateAndValidate()
-		require.Nil(t, err)
-		require.Equal(t, "1.1.1.1:64", rc.ExternalNameServers[0], "Expected nameserver to remain unchanged")
-	})
-	t.Run("Using local address with no port", func(t *testing.T) {
-		rc := &ResolverConfig{
-			LocalAddrs: []net.IP{net.ParseIP("192.168.1.1")},
-		}
-		err := rc.PopulateAndValidate()
-		require.Nil(t, err)
-		require.Equal(t, "192.168.1.1", rc.LocalAddrs[0].String(), "Expected local address to be unchanged")
-	})
-
-	t.Run("Mixing loopback and non-loopback nameservers results in error", func(t *testing.T) {
-		rc := &ResolverConfig{
-			ExternalNameServers: []string{"127.0.0.1:53", "8.8.8.8:53"},
-		}
-		err := rc.PopulateAndValidate()
-		require.NotNil(t, err, "Mixing loopback and non-loopback nameservers should result in an error")
-	})
-
-	t.Run("Using non-loopback nameservers with loopback local address results in nameserver being overwritten", func(t *testing.T) {
-		rc := &ResolverConfig{
-			ExternalNameServers: []string{"8.8.8.8:53"},
+			RootNameServers:     []string{"127.0.0.53:53"},
 			LocalAddrs:          []net.IP{net.ParseIP("127.0.0.1")},
 		}
-		err := rc.PopulateAndValidate()
-		require.NotNil(t, err, "Using non-loopback nameservers with loopback local address should result in an error")
+		err := rc.Validate()
+		require.Nil(t, err, "Expected no error but got %v", err)
+	})
+	t.Run("Using external nameserver with no port", func(t *testing.T) {
+		rc := &ResolverConfig{
+			ExternalNameServers: []string{"127.0.0.53"},
+			RootNameServers:     []string{"127.0.0.53:53"},
+			LocalAddrs:          []net.IP{net.ParseIP("127.0.0.1")},
+		}
+		err := rc.Validate()
+		require.NotNil(t, err)
+	})
+	t.Run("Using root nameserver with no port", func(t *testing.T) {
+		rc := &ResolverConfig{
+			ExternalNameServers: []string{"127.0.0.53:53"},
+			RootNameServers:     []string{"127.0.0.53"},
+			LocalAddrs:          []net.IP{net.ParseIP("127.0.0.1")},
+		}
+		err := rc.Validate()
+		require.NotNil(t, err)
+	})
+	t.Run("Missing external nameserver", func(t *testing.T) {
+		rc := &ResolverConfig{
+			RootNameServers: []string{"127.0.0.53:53"},
+			LocalAddrs:      []net.IP{net.ParseIP("127.0.0.1")},
+		}
+		err := rc.Validate()
+		require.NotNil(t, err)
+	})
+	t.Run("Missing root nameserver", func(t *testing.T) {
+		rc := &ResolverConfig{
+			ExternalNameServers: []string{"127.0.0.53:53"},
+			LocalAddrs:          []net.IP{net.ParseIP("127.0.0.1")},
+		}
+		err := rc.Validate()
+		require.NotNil(t, err)
+	})
+	t.Run("Missing local addr", func(t *testing.T) {
+		rc := &ResolverConfig{
+			ExternalNameServers: []string{"127.0.0.53:53"},
+			RootNameServers:     []string{"127.0.0.53:53"},
+		}
+		err := rc.Validate()
+		require.NotNil(t, err)
 	})
 
-	t.Run("Using loopback nameservers with non-loopback local address results in local address being overwritten", func(t *testing.T) {
+	t.Run("Cannot mix loopback addresses in nameservers", func(t *testing.T) {
 		rc := &ResolverConfig{
-			ExternalNameServers: []string{"127.0.0.1:53"},
-			LocalAddrs:          []net.IP{net.ParseIP("192.168.0.1")},
+			ExternalNameServers: []string{"127.0.0.53:53, 1.1.1.1:53"},
+			RootNameServers:     []string{"127.0.0.53:53"},
+			LocalAddrs:          []net.IP{net.ParseIP("127.0.0.1")},
 		}
-		err := rc.PopulateAndValidate()
-		require.Nil(t, err)
-		require.Equal(t, LoopbackAddrString, rc.LocalAddrs[0].String(), "Expected local address to be overwritten with loopback address")
+		err := rc.Validate()
+		require.NotNil(t, err)
 	})
-
-	t.Run("Valid non-loopback nameservers and local addresses", func(t *testing.T) {
+	t.Run("Cannot mix loopback addresses among nameservers", func(t *testing.T) {
 		rc := &ResolverConfig{
-			ExternalNameServers: []string{"8.8.8.8:53", "8.8.4.4:53"},
-			LocalAddrs:          []net.IP{net.ParseIP("192.168.0.1"), net.ParseIP("192.168.0.2")},
+			ExternalNameServers: []string{"1.1.1.1:53"},
+			RootNameServers:     []string{"127.0.0.53:53"},
+			LocalAddrs:          []net.IP{net.ParseIP("127.0.0.1")},
 		}
-		err := rc.PopulateAndValidate()
-		require.Nil(t, err, "Valid non-loopback nameservers and local addresses should not result in an error")
-		require.Equal(t, "8.8.8.8:53", rc.ExternalNameServers[0], "Expected nameserver to remain unchanged")
-		require.Equal(t, "192.168.0.1", rc.LocalAddrs[0].String(), "Expected local address to remain unchanged")
+		err := rc.Validate()
+		require.NotNil(t, err)
 	})
-
-	t.Run("Valid loopback nameservers and local addresses", func(t *testing.T) {
+	t.Run("Cannot reach loopback NSes from non-loopback local address", func(t *testing.T) {
 		rc := &ResolverConfig{
-			ExternalNameServers: []string{"127.0.0.1:53", "127.0.0.2:53"},
-			LocalAddrs:          []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("127.0.0.2")},
+			ExternalNameServers: []string{"127.0.0.53:53"},
+			RootNameServers:     []string{"127.0.0.53:53"},
+			LocalAddrs:          []net.IP{net.ParseIP("192.168.1.2")},
 		}
-		err := rc.PopulateAndValidate()
-		require.Nil(t, err, "Valid loopback nameservers and local addresses should not result in an error")
-		require.Equal(t, LoopbackAddrString, rc.LocalAddrs[0].String(), "Expected local address to be overwritten with loopback address")
-		require.Equal(t, "127.0.0.1:53", rc.ExternalNameServers[0], "Expected nameserver to remain unchanged")
+		err := rc.Validate()
+		require.NotNil(t, err)
 	})
-
-	t.Run("Valid loobpack root nameservers and valid non-loopback external nameservers is not allowed", func(t *testing.T) {
+	t.Run("Cannot reach non-loopback NSes from loopback local address", func(t *testing.T) {
 		rc := &ResolverConfig{
-			ExternalNameServers: []string{"1.1.1.1"},
-			RootNameServers:     []string{"127.0.0.1"},
+			ExternalNameServers: []string{"1.1.1.1:53"},
+			RootNameServers:     []string{"1.1.1.1:53"},
+			LocalAddrs:          []net.IP{net.ParseIP("127.0.0.1")},
 		}
-		err := rc.PopulateAndValidate()
-		require.NotNil(t, err, "cannot mix loopback root nameservers with non-loopback external nameservers")
-	})
-
-	t.Run("Invalid Root NS", func(t *testing.T) {
-		rc := &ResolverConfig{
-			RootNameServers: []string{"1.2.3"},
-		}
-		err := rc.PopulateAndValidate()
-		require.NotNil(t, err, "Expected error for invalid root nameserver")
-	})
-
-	t.Run("Validate Port-appended Root NS", func(t *testing.T) {
-		rc := &ResolverConfig{
-			RootNameServers: []string{"1.2.3.4:49"},
-		}
-		err := rc.PopulateAndValidate()
-		require.Nil(t, err, "Expected no error for valid root nameserver")
-		require.Equal(t, "49", strings.Split(rc.RootNameServers[0], ":")[1], "Expected port to be unchanged")
-		rc = &ResolverConfig{
-			RootNameServers: []string{"1.2.3.4"},
-		}
-		err = rc.PopulateAndValidate()
-		require.Nil(t, err, "Expected no error for valid root nameserver")
-		require.Equal(t, "53", strings.Split(rc.RootNameServers[0], ":")[1], "Expected port to be populated")
+		err := rc.Validate()
+		require.NotNil(t, err)
 	})
 }


### PR DESCRIPTION
When #412 was merged, it removed the assumption we had that with `--iterative` mode, the root servers were hard-coded as the 13 global root servers. #412 added the ability for a user to specify `--name-servers` in `--iterative` mode to test iteration against a specified name server. Thus, the assumption was broken.

This meant that with `main`, if the OS configured resolver was loopback, iterative lookups would fail since we were setting the `root-servers` as Cloudflare/Google [here](https://github.com/zmap/zdns/pull/415/files#diff-51353152c920df2fde6a6b33d32210eb26075b03e5fbdcb17175f0e53b4ad248L91).

```
➜  zdns git:(main) ✗ head -n 1 benchmark/10k_crux_top_domains.input| ./zdns A --iterative --verbosity=5
DEBU[0000] OS external resolution nameservers are loopback and iterative mode is enabled. Using default non-loopback nameservers to prevent resolution failure edge case
INFO[0000] using local addresses: [137.184.54.104]
INFO[0000] for non-iterative lookups, using external nameservers: 8.8.8.8:53, 8.8.4.4:53, 1.1.1.1:53, 1.0.0.1:53
INFO[0000] for iterative lookups, using nameservers: 8.8.8.8:53, 8.8.4.4:53, 1.1.1.1:53, 1.0.0.1:53
...
{"data":{"additionals":[{"flags":"","type":"EDNS0","udpsize":1232,"version":0}],"protocol":"udp","resolver":"1.1.1.1:53"},"duration":0.039246057,"name":"m.fabswingers.com","status":"SERVFAIL","timestamp":"2024-08-07T22:07:28Z"}
```

## Other Changes
- Added a lock in `ResolverConfig` since each Resolver attempts to populateAndValidate the config at once in `worker_manager.go`, this lead to some race conditions easily prevented by locking before validation. This lock is only retrieved during Resolver setup, so there shouldn't be performance degradation post initial setup.
- Removed now un-used function


## Testing
After having this issue crop up and working thru edge cases with `Phillip/ipv6`, I tried to be more systematic with my testing for this.

Sorry for formatting, Github is not letting us use all available screen real estate here 😢 

Variables 
- A - `/etc/resolv.conf` using loopback nameservers
- B - user-provided nameservers (T/F)
	- Option 1 - user provided loopback nameservers 
	- Option 2user provided non-loopback nameservers
- C -  `--iterative` mode used or not
- D - `--localAddr` specified
	- Option 1 - user provided loopback addr
	- Option 2 - user provided non-loopback addr
2 * 2 * 3 * 3 = 36 possibilities

|  A  |   B   |  C  |   D   | Command                                                                       | Expected Outcome                                                                             | Tested Outcome |
| :-: | :---: | :-: | :---: | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | -------------- |
|  F  |   F   |  T  |   F   | ./zdns A --iterative                                                          | Iteration should start from a default root server with the non-loopback NS, SUCCESS          | PASS           |
|  F  |   F   |  T  | Opt 1 | ./zdns A --iterative --local-addr="127.0.0.1"<br>                             | Should fail config validation, no nameservers reachable                                      | PASS           |
|  F  |   F   |  T  | Opt 2 | ./zdns A --iterative --local-addr="192.168.1.243"<br>                         | Iteration should start from a default root server with the non-loopback local-addr, SUCCESS  | PASS           |
|  F  |   F   |  F  |   F   | ./zdns A                                                                      | External query to whatever NS was set in `/etc/resolv.conf`                                  | PASS           |
|  F  |   F   |  F  | Opt 1 | ./zdns A --local-addr="127.0.0.1"                                             | Should fail config validation, no nameservers reachable                                      | PASS           |
|  F  |   F   |  F  | Opt 2 | ./zdns A --local-addr="192.168.1.243"                                         | External query to whatever NS was set in `/etc/resolv.conf`                                  | PASS           |
|  F  | Opt 1 |  T  |   F   | ./zdns A --iterative --name-servers="127.0.0.53"                              | Pass config validation, iterative lookup attempted using local addr loopback, to NS loopback | PASS           |
|  F  | Opt 1 |  T  | Opt 1 | ./zdns A --iterative --name-servers="127.0.0.53" --local-addr="127.0.0.1"     | Pass config validation, iterative lookup attempted using local addr loopback, to NS loopback | PASS           |
|  F  | Opt 1 |  T  | Opt 2 | ./zdns A --iterative --name-servers="127.0.0.53" --local-addr="192.168.1.243" | Config does not pass validation                                                              | PASS           |
|  F  | Opt 1 |  F  |   F   | ./zdns A --name-servers="127.0.0.53"                                          | Pass config validation, external lookup attempted using local addr loopback, to NS loopback  | PASS           |
|  F  | Opt 1 |  F  | Opt 1 | ./zdns A --name-servers="127.0.0.53" --local-addr="127.0.0.1"                 | Pass config validation, external lookup attempted using local addr loopback, to NS loopback  | PASS           |
|  F  | Opt 1 |  F  | Opt 2 | ./zdns A --name-servers="127.0.0.53" --local-addr="192.168.1.243"             | Config does not pass validation                                                              | PASS           |
|  F  | Opt 2 |  T  |   F   | ./zdns A --iterative --name-servers="198.41.0.4"                              | Attempt iterative lookup to a.root-server.net using a non-loopback local addr                | PASS           |
|  F  | Opt 2 |  T  | Opt 1 | ./zdns A --iterative --name-servers="198.41.0.4" --local-addr="127.0.0.1"     | Fail config validation, loopback mismatch                                                    | PASS           |
|  F  | Opt 2 |  T  | Opt 2 | ./zdns A --iterative --name-servers="198.41.0.4" --local-addr="192.168.1.243" | Attempt iterative lookup to a.root-server.net using a non-loopback local addr                | PASS           |
|  F  | Opt 2 |  F  |   F   | ./zdns A --name-servers="198.41.0.4"                                          | Attempt external lookup to a.root-server.net using a non-loopback local addr                 | PASS           |
|  F  | Opt 2 |  F  | Opt 1 | ./zdns A --name-servers="198.41.0.4" --local-addr="127.0.0.1"                 | Fail config validation, loopback mismatch                                                    | PASS           |
|  F  | Opt 2 |  F  | Opt 2 | ./zdns A --name-servers="198.41.0.4" --local-addr="192.168.1.243"             | Attempt external lookup to a.root-server.net using a non-loopback local addr                 | PASS           |
|  T  |   F   |  T  |   F   | ./zdns A --iterative                                                          | Iteration should start from a default root server with a non-loopback local addr, SUCCESS    | PASS           |
|  T  |   F   |  T  | Opt 1 | ./zdns A --iterative --local-addr="127.0.0.1"<br>                             | Fail config validation                                                                       | PASS           |
|  T  |   F   |  T  | Opt 2 | ./zdns A --iterative --local-addr="192.168.1.243"<br>                         | Iteration should start from a default root server with the non-loopback local addr, SUCCESS  | PASS           |
|  T  |   F   |  F  |   F   | ./zdns A                                                                      | External query to whatever NS was set in `/etc/resolv.conf` using loopback local addr        | PASS           |
|  T  |   F   |  F  | Opt 1 | ./zdns A --local-addr="127.0.0.1"                                             | Attempt external lookup against local NS with loopback local addr                            | PASS           |
|  T  |   F   |  F  | Opt 2 | ./zdns A --local-addr="192.168.1.243"                                         | Fail config validation                                                                       | PASS           |
|  T  | Opt 1 |  T  |   F   | ./zdns A --iterative --name-servers="127.0.0.53"                              | Pass config validation, iterative lookup attempted using local addr loopback, to NS loopback | PASS           |
|  T  | Opt 1 |  T  | Opt 1 | ./zdns A --iterative --name-servers="127.0.0.53" --local-addr="127.0.0.1"     | Pass config validation, iterative lookup attempted using local addr loopback, to NS loopback | PASS           |
|  T  | Opt 1 |  T  | Opt 2 | ./zdns A --iterative --name-servers="127.0.0.53" --local-addr="192.168.1.243" | Fail config valiation                                                                        | PASS           |
|  T  | Opt 1 |  F  |   F   | ./zdns A --name-servers="127.0.0.53"                                          | Pass config validation, external lookup attempted using local addr loopback, to NS loopback  | PASS           |
|  T  | Opt 1 |  F  | Opt 1 | ./zdns A --name-servers="127.0.0.53" --local-addr="127.0.0.1"                 | Pass config validation, external lookup attempted using local addr loopback, to NS loopback  | PASS           |
|  T  | Opt 1 |  F  | Opt 2 | ./zdns A --name-servers="127.0.0.53" --local-addr="192.168.1.243"             | Fail config validation                                                                       | PASS           |
|  T  | Opt 2 |  T  |   F   | ./zdns A --iterative --name-servers="198.41.0.4"                              | Attempt iterative lookup to a.root-server.net using a non-loopback local addr                | PASS           |
|  T  | Opt 2 |  T  | Opt 1 | ./zdns A --iterative --name-servers="198.41.0.4" --local-addr="127.0.0.1"     | Fail config validation, loopback mismatch                                                    | PASS           |
|  T  | Opt 2 |  T  | Opt 2 | ./zdns A --iterative --name-servers="198.41.0.4" --local-addr="192.168.1.243" | Attempt iterative lookup to a.root-server.net using a non-loopback local addr                | PASS           |
|  T  | Opt 2 |  F  |   F   | ./zdns A --name-servers="198.41.0.4"                                          | Attempt external lookup to a.root-server.net using a non-loopback local addr                 | PASS           |
|  T  | Opt 2 |  F  | Opt 1 | ./zdns A --name-servers="198.41.0.4" --local-addr="127.0.0.1"                 | Fail config validation, loopback mismatch                                                    | PASS           |
|  T  | Opt 2 |  F  | Opt 2 | ./zdns A --name-servers="198.41.0.4" --local-addr="192.168.1.243"             | Attempt external lookup to a.root-server.net using a non-loopback local addr                 | PASS           |