### PR TITLE
Multi-thread Python Tests for easier development and add a CNAME loop test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
           python --version
           pip install -r testing/requirements.txt
-          ./testing/integration_tests.py
+          pytest -n auto ./testing/integration_tests.py
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
           python --version
           pip install -r testing/requirements.txt
-          pytest -n auto ./testing/integration_tests.py
+          pytest -n 1 ./testing/integration_tests.py
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ test: zdns
 
 integration-tests: zdns
 	pip3 install -r testing/requirements.txt
-	python3 testing/integration_tests.py
+	pytest -n auto testing/integration_tests.py
 	python3 testing/large_scan_integration/large_scan_integration_tests.py
 
 # Not all hosts support this, so this will be a custom make target

--- a/makefile
+++ b/makefile
@@ -11,6 +11,8 @@ install: zdns
 
 test: zdns
 	go test -v ./...
+	pip3 install -r testing/requirements.txt
+	pytest -n auto testing/integration_tests.py
 
 integration-tests: zdns
 	pip3 install -r testing/requirements.txt

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -463,7 +463,7 @@ class Tests(unittest.TestCase):
 
     SPF_ANSWER = {
         "data": {
-            "spf": "v=spf1 mx include:_spf.google.com -all"
+            "spf": "v=spf1 mx include:spf.google.com -all"
         }
     }
 

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -636,12 +636,6 @@ class Tests(unittest.TestCase):
         self.assertSuccess(res, cmd)
         self.assertEqualAnswers(res, self.WWW_CNAME_ANSWERS, cmd)
 
-    def test_cname_loop(self):
-        c = "A"
-        name = "cname-loop.zdns-testing.com"
-        cmd, res = self.run_zdns(c, name)
-        self.assertSuccess(res, cmd)
-        self.assertEqualAnswers(res, self.CNAME_LOOP_ANSWERS, cmd)
     def test_cname_loop_iterative(self):
         c = "A --iterative"
         name = "cname-loop.zdns-testing.com"

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -420,7 +420,6 @@ class Tests(unittest.TestCase):
         }
     ]
 
-
     CNAME_LOOP_ANSWERS = [
         {
             "type": "CNAME",
@@ -636,6 +635,19 @@ class Tests(unittest.TestCase):
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd)
         self.assertEqualAnswers(res, self.WWW_CNAME_ANSWERS, cmd)
+
+    def test_cname_loop(self):
+        c = "A"
+        name = "cname-loop.zdns-testing.com"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd)
+        self.assertEqualAnswers(res, self.CNAME_LOOP_ANSWERS, cmd)
+    def test_cname_loop_iterative(self):
+        c = "A --iterative"
+        name = "cname-loop.zdns-testing.com"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd)
+        self.assertEqualAnswers(res, self.CNAME_LOOP_ANSWERS, cmd)
 
     def test_a_behind_cname(self):
         c = "A"

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -463,7 +463,7 @@ class Tests(unittest.TestCase):
 
     SPF_ANSWER = {
         "data": {
-            "spf": "v=spf1 mx include:spf.google.com -all"
+            "spf": "v=spf1 mx include:_spf.google.com -all"
         }
     }
 

--- a/testing/requirements.txt
+++ b/testing/requirements.txt
@@ -1,2 +1,3 @@
 python-dateutil==2.9.0.post0
 datetime>=4.3
+pytest-xdist==3.6.1


### PR DESCRIPTION
## Description
- wanted faster feedback on tests, using the `pytest-xdist` with `pytest` lets us spread tests across available cores (4 on GH runners)
    - When using all 4, I saw an `--iterative-timeout`, so dropped the GH action specifically to use 1 cores. Honestly didn't see much speedup on GH, it's nice to have locally though so I think this is still worth it.
- realized we had a CNAME_LOOP_ANSWERS constant in `integration_tests` but no test actually used it, added one

## Performance
Running the `integration_tests.py` on a MacBook Air:
- `main` - 20.9 s.
- This Branch - ~6 seconds