### PR TITLE
Fix `--class` not being respected by CLI

### DIFF
--- a/src/cli/modules.go
+++ b/src/cli/modules.go
@@ -142,6 +142,7 @@ func (lm *BasicLookupModule) CLIInit(gc *CLIConf, rc *zdns.ResolverConfig) error
 	}
 	lm.LookupAllNameServers = rc.LookupAllNameServers
 	lm.IsIterative = gc.IterativeResolution
+	lm.DNSClass = gc.Class
 	return nil
 }
 

--- a/src/cli/modules.go
+++ b/src/cli/modules.go
@@ -141,8 +141,11 @@ func (lm *BasicLookupModule) CLIInit(gc *CLIConf, rc *zdns.ResolverConfig) error
 		return errors.New("ResolverConfig cannot be nil")
 	}
 	lm.LookupAllNameServers = rc.LookupAllNameServers
+	if gc.Class != 0 {
+		// if the user has specified a class, use it
+		lm.DNSClass = gc.Class
+	}
 	lm.IsIterative = gc.IterativeResolution
-	lm.DNSClass = gc.Class
 	return nil
 }
 

--- a/src/modules/dmarc/dmarc_test.go
+++ b/src/modules/dmarc/dmarc_test.go
@@ -66,7 +66,7 @@ func TestDmarcLookup_Valid_1(t *testing.T) {
 			zdns.Answer{Name: "_dmarc.zdns-testing.com", Answer: "v=DMARC1; p=none; rua=mailto:postmaster@censys.io"}},
 	}
 	dmarcMod := DmarcLookupModule{}
-	err := dmarcMod.CLIInit(&cli.CLIConf{Class: dns.ClassINET}, &zdns.ResolverConfig{})
+	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
 	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
@@ -87,7 +87,7 @@ func TestDmarcLookup_Valid_2(t *testing.T) {
 			zdns.Answer{Name: "_dmarc.zdns-testing.com", Answer: "V=DMARC1; p=none; rua=mailto:postmaster@censys.io"}},
 	}
 	dmarcMod := DmarcLookupModule{}
-	err := dmarcMod.CLIInit(&cli.CLIConf{Class: dns.ClassINET}, &zdns.ResolverConfig{})
+	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
 	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
@@ -108,7 +108,7 @@ func TestDmarcLookup_Valid_3(t *testing.T) {
 			zdns.Answer{Name: "_dmarc.zdns-testing.com", Answer: "v\t\t\t=\t\t  DMARC1\t\t; p=none; rua=mailto:postmaster@censys.io"}},
 	}
 	dmarcMod := DmarcLookupModule{}
-	err := dmarcMod.CLIInit(&cli.CLIConf{Class: dns.ClassINET}, &zdns.ResolverConfig{})
+	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
 	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
@@ -129,7 +129,7 @@ func TestDmarcLookup_NotValid_1(t *testing.T) {
 			zdns.Answer{Name: "_dmarc.zdns-testing.com", Answer: "\t\t   v   =DMARC1; p=none; rua=mailto:postmaster@censys.io"}},
 	}
 	dmarcMod := DmarcLookupModule{}
-	err := dmarcMod.CLIInit(&cli.CLIConf{Class: dns.ClassINET}, &zdns.ResolverConfig{})
+	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
 	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
@@ -150,7 +150,7 @@ func TestDmarcLookup_NotValid_2(t *testing.T) {
 			zdns.Answer{Name: "_dmarc.zdns-testing.com", Answer: "v=DMARc1; p=none; rua=mailto:postmaster@censys.io"}},
 	}
 	dmarcMod := DmarcLookupModule{}
-	err := dmarcMod.CLIInit(&cli.CLIConf{Class: dns.ClassINET}, &zdns.ResolverConfig{})
+	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
 	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
@@ -171,7 +171,7 @@ func TestDmarcLookup_NotValid_3(t *testing.T) {
 			zdns.Answer{Name: "_dmarc.zdns-testing.com", Answer: "v=DMARc1. p=none; rua=mailto:postmaster@censys.io"}},
 	}
 	dmarcMod := DmarcLookupModule{}
-	err := dmarcMod.CLIInit(&cli.CLIConf{Class: dns.ClassINET}, &zdns.ResolverConfig{})
+	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
 	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))

--- a/src/modules/dmarc/dmarc_test.go
+++ b/src/modules/dmarc/dmarc_test.go
@@ -66,7 +66,7 @@ func TestDmarcLookup_Valid_1(t *testing.T) {
 			zdns.Answer{Name: "_dmarc.zdns-testing.com", Answer: "v=DMARC1; p=none; rua=mailto:postmaster@censys.io"}},
 	}
 	dmarcMod := DmarcLookupModule{}
-	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
+	err := dmarcMod.CLIInit(&cli.CLIConf{Class: dns.ClassINET}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
 	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
@@ -87,7 +87,7 @@ func TestDmarcLookup_Valid_2(t *testing.T) {
 			zdns.Answer{Name: "_dmarc.zdns-testing.com", Answer: "V=DMARC1; p=none; rua=mailto:postmaster@censys.io"}},
 	}
 	dmarcMod := DmarcLookupModule{}
-	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
+	err := dmarcMod.CLIInit(&cli.CLIConf{Class: dns.ClassINET}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
 	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
@@ -108,7 +108,7 @@ func TestDmarcLookup_Valid_3(t *testing.T) {
 			zdns.Answer{Name: "_dmarc.zdns-testing.com", Answer: "v\t\t\t=\t\t  DMARC1\t\t; p=none; rua=mailto:postmaster@censys.io"}},
 	}
 	dmarcMod := DmarcLookupModule{}
-	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
+	err := dmarcMod.CLIInit(&cli.CLIConf{Class: dns.ClassINET}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
 	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
@@ -129,7 +129,7 @@ func TestDmarcLookup_NotValid_1(t *testing.T) {
 			zdns.Answer{Name: "_dmarc.zdns-testing.com", Answer: "\t\t   v   =DMARC1; p=none; rua=mailto:postmaster@censys.io"}},
 	}
 	dmarcMod := DmarcLookupModule{}
-	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
+	err := dmarcMod.CLIInit(&cli.CLIConf{Class: dns.ClassINET}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
 	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
@@ -150,7 +150,7 @@ func TestDmarcLookup_NotValid_2(t *testing.T) {
 			zdns.Answer{Name: "_dmarc.zdns-testing.com", Answer: "v=DMARc1; p=none; rua=mailto:postmaster@censys.io"}},
 	}
 	dmarcMod := DmarcLookupModule{}
-	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
+	err := dmarcMod.CLIInit(&cli.CLIConf{Class: dns.ClassINET}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
 	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
@@ -171,7 +171,7 @@ func TestDmarcLookup_NotValid_3(t *testing.T) {
 			zdns.Answer{Name: "_dmarc.zdns-testing.com", Answer: "v=DMARc1. p=none; rua=mailto:postmaster@censys.io"}},
 	}
 	dmarcMod := DmarcLookupModule{}
-	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
+	err := dmarcMod.CLIInit(&cli.CLIConf{Class: dns.ClassINET}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
 	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))


### PR DESCRIPTION
Closes #426

NOTE - presently, all modules hard-code `INET` as the class, except `BINDVERSION` which sets it as `CHAOS`. This is not changed in this PR.

## Description
- populate lookup module's `Class` field so user's --class choice is respected

## Testing

It's not really possible (that I can figure) how to test this in integration tests. Running `tcpdump` and evaluating the output seems iffy on random CI systems and no DNS server seemed to respond when I set the class as anything other than `INET`, so I ended up just showing both in Wireshark.

With Wireshark, I ran `./zdns A zdns-testing.com --name-servers=1.1.1.1 --class=CHAOS` with the Display Filter `sudo tcpdump -i en0 udp dst port 53 and dst host 1.1.1.1 `

### `main`
```
16:57:09.209413 IP phillips-laptop.lan.56789 > one.one.one.one.domain: 53589+ [1au] A? zdns-testing.com. (45)
```

### `Phillip/426...`
```
16:57:19.112017 IP phillips-laptop.lan.60563 > one.one.one.one.domain: 14018+ [1au] A CHAOS? zdns-testing.com. (45)
```

