### PR TITLE
Fixes Seg-Faults if Close is called on a resolver and IPv4/v6 isn't used and update examples/

### DIFF
--- a/examples/multi_thread_lookup/multi_threaded.go
+++ b/examples/multi_thread_lookup/multi_threaded.go
@@ -14,11 +14,13 @@
 package main
 
 import (
+	"net"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/dns"
 
+	"github.com/zmap/zdns/examples/utils"
 	"github.com/zmap/zdns/src/zdns"
 )
 
@@ -66,6 +68,14 @@ func main() {
 func initializeResolver(cache *zdns.Cache) *zdns.Resolver {
 	// Create a ResolverConfig object
 	resolverConfig := zdns.NewResolverConfig()
+	localAddr, err := utils.GetLocalIPByConnecting()
+	if err != nil {
+		log.Fatal("Error getting local IP: ", err)
+	}
+	resolverConfig.LocalAddrsV4 = []net.IP{localAddr}
+	resolverConfig.ExternalNameServersV4 = []string{"1.1.1.1:53"}
+	resolverConfig.RootNameServersV4 = []string{"198.41.0.4:53"}
+	resolverConfig.IPVersionMode = zdns.IPv4Only
 	// Set any desired options on the ResolverConfig object
 	resolverConfig.Cache = cache
 	// Create a new Resolver object with the ResolverConfig object, it will retain all settings set on the ResolverConfig object

--- a/examples/multi_thread_lookup/multi_threaded.go
+++ b/examples/multi_thread_lookup/multi_threaded.go
@@ -60,6 +60,8 @@ func main() {
 	}()
 	wg.Wait()
 	log.Warn("All lookups complete")
+	resolver1.Close()
+	resolver2.Close()
 }
 
 // initializeResolver

--- a/examples/multi_thread_lookup/multi_threaded_test.go
+++ b/examples/multi_thread_lookup/multi_threaded_test.go
@@ -1,0 +1,21 @@
+/* ZDNS Copyright 2024 Regents of the University of Michigan
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy
+* of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+* implied. See the License for the specific language governing
+* permissions and limitations under the License.
+ */
+package main
+
+import (
+	"testing"
+)
+
+func TestMultiThreadedExampleMain(t *testing.T) {
+	main()
+}

--- a/examples/single_lookup/simple.go
+++ b/examples/single_lookup/simple.go
@@ -53,7 +53,6 @@ func main() {
 	if err != nil {
 		log.Fatal("Error marshalling trace: ", err)
 	}
-	log.Warnf("Trace: %v", string(bytes))
 	log.Warnf("Status: %v", status)
 	resolver.Close()
 }

--- a/examples/single_lookup/simple.go
+++ b/examples/single_lookup/simple.go
@@ -15,15 +15,16 @@ package main
 
 import (
 	"encoding/json"
+	"net"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/dns"
 
+	"github.com/zmap/zdns/examples/utils"
 	"github.com/zmap/zdns/src/zdns"
 )
 
 func main() {
-
 	// Perform the lookup
 	domain := "google.com"
 	dnsQuestion := &zdns.Question{Name: domain, Type: dns.TypeA, Class: dns.ClassINET}
@@ -54,13 +55,22 @@ func main() {
 	}
 	log.Warnf("Trace: %v", string(bytes))
 	log.Warnf("Status: %v", status)
+	resolver.Close()
 }
 
 func initializeResolver() *zdns.Resolver {
+	localAddr, err := utils.GetLocalIPByConnecting()
+	if err != nil {
+		log.Fatal("Error getting local IP: ", err)
+	}
 	// Create a ResolverConfig object
 	resolverConfig := zdns.NewResolverConfig()
 	// Set any desired options on the ResolverConfig object
 	resolverConfig.LogLevel = log.InfoLevel
+	resolverConfig.LocalAddrsV4 = []net.IP{localAddr}
+	resolverConfig.ExternalNameServersV4 = []string{"1.1.1.1:53"}
+	resolverConfig.RootNameServersV4 = []string{"198.41.0.4:53"}
+	resolverConfig.IPVersionMode = zdns.IPv4Only
 	// Create a new Resolver object with the ResolverConfig object, it will retain all settings set on the ResolverConfig object
 	resolver, err := zdns.InitResolver(resolverConfig)
 	if err != nil {

--- a/examples/single_lookup/simple_test.go
+++ b/examples/single_lookup/simple_test.go
@@ -1,0 +1,20 @@
+/* ZDNS Copyright 2024 Regents of the University of Michigan
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy
+* of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+* implied. See the License for the specific language governing
+* permissions and limitations under the License.
+ */
+
+package main
+
+import "testing"
+
+func TestMultiThreadedExampleMain(t *testing.T) {
+	main()
+}

--- a/examples/utils/utils.go
+++ b/examples/utils/utils.go
@@ -1,0 +1,28 @@
+/* ZDNS Copyright 2024 Regents of the University of Michigan
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy
+* of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+* implied. See the License for the specific language governing
+* permissions and limitations under the License.
+ */
+
+package utils
+
+import "net"
+
+func GetLocalIPByConnecting() (net.IP, error) {
+	conn, err := net.Dial("udp", "1.1.1.1:53")
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+
+	return localAddr.IP, nil
+}

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -648,6 +648,8 @@ func doLookupWorker(gc *CLIConf, rc *zdns.ResolverConfig, input <-chan string, o
 		}
 		metadata.Names++
 	}
+	// close the resolver, freeing up resources
+	resolver.Close()
 	metaChan <- metadata
 	return nil
 }

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -497,12 +497,12 @@ func (r *Resolver) IterativeLookup(q *Question) (*SingleQueryResult, Trace, Stat
 // Close cleans up any resources used by the resolver. This should be called when the resolver is no longer needed.
 // Lookup will panic if called after Close.
 func (r *Resolver) Close() {
-	if r.connInfoIPv4.conn != nil {
+	if r.connInfoIPv4 != nil && r.connInfoIPv4.conn != nil {
 		if err := r.connInfoIPv4.conn.Close(); err != nil {
 			log.Errorf("error closing IPv4 connection: %v", err)
 		}
 	}
-	if r.connInfoIPv6.conn != nil {
+	if r.connInfoIPv6 != nil && r.connInfoIPv6.conn != nil {
 		if err := r.connInfoIPv6.conn.Close(); err != nil {
 			log.Errorf("error closing IPv6 connection: %v", err)
 		}


### PR DESCRIPTION
Closes #423 

A user reached out over email saying that the `resolver.Close` had broken with the recent IPv6 changes. This PR:

- ensures `Close` doesn't panic if we don't have an IPv4 or IPv6 conn object
- Utilize `Close` in our `worker_manager` so that this sort of seg fault would be caught by our CI. (We simply we're calling `resolver.Close` before
- Updates the `examples/` folder so they compile again with the recent changes around IPv4/v6 resolver validation
- Adds a unit test so any breaking changes to `examples/` will be caught before PR merge