### PR TITLE
Revert "Remove ALOOKUP module and associated code (#419)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ friendlier interface, we also provide several _lookup_ modules: `alookup` and
 
 `mxlookup` will additionally do an A lookup for the IP addresses that
 correspond with an exchange record. `alookup` acts similar to nslookup and will
-follow CNAME records.
+follow CNAME records. `nslookup` will additionally do an A/AAAA lookup for IP 
+addresses that correspond with an NS record
 
 For example,
 

--- a/README.md
+++ b/README.md
@@ -119,12 +119,12 @@ Lookup Modules
 Raw DNS responses frequently do not provide the data you _want_. For example,
 an MX response may not include the associated A records in the additionals
 section requiring an additional lookup. To address this gap and provide a
-friendlier interface, we also provide several _lookup_ modules: `nslookup` and
+friendlier interface, we also provide several _lookup_ modules: `alookup` and
 `mxlookup`.
 
 `mxlookup` will additionally do an A lookup for the IP addresses that
-correspond with an exchange record. 
-`nslookup` will additionally do an A/AAAA lookup for IP addresses that correspond with an NS record
+correspond with an exchange record. `alookup` acts similar to nslookup and will
+follow CNAME records.
 
 For example,
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/zmap/zdns/src/cli"
 	// the order of these imports is important, as the modules are registered in the init() functions.
 	// Import modules after the basic cmd pkg
+	_ "github.com/zmap/zdns/src/modules/alookup"
 	_ "github.com/zmap/zdns/src/modules/axfr"
 	_ "github.com/zmap/zdns/src/modules/bindversion"
 	_ "github.com/zmap/zdns/src/modules/dmarc"

--- a/src/cli/alookup.go
+++ b/src/cli/alookup.go
@@ -1,0 +1,48 @@
+/*
+ * ZDNS Copyright 2024 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package cli
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/zmap/zdns/src/internal/util"
+)
+
+// alookupCmd represents the alookup command
+var alookupCmd = &cobra.Command{
+	Use:   "alookup",
+	Short: "A record lookups that follow CNAME records",
+	Long: `alookup will get the information that is typically desired, instead of just
+the information that exists in a single record.
+
+Specifically, alookup acts similar to nslookup and will follow CNAME records.`,
+	Args: cobra.MatchAll(cobra.ExactArgs(0), cobra.OnlyValidArgs),
+	Run: func(cmd *cobra.Command, args []string) {
+		GC.Module = strings.ToUpper("alookup")
+		Run(GC, cmd.Flags())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(alookupCmd)
+
+	alookupCmd.PersistentFlags().Bool("ipv4-lookup", false, "perform A lookups for each server")
+	alookupCmd.PersistentFlags().Bool("ipv6-lookup", false, "perform AAAA record lookups for each server")
+
+	util.BindFlags(alookupCmd, viper.GetViper(), util.EnvPrefix)
+}

--- a/src/modules/alookup/a_lookup.go
+++ b/src/modules/alookup/a_lookup.go
@@ -1,0 +1,68 @@
+/*
+ * ZDNS Copyright 2024 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package alookup
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+
+	"github.com/zmap/zdns/src/cli"
+	"github.com/zmap/zdns/src/zdns"
+)
+
+type ALookupModule struct {
+	IPv4Lookup bool
+	IPv6Lookup bool
+	baseModule cli.BasicLookupModule
+}
+
+func init() {
+	al := new(ALookupModule)
+	cli.RegisterLookupModule("ALOOKUP", al)
+}
+
+// CLIInit initializes the ALookupModule with the given parameters, used to call ALOOKUP from the command line
+func (aMod *ALookupModule) CLIInit(gc *cli.CLIConf, resolverConfig *zdns.ResolverConfig, f *pflag.FlagSet) error {
+	ipv4Lookup, err := f.GetBool("ipv4-lookup")
+	if err != nil {
+		return errors.Wrap(err, "failed to get ipv4-lookup flag")
+	}
+	ipv6Lookup, err := f.GetBool("ipv6-lookup")
+	if err != nil {
+		return errors.Wrap(err, "failed to get ipv6-lookup flag")
+	}
+	aMod.Init(ipv4Lookup, ipv6Lookup)
+	err = aMod.baseModule.CLIInit(gc, resolverConfig, f)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize base module")
+	}
+	return nil
+}
+
+// Init initializes the ALookupModule with the given parameters, used to call ALOOKUP programmatically
+func (aMod *ALookupModule) Init(ipv4Lookup bool, ipv6Lookup bool) {
+	aMod.IPv4Lookup = ipv4Lookup || !ipv6Lookup
+	aMod.IPv6Lookup = ipv6Lookup
+}
+
+func (aMod *ALookupModule) Lookup(r *zdns.Resolver, lookupName, nameServer string) (interface{}, zdns.Trace, zdns.Status, error) {
+	ipResult, trace, status, err := r.DoTargetedLookup(lookupName, nameServer, aMod.baseModule.IsIterative, aMod.IPv4Lookup, aMod.IPv6Lookup)
+	return ipResult, trace, status, err
+}
+
+// Help returns the module's help string
+func (aMod *ALookupModule) Help() string {
+	return ""
+}

--- a/src/zdns/alookup.go
+++ b/src/zdns/alookup.go
@@ -14,9 +14,9 @@
 package zdns
 
 import (
+	"github.com/pkg/errors"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/zmap/dns"
 
 	"github.com/zmap/zdns/src/internal/util"
@@ -27,9 +27,7 @@ import (
 func (r *Resolver) DoTargetedLookup(name, nameServer string, isIterative, lookupA, lookupAAAA bool) (*IPResult, Trace, Status, error) {
 	name = strings.ToLower(name)
 	res := IPResult{}
-	candidateSet := map[string][]Answer{}
-	cnameSet := map[string][]Answer{}
-	dnameSet := map[string][]Answer{}
+	singleQueryRes := &SingleQueryResult{}
 	var ipv4 []string
 	var ipv6 []string
 	var ipv4Trace Trace
@@ -37,23 +35,28 @@ func (r *Resolver) DoTargetedLookup(name, nameServer string, isIterative, lookup
 	var ipv4status Status
 	var ipv6status Status
 
-	if lookupA {
-		ipv4, ipv4Trace, ipv4status, _ = recursiveIPLookup(r, name, nameServer, dns.TypeA, candidateSet, cnameSet, dnameSet, name, 0, isIterative)
-		if len(ipv4) > 0 {
-			ipv4 = Unique(ipv4)
-			res.IPv4Addresses = make([]string, len(ipv4))
-			copy(res.IPv4Addresses, ipv4)
-		}
+	if lookupA && isIterative {
+		singleQueryRes, ipv4Trace, ipv4status, _ = r.IterativeLookup(&Question{Name: name, Type: dns.TypeA, Class: dns.ClassINET})
+	} else if lookupA {
+		singleQueryRes, ipv4Trace, ipv4status, _ = r.ExternalLookup(&Question{Name: name, Type: dns.TypeA, Class: dns.ClassINET}, nameServer)
 	}
-	candidateSet = map[string][]Answer{}
-	cnameSet = map[string][]Answer{}
-	if lookupAAAA {
-		ipv6, ipv6Trace, ipv6status, _ = recursiveIPLookup(r, name, nameServer, dns.TypeAAAA, candidateSet, cnameSet, dnameSet, name, 0, isIterative)
-		if len(ipv6) > 0 {
-			ipv6 = Unique(ipv6)
-			res.IPv6Addresses = make([]string, len(ipv6))
-			copy(res.IPv6Addresses, ipv6)
-		}
+	ipv4, _ = getIPAddressesFromQueryResult(singleQueryRes, "A", name)
+	if len(ipv4) > 0 {
+		ipv4 = Unique(ipv4)
+		res.IPv4Addresses = make([]string, len(ipv4))
+		copy(res.IPv4Addresses, ipv4)
+	}
+	singleQueryRes = &SingleQueryResult{} // reset result
+	if lookupAAAA && isIterative {
+		singleQueryRes, ipv6Trace, ipv6status, _ = r.IterativeLookup(&Question{Name: name, Type: dns.TypeAAAA, Class: dns.ClassINET})
+	} else if lookupAAAA {
+		singleQueryRes, ipv6Trace, ipv6status, _ = r.ExternalLookup(&Question{Name: name, Type: dns.TypeAAAA, Class: dns.ClassINET}, nameServer)
+	}
+	ipv6, _ = getIPAddressesFromQueryResult(singleQueryRes, "AAAA", name)
+	if len(ipv6) > 0 {
+		ipv6 = Unique(ipv6)
+		res.IPv6Addresses = make([]string, len(ipv6))
+		copy(res.IPv6Addresses, ipv6)
 	}
 
 	combinedTrace := util.Concat(ipv4Trace, ipv6Trace)
@@ -72,56 +75,24 @@ func (r *Resolver) DoTargetedLookup(name, nameServer string, isIterative, lookup
 	return &res, combinedTrace, StatusNoError, nil
 }
 
-// recursiveIPLookup helper fn that recursively follows both A/AAAA records and CNAME records to find IP addresses
-// returns an array of IP addresses, a trace of the lookups, a status, and an error
-func recursiveIPLookup(r *Resolver, name, nameServer string, dnsType uint16, candidateSet map[string][]Answer, cnameSet map[string][]Answer, dnameSet map[string][]Answer, origName string, depth int, isIterative bool) ([]string, Trace, Status, error) {
-	// avoid infinite loops
-	if name == origName && depth != 0 {
-		return nil, make(Trace, 0), StatusError, errors.New("infinite redirection loop")
+func getIPAddressesFromQueryResult(res *SingleQueryResult, queryType, name string) ([]string, error) {
+	if res == nil {
+		return nil, errors.New("nil SingleQueryResult")
 	}
-	if depth > 10 {
-		return nil, make(Trace, 0), StatusError, errors.New("max recursion depth reached")
-	}
-	// check if the record is already in our cache. if not, perform normal A lookup and
-	// see what comes back. Then iterate over results and if needed, perform further lookups
-	var trace Trace
-	var result *SingleQueryResult
-	garbage := map[string][]Answer{}
-	if _, ok := candidateSet[name]; !ok {
-		var status Status
-		var err error
-		if isIterative {
-			result, trace, status, err = r.IterativeLookup(&Question{Name: name, Type: dnsType, Class: dns.ClassINET})
-		} else {
-			result, trace, status, err = r.ExternalLookup(&Question{Name: name, Type: dnsType, Class: dns.ClassINET}, nameServer)
+	ips := make([]string, 0, len(res.Answers)+len(res.Additional))
+	for _, ans := range res.Answers {
+		if a, ok := ans.(Answer); ok {
+			if a.Type == queryType {
+				ips = append(ips, a.Answer)
+			}
 		}
-
-		if status != StatusNoError || err != nil {
-			return nil, trace, status, err
-		}
-
-		populateResults(result.Answers, dnsType, candidateSet, cnameSet, dnameSet, garbage)
-		populateResults(result.Additional, dnsType, candidateSet, cnameSet, dnameSet, garbage)
 	}
-	// our cache should now have any data that exists about the current name
-	if res, ok := candidateSet[name]; ok && len(res) > 0 {
-		// we have IP addresses to hand back to the user. let's make an easy-to-use array of strings
-		var ips []string
-		for _, answer := range res {
-			ips = append(ips, answer.Answer)
+	for _, ans := range res.Additional {
+		if a, ok := ans.(Answer); ok {
+			if a.Type == queryType {
+				ips = append(ips, a.Answer)
+			}
 		}
-		return ips, trace, StatusNoError, nil
-	} else if res, ok = cnameSet[name]; ok && len(res) > 0 {
-		// we have a CNAME and need to further recurse to find IPs
-		shortName := strings.ToLower(strings.TrimSuffix(res[0].Answer, "."))
-		res, secondTrace, status, err := recursiveIPLookup(r, shortName, nameServer, dnsType, candidateSet, cnameSet, dnameSet, origName, depth+1, isIterative)
-		trace = append(trace, secondTrace...)
-		return res, trace, status, err
-	} else if res, ok = garbage[name]; ok && len(res) > 0 {
-		return nil, trace, StatusError, errors.New("unexpected record type received")
-	} else {
-		// we have no data whatsoever about this name. return an empty recordset to the user
-		var ips []string
-		return ips, trace, StatusNoError, nil
 	}
+	return ips, nil
 }

--- a/src/zdns/alookup.go
+++ b/src/zdns/alookup.go
@@ -24,7 +24,6 @@ import (
 
 // DoTargetedLookup performs a lookup of the given domain name against the given nameserver, looking up both IPv4 and IPv6 addresses
 // Will follow CNAME records as well as A/AAAA records to get IP addresses
-// While we follow CNAMEs by default in our own iteration, this function will follow CNAMEs in external lookups as well
 func (r *Resolver) DoTargetedLookup(name, nameServer string, isIterative, lookupA, lookupAAAA bool) (*IPResult, Trace, Status, error) {
 	name = strings.ToLower(name)
 	res := IPResult{}

--- a/src/zdns/alookup.go
+++ b/src/zdns/alookup.go
@@ -14,8 +14,9 @@
 package zdns
 
 import (
-	"github.com/pkg/errors"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/zmap/dns"
 
@@ -34,11 +35,12 @@ func (r *Resolver) DoTargetedLookup(name, nameServer string, isIterative, lookup
 	var ipv6Trace Trace
 	var ipv4status Status
 	var ipv6status Status
+	var err error
 
 	if lookupA && isIterative {
-		singleQueryRes, ipv4Trace, ipv4status, _ = r.IterativeLookup(&Question{Name: name, Type: dns.TypeA, Class: dns.ClassINET})
+		singleQueryRes, ipv4Trace, ipv4status, err = r.IterativeLookup(&Question{Name: name, Type: dns.TypeA, Class: dns.ClassINET})
 	} else if lookupA {
-		singleQueryRes, ipv4Trace, ipv4status, _ = r.ExternalLookup(&Question{Name: name, Type: dns.TypeA, Class: dns.ClassINET}, nameServer)
+		singleQueryRes, ipv4Trace, ipv4status, err = r.ExternalLookup(&Question{Name: name, Type: dns.TypeA, Class: dns.ClassINET}, nameServer)
 	}
 	ipv4, _ = getIPAddressesFromQueryResult(singleQueryRes, "A", name)
 	if len(ipv4) > 0 {
@@ -65,9 +67,9 @@ func (r *Resolver) DoTargetedLookup(name, nameServer string, isIterative, lookup
 	// IPv4 or IPv6 lookup, we return that status.
 	if len(res.IPv4Addresses) == 0 && len(res.IPv6Addresses) == 0 {
 		if lookupA && !SafeStatus(ipv4status) {
-			return nil, combinedTrace, ipv4status, nil
+			return nil, combinedTrace, ipv4status, err
 		} else if lookupAAAA && !SafeStatus(ipv6status) {
-			return nil, combinedTrace, ipv6status, nil
+			return nil, combinedTrace, ipv6status, err
 		} else {
 			return &res, combinedTrace, StatusNoError, nil
 		}

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -239,7 +239,7 @@ func (r *Resolver) followingLookup(ctx context.Context, q Question, nameServer s
 		}
 	}
 	log.Debugf("MIEKG-IN: max recursion depth reached for %s lookup", originalName)
-	return nil, trace, StatusServFail, nil
+	return nil, trace, StatusServFail, errors.New("max recursion depth reached")
 }
 
 // isLookupComplete checks if there's a valid answer using the originalName and following CNAMES

--- a/src/zdns/lookup_test.go
+++ b/src/zdns/lookup_test.go
@@ -1424,7 +1424,6 @@ func TestTwoNSInAdditional(t *testing.T) {
 
 func TestAandQuadAInAdditional(t *testing.T) {
 	config := InitTest(t)
-	//config.IPVersionMode = IPv4OrIPv6
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
@@ -1474,7 +1473,6 @@ func TestAandQuadAInAdditional(t *testing.T) {
 
 func TestNsMismatchIpType(t *testing.T) {
 	config := InitTest(t)
-	//config.IPVersionMode = IPv4OrIPv6
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
@@ -1524,7 +1522,6 @@ func TestNsMismatchIpType(t *testing.T) {
 
 func TestAandQuadALookup(t *testing.T) {
 	config := InitTest(t)
-	//config.IPVersionMode = IPv4OrIPv6
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 

--- a/src/zdns/lookup_test.go
+++ b/src/zdns/lookup_test.go
@@ -1424,6 +1424,7 @@ func TestTwoNSInAdditional(t *testing.T) {
 
 func TestAandQuadAInAdditional(t *testing.T) {
 	config := InitTest(t)
+	//config.IPVersionMode = IPv4OrIPv6
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
@@ -1473,6 +1474,7 @@ func TestAandQuadAInAdditional(t *testing.T) {
 
 func TestNsMismatchIpType(t *testing.T) {
 	config := InitTest(t)
+	//config.IPVersionMode = IPv4OrIPv6
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
@@ -1522,6 +1524,7 @@ func TestNsMismatchIpType(t *testing.T) {
 
 func TestAandQuadALookup(t *testing.T) {
 	config := InitTest(t)
+	//config.IPVersionMode = IPv4OrIPv6
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -761,6 +761,41 @@ class Tests(unittest.TestCase):
         self.assertSuccess(res, cmd)
         self.assertEqualMXLookup(res, self.MX_LOOKUP_ANSWER_IPV4)
 
+    def test_a_lookup(self):
+        c = "alookup --ipv4-lookup --ipv6-lookup"
+        name = "www.zdns-testing.com"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd)
+        self.assertEqualALookup(res, self.A_LOOKUP_WWW_ZDNS_TESTING)
+
+    def test_a_lookup_iterative(self):
+        c = "alookup --ipv4-lookup --ipv6-lookup --iterative"
+        name = "www.zdns-testing.com"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd)
+        self.assertEqualALookup(res, self.A_LOOKUP_WWW_ZDNS_TESTING)
+
+    def test_a_lookup_ipv4(self):
+        c = "alookup --ipv4-lookup"
+        name = "www.zdns-testing.com"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd)
+        self.assertEqualALookup(res, self.A_LOOKUP_IPV4_WWW_ZDNS_TESTING)
+
+    def test_a_lookup_ipv6(self):
+        c = "alookup --ipv6-lookup"
+        name = "www.zdns-testing.com"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd)
+        self.assertEqualALookup(res, self.A_LOOKUP_IPV6_WWW_ZDNS_TESTING)
+
+    def test_a_lookup_default(self):
+        c = "alookup"
+        name = "www.zdns-testing.com"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd)
+        self.assertEqualALookup(res, self.A_LOOKUP_IPV4_WWW_ZDNS_TESTING)
+
     def test_ns_lookup(self):
         c = "nslookup --ipv4-lookup --ipv6-lookup"
         name = "www.zdns-testing.com"

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -162,6 +162,17 @@ class Tests(unittest.TestCase):
         }
     }
 
+    A_LOOKUP_CNAME_CHAIN_03 = {
+        "name": "cname-chain-03.esrg.stanford.edu",
+        "class": "IN",
+        "status": "NOERROR",
+        "data": {
+            "ipv4_addresses": [
+                "1.2.3.4",
+            ],
+        }
+    }
+
     A_LOOKUP_IPV4_WWW_ZDNS_TESTING = copy.deepcopy(A_LOOKUP_WWW_ZDNS_TESTING)
     del A_LOOKUP_IPV4_WWW_ZDNS_TESTING["data"]["ipv6_addresses"]
     A_LOOKUP_IPV6_WWW_ZDNS_TESTING = copy.deepcopy(A_LOOKUP_WWW_ZDNS_TESTING)
@@ -795,6 +806,34 @@ class Tests(unittest.TestCase):
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd)
         self.assertEqualALookup(res, self.A_LOOKUP_IPV4_WWW_ZDNS_TESTING)
+
+    def test_a_lookup_iterative_cname_loop(self):
+        c = "alookup --iterative"
+        name = "cname-loop.zdns-testing.com"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd)
+        assert len(res["data"]) == 0
+
+    # There exists DNS records in esrg.stanford.edu and zdns-testing.com of the form:
+    # cname-chain-01.esrg.stanford.edu CNAME cname-chain-02.zdns-testing.com.
+    # cname-chain-02.zdns-testing.com CNAME cname-chain-03.esrg.stanford.edu.
+    # ...
+    # cname-chain-11.esrg.stanford.edu CNAME cname-chain-12.zdns-testing.com.
+    # cname-chain-12.zdns-testing.com A 1.2.3.4
+    # We only follow 10 CNAMEs in a chain, so we should not be able to resolve the A record using cname-chain-01
+    def test_a_lookup_cname_chain_too_long(self):
+        c = "alookup --iterative --ipv4-lookup"
+        name = "cname-chain-01.esrg.stanford.edu"
+        cmd, res = self.run_zdns(c, name)
+        self.assertServFail(res, cmd)
+
+    def test_a_lookup_cname_chain(self):
+        c = "alookup --iterative --ipv4-lookup"
+        name = "cname-chain-03.esrg.stanford.edu"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd)
+        self.assertEqualALookup(res, self.A_LOOKUP_CNAME_CHAIN_03)
+
 
     def test_ns_lookup(self):
         c = "nslookup --ipv4-lookup --ipv6-lookup"

--- a/testing/large_scan_integration/README.md
+++ b/testing/large_scan_integration/README.md
@@ -1,5 +1,5 @@
 ## Large Scan Integration Test
-This script runs a large scan integration test for the A modules of zdns.
+This script runs a large scan integration test for the A and ALOOKUP modules of zdns.
 
 10,000 domains were set up in the zdns-testing.com namespace, 5k for `subdomain0.zdns-testing.com` and 5k for
 `subdomain1.subdomain0.zdns-testing.com`, with the following structure:

--- a/testing/large_scan_integration/large_scan_integration_tests.py
+++ b/testing/large_scan_integration/large_scan_integration_tests.py
@@ -49,8 +49,18 @@ def get_IPs_from_actual_line_a_module(actual_line):
             IPs.append(answer['answer'])
     return set(IPs)
 
-# verify_output takes the stdout from zdns and the module that was run and verifies that the output matches the
-# expected output
+def get_IPs_from_actual_line_alookup_module(actual_line):
+    if 'data' not in actual_line:
+        return []
+    if 'ipv4_addresses' not in actual_line['data']:
+        return []
+    IPs = []
+    for IP in actual_line['data']['ipv4_addresses']:
+        IPs.append(IP)
+    return set(IPs)
+
+
+# verify_output takes the stdout from zdns and the module that was run and verifies that the output matches the expected output
 def verify_output(stdout, module):
     # verify that the output matches the expected output
     output_lines = stdout.split("\n")
@@ -66,6 +76,8 @@ def verify_output(stdout, module):
             assert actual_status == "NOERROR", f"Status is not NOERROR: {actual_status}"
         if module == "A":
             actual_IPs = get_IPs_from_actual_line_a_module(actual_line)
+        elif module == "ALOOKUP":
+            actual_IPs = get_IPs_from_actual_line_alookup_module(actual_line)
         else:
             assert False, f"Invalid module: {module}"
 
@@ -80,4 +92,7 @@ print("Beginning tests")
 std_out, std_err = run_zdns(["A", "--iterative", "--threads", "100"])
 verify_output(std_out, "A")
 print("A module passed")
+std_out, std_err = run_zdns(["ALOOKUP", "--iterative", "--threads", "100"])
+verify_output(std_out, "ALOOKUP")
+print("ALOOKUP module passed")
 print("All tests passed")


### PR DESCRIPTION
This reverts commit d73adea269ccb736a8afa39b269ea851cb2d1bd0.

- Removed the CNAME following logic in ALOOKUP, since that's handled by default now
- Since our unit testing interface skips the CNAME-following logic, moved our unit tests to integration tests and setup the required DNS records in `esrg.stanford.edu` and `zdns-testing.com`
- Reverted the `alookup` removal commit

Closes #424