### PR TITLE
Add new Concat utility and use it to fix slice.append gotcha

### DIFF
--- a/src/internal/util/util.go
+++ b/src/internal/util/util.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"regexp"
-	slices2 "slices"
 	"strconv"
 	"strings"
 
@@ -154,7 +153,7 @@ func RemoveDuplicates[T comparable](slice []T) []T {
 // Avoids a gotcha in Go where since append modifies the underlying memory of the input slice, doing
 // newSlice := append(slice1, slice2) can modify slice1. See https://go.dev/doc/effective_go#append
 // A std. library concat was added in go 1.22, but this is for backwards compatibility. https://pkg.go.dev/slices#Concat
-// This is a direct copy of the std. library implementation's Concat implementation.
+// This is mostly similiar to the std. library concat, but with a few differences so it compiles on go 1.20.
 func Concat[S ~[]E, E any](slices ...S) S {
 	size := 0
 	for _, s := range slices {
@@ -163,9 +162,9 @@ func Concat[S ~[]E, E any](slices ...S) S {
 			panic("len out of range")
 		}
 	}
-	newslice := slices2.Grow[S](nil, size)
+	newSlice := make([]E, 0, size)
 	for _, s := range slices {
-		newslice = append(newslice, s...)
+		newSlice = append(newSlice, s...)
 	}
-	return newslice
+	return newSlice
 }

--- a/src/internal/util/util.go
+++ b/src/internal/util/util.go
@@ -147,3 +147,20 @@ func RemoveDuplicates[T comparable](slice []T) []T {
 	}
 	return result
 }
+
+// Concat concatenates multiple slices of the same type into a new single slice of that type.
+// Avoids a gotcha in Go where since append modifies the underlying memory of the input slice, doing
+// newSlice := append(slice1, slice2) can modify slice1. See https://go.dev/doc/effective_go#append
+// A std. library concat was added in go 1.22, but this is for backwards compatibility. https://pkg.go.dev/slices#Concat
+// This should be used anytime you're not trying to modify the input slices.
+func Concat[T any](slices ...[]T) []T {
+	var totalLen int
+	for _, s := range slices {
+		totalLen += len(s)
+	}
+	result := make([]T, 0, totalLen)
+	for _, s := range slices {
+		result = append(result, s...)
+	}
+	return result
+}

--- a/src/internal/util/util.go
+++ b/src/internal/util/util.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	slices2 "slices"
 	"strconv"
 	"strings"
 
@@ -148,19 +149,23 @@ func RemoveDuplicates[T comparable](slice []T) []T {
 	return result
 }
 
-// Concat concatenates multiple slices of the same type into a new single slice of that type.
+// Concat returns a new slice concatenating the passed in slices.
+//
 // Avoids a gotcha in Go where since append modifies the underlying memory of the input slice, doing
 // newSlice := append(slice1, slice2) can modify slice1. See https://go.dev/doc/effective_go#append
 // A std. library concat was added in go 1.22, but this is for backwards compatibility. https://pkg.go.dev/slices#Concat
-// This should be used anytime you're not trying to modify the input slices.
-func Concat[T any](slices ...[]T) []T {
-	var totalLen int
+// This is a direct copy of the std. library implementation's Concat implementation.
+func Concat[S ~[]E, E any](slices ...S) S {
+	size := 0
 	for _, s := range slices {
-		totalLen += len(s)
+		size += len(s)
+		if size < 0 {
+			panic("len out of range")
+		}
 	}
-	result := make([]T, 0, totalLen)
+	newslice := slices2.Grow[S](nil, size)
 	for _, s := range slices {
-		result = append(result, s...)
+		newslice = append(newslice, s...)
 	}
-	return result
+	return newslice
 }

--- a/src/internal/util/util_test.go
+++ b/src/internal/util/util_test.go
@@ -149,9 +149,17 @@ func TestConcat(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		inputSlice1 = append(inputSlice1, i)
 	}
-	newSlice1 := Concat(inputSlice1, []int{4})
-	newSlice2 := Concat(inputSlice1, []int{5})
-	newSlice3 := Concat(inputSlice1, []int{6})
+	// Test naive append
+	newSlice1 := append(inputSlice1, 4)
+	newSlice2 := append(inputSlice1, 5)
+	newSlice3 := append(inputSlice1, 6)
+	// Shows test is working, you'd think that this would be Equal but it isn't. append() is modifying the inputSlice1
+	require.NotEqual(t, []int{0, 1, 2, 4}, newSlice1)
+	require.NotEqual(t, []int{0, 1, 2, 5}, newSlice2)
+	// Now try with new Concat
+	newSlice1 = Concat(inputSlice1, []int{4})
+	newSlice2 = Concat(inputSlice1, []int{5})
+	newSlice3 = Concat(inputSlice1, []int{6})
 	require.Len(t, inputSlice1, 3)
 	require.Equal(t, 10, cap(inputSlice1))
 	require.Equal(t, []int{0, 1, 2}, inputSlice1)

--- a/src/internal/util/util_test.go
+++ b/src/internal/util/util_test.go
@@ -143,3 +143,19 @@ func TestRemoveDuplicates(t *testing.T) {
 		})
 	}
 }
+
+func TestConcat(t *testing.T) {
+	inputSlice1 := make([]int, 0, 10)
+	for i := 0; i < 3; i++ {
+		inputSlice1 = append(inputSlice1, i)
+	}
+	newSlice1 := Concat(inputSlice1, []int{4})
+	newSlice2 := Concat(inputSlice1, []int{5})
+	newSlice3 := Concat(inputSlice1, []int{6})
+	require.Len(t, inputSlice1, 3)
+	require.Equal(t, 10, cap(inputSlice1))
+	require.Equal(t, []int{0, 1, 2}, inputSlice1)
+	require.Equal(t, []int{0, 1, 2, 4}, newSlice1)
+	require.Equal(t, []int{0, 1, 2, 5}, newSlice2)
+	require.Equal(t, []int{0, 1, 2, 6}, newSlice3)
+}

--- a/src/internal/util/util_test.go
+++ b/src/internal/util/util_test.go
@@ -156,6 +156,7 @@ func TestConcat(t *testing.T) {
 	// Shows test is working, you'd think that this would be Equal but it isn't. append() is modifying the inputSlice1
 	require.NotEqual(t, []int{0, 1, 2, 4}, newSlice1)
 	require.NotEqual(t, []int{0, 1, 2, 5}, newSlice2)
+	require.Equal(t, []int{0, 1, 2, 6}, newSlice3)
 	// Now try with new Concat
 	newSlice1 = Concat(inputSlice1, []int{4})
 	newSlice2 = Concat(inputSlice1, []int{5})

--- a/src/zdns/alookup.go
+++ b/src/zdns/alookup.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/zmap/dns"
+
+	"github.com/zmap/zdns/src/internal/util"
 )
 
 // DoTargetedLookup performs a lookup of the given domain name against the given nameserver, looking up both IPv4 and IPv6 addresses
@@ -57,7 +59,7 @@ func (r *Resolver) DoTargetedLookup(name, nameServer string, ipMode IPVersionMod
 		}
 	}
 
-	combinedTrace := append(ipv4Trace, ipv6Trace...)
+	combinedTrace := util.Concat(ipv4Trace, ipv6Trace)
 
 	// In case we get no IPs and a non-NOERROR status from either
 	// IPv4 or IPv6 lookup, we return that status.

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -292,7 +292,7 @@ func (r *Resolver) LookupAllNameservers(q *Question, nameServer string) (*Combin
 	for _, nserver := range nsResults.Servers {
 		// Use all the ipv4 and ipv6 addresses of each nameserver
 		nameserver := nserver.Name
-		ips := append(nserver.IPv4Addresses, nserver.IPv6Addresses...)
+		ips := util.Concat(nserver.IPv4Addresses, nserver.IPv6Addresses)
 		for _, ip := range ips {
 			curServer = net.JoinHostPort(ip, "53")
 			res, trace, status, _ := r.ExternalLookup(q, curServer)


### PR DESCRIPTION
While debugging an issue with `Phillip/ipv6`, I realized that 
`newSlice := append(inputSlice1, inputSlice2...)`
can modify `inputSlice1`.

While `Concat` was added in go `1.22`, I think that's a bit too cutting edge to mandate people have. 

I could not find a linter to automatically check for these sorts of issues, so we'll just have to be careful.


## Changes
- added new utility `Concat` copied from Go's std. lib.
- added testing to show it doesn't modify underlying array
- Used everywhere we were using append to create a new slice