### PR TITLE
Stop handling a domain if all nameservers don't provide sufficient glue records when they should

### DIFF
--- a/src/zdns/conf.go
+++ b/src/zdns/conf.go
@@ -51,6 +51,7 @@ const (
 	StatusTimeout      Status = "TIMEOUT"
 	StatusIterTimeout  Status = "ITERATIVE_TIMEOUT"
 	StatusNoAuth       Status = "NOAUTH"
+	StatusNoNeededGlue Status = "NONEEDEDGLUE" // When a nameserver is authoritative for itself and the parent nameserver doesn't provide the glue to look it up
 )
 
 var RootServersV4 = []string{

--- a/src/zdns/util.go
+++ b/src/zdns/util.go
@@ -92,7 +92,8 @@ func checkGlueHelper(server, ansType string, result SingleQueryResult) (SingleQu
 		if !ok {
 			continue
 		}
-		if ans.Type == ansType && strings.TrimSuffix(ans.Name, ".") == server {
+		// sanitize case and trailing dot
+		if ans.Type == ansType && strings.ToLower(strings.TrimSuffix(ans.Name, ".")) == strings.ToLower(server) {
 			var retv SingleQueryResult
 			retv.Authorities = make([]interface{}, 0)
 			retv.Answers = make([]interface{}, 0, 1)
@@ -150,10 +151,12 @@ func TranslateDNSErrorCode(err int) Status {
 }
 
 // handleStatus is a helper function to deal with a status and error. Error is only returned if the status is an
-// Iterative Timeout
+// Iterative Timeout or NoNeededGlueRecord
 func handleStatus(status Status, err error) (Status, error) {
 	switch status {
 	case StatusIterTimeout:
+		return status, err
+	case StatusNoNeededGlue:
 		return status, err
 	case StatusNXDomain:
 		return status, nil

--- a/src/zdns/util.go
+++ b/src/zdns/util.go
@@ -93,6 +93,7 @@ func checkGlueHelper(server, ansType string, result SingleQueryResult) (SingleQu
 			continue
 		}
 		// sanitize case and trailing dot
+		// RFC 4343 - states DNS names are case insensitive
 		if ans.Type == ansType && strings.ToLower(strings.TrimSuffix(ans.Name, ".")) == strings.ToLower(server) {
 			var retv SingleQueryResult
 			retv.Authorities = make([]interface{}, 0)

--- a/src/zdns/util.go
+++ b/src/zdns/util.go
@@ -93,8 +93,8 @@ func checkGlueHelper(server, ansType string, result SingleQueryResult) (SingleQu
 			continue
 		}
 		// sanitize case and trailing dot
-		// RFC 4343 - states DNS names are case insensitive
-		if ans.Type == ansType && strings.ToLower(strings.TrimSuffix(ans.Name, ".")) == strings.ToLower(server) {
+		// RFC 4343 - states DNS names are case-insensitive
+		if ans.Type == ansType && strings.EqualFold(strings.TrimSuffix(ans.Name, "."), server) {
 			var retv SingleQueryResult
 			retv.Authorities = make([]interface{}, 0)
 			retv.Answers = make([]interface{}, 0, 1)

--- a/testing/ipv6_tests.py
+++ b/testing/ipv6_tests.py
@@ -48,7 +48,7 @@ class Tests(unittest.TestCase):
         name = "esrg.stanford.edu"
         cmd, res = self.run_zdns(c, name)
         # esrg.stanford.edu is hosted on NS's that do not have an IPv6 address. Therefore, this will fail.
-        self.assertServFail(res, cmd)
+        self.assertEqual(res["status"], "NONEEDEDGLUE", cmd)
 
     def test_ipv6_external_lookup_unreachable_nameserver(self):
         c = "A --6=true --4=false --name-servers=1.1.1.1"

--- a/testing/ipv6_tests.py
+++ b/testing/ipv6_tests.py
@@ -47,7 +47,7 @@ class Tests(unittest.TestCase):
         c = "A --iterative --6=true --4=false"
         name = "esrg.stanford.edu"
         cmd, res = self.run_zdns(c, name)
-        # esrg.stanford.edu is hosted on NS's that do not have an IPv6 address. Therefore, this will fail.
+        # esrg.stanford.edu is hosted on NS's that do not have an IPv6 address. Therefore, the lookup won't get sufficient glue records to resolve the query.
         self.assertEqual(res["status"], "NONEEDEDGLUE", cmd)
 
     def test_ipv6_external_lookup_unreachable_nameserver(self):


### PR DESCRIPTION
## Description
Wanted to get a specific review on this since it seems to core logic that affects more than just IPv6 lookups.

The issue that caused me to look into this was trying to get `A` records for `esrg.stanford.edu` from `Stanford.edu` nameservers over IPv6

```
$ dig -t A esrg.stanford.edu @avallone.stanford.edu -6

; <<>> DiG 9.10.6 <<>> -t A esrg.stanford.edu @avallone.stanford.edu -6
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 20243
;; flags: qr rd; QUERY: 1, ANSWER: 0, AUTHORITY: 2, ADDITIONAL: 3
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;esrg.stanford.edu.		IN	A

;; AUTHORITY SECTION:
esrg.stanford.edu.	1800	IN	NS	dns-02.esrg.stanford.edu.
esrg.stanford.edu.	1800	IN	NS	dns-01.esrg.stanford.edu.

;; ADDITIONAL SECTION:
dns-02.esrg.stanford.edu. 1800	IN	A	171.67.68.26
dns-01.esrg.stanford.edu. 1800	IN	A	171.67.68.25

;; Query time: 84 msec
;; SERVER: 2620:6c:40c0:0:204:63:224:53#53(2620:6c:40c0:0:204:63:224:53)
;; WHEN: Mon Aug 12 12:17:07 EDT 2024
;; MSG SIZE  rcvd: 120
```

We can't proceed to look up `dns-01.esrg.stanford.edu` any further, and without an `AAAA` record to continue IPv6 iteration, we cannot proceed.

## Solution
- Add a new `NONEEDEDGLUE` status that is returned if a given name is beneath the current layer (`esrg.stanford.edu` is beneath `Stanford.edu` and the glue doesn't contain a next hop.)
- If all authorities in `iterateOnAuthorities` return this, we'll terminate the iteration

## Testing
### `esrg.stanford.edu` lookup
ipv6 base branch
```
$ echo "esrg.stanford.edu" | ./zdns A --6 --iterative
{"data":{"protocol":"","resolver":""},"duration":15.001968875,"name":"esrg.stanford.edu","status":"TIMEOUT","timestamp":"2024-08-12T12:22:51-04:00"}
```
ipv6-recursive-base
```
$ echo "esrg.stanford.edu" | ./zdns A --6 --iterative
{"data":{"protocol":"","resolver":""},"duration":0.21923125,"name":"esrg.stanford.edu","status":"NONEEDEDGLUE","timestamp":"2024-08-12T12:23:26-04:00"}
```

### Ensuring this doesn't break known working domains
main
```
Benchmarking ZDNS, Resolving 2000 domains... 100% 
Benchmark took:                                                       23.12s
Min resolution time:                                                 27.35µs
Max resolution time:                                                  15.00s
Average resolution time:                                            744.78ms

Domains resolved successfully:                                     1830/2000
Domains that timed out:                                                  152
Domains that failed:                                                      18
```

ipv6-recursive-base
```
~/zdns on  phillip/ipv6-recursive-base! ⌚ 16:24:40
$ make benchmark
go build -o zdns
cd ./benchmark && go run main.go stats.go
Benchmarking ZDNS, Resolving 2000 domains... 100% 
Benchmark took:                                                       23.98s
Min resolution time:                                                 28.17µs
Max resolution time:                                                  15.00s

Domains resolved successfully:                                     1803/2000
Domains that timed out:                                                  180
Domains that failed:                                                      17
```