### PR TITLE
Pass domains as NameServers and NameServer struct re-factor

### DIFF
--- a/examples/multi_thread_lookup/multi_threaded.go
+++ b/examples/multi_thread_lookup/multi_threaded.go
@@ -75,8 +75,8 @@ func initializeResolver(cache *zdns.Cache) *zdns.Resolver {
 		log.Fatal("Error getting local IP: ", err)
 	}
 	resolverConfig.LocalAddrsV4 = []net.IP{localAddr}
-	resolverConfig.ExternalNameServersV4 = []string{"1.1.1.1:53"}
-	resolverConfig.RootNameServersV4 = []string{"198.41.0.4:53"}
+	resolverConfig.ExternalNameServersV4 = []zdns.NameServer{{IP: net.ParseIP("1.1.1.1"), Port: 53}}
+	resolverConfig.RootNameServersV4 = []zdns.NameServer{{IP: net.ParseIP("198.41.0.4"), Port: 53}}
 	resolverConfig.IPVersionMode = zdns.IPv4Only
 	// Set any desired options on the ResolverConfig object
 	resolverConfig.Cache = cache

--- a/examples/single_lookup/simple.go
+++ b/examples/single_lookup/simple.go
@@ -30,7 +30,7 @@ func main() {
 	dnsQuestion := &zdns.Question{Name: domain, Type: dns.TypeA, Class: dns.ClassINET}
 	resolver := initializeResolver()
 
-	result, _, status, err := resolver.ExternalLookup(dnsQuestion, "1.1.1.1:53")
+	result, _, status, err := resolver.ExternalLookup(dnsQuestion, &zdns.NameServer{IP: net.ParseIP("1.1.1.1"), Port: 53})
 	if err != nil {
 		log.Fatal("Error looking up domain: ", err)
 	}
@@ -67,8 +67,8 @@ func initializeResolver() *zdns.Resolver {
 	// Set any desired options on the ResolverConfig object
 	resolverConfig.LogLevel = log.InfoLevel
 	resolverConfig.LocalAddrsV4 = []net.IP{localAddr}
-	resolverConfig.ExternalNameServersV4 = []string{"1.1.1.1:53"}
-	resolverConfig.RootNameServersV4 = []string{"198.41.0.4:53"}
+	resolverConfig.ExternalNameServersV4 = []zdns.NameServer{{IP: net.ParseIP("1.1.1.1"), Port: 53}}
+	resolverConfig.RootNameServersV4 = []zdns.NameServer{{IP: net.ParseIP("198.41.0.4"), Port: 53}}
 	resolverConfig.IPVersionMode = zdns.IPv4Only
 	// Create a new Resolver object with the ResolverConfig object, it will retain all settings set on the ResolverConfig object
 	resolver, err := zdns.InitResolver(resolverConfig)

--- a/src/cli/modules.go
+++ b/src/cli/modules.go
@@ -25,7 +25,7 @@ import (
 
 type LookupModule interface {
 	CLIInit(gc *CLIConf, rc *zdns.ResolverConfig) error
-	Lookup(resolver *zdns.Resolver, lookupName, nameServer string) (interface{}, zdns.Trace, zdns.Status, error)
+	Lookup(resolver *zdns.Resolver, lookupName string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error)
 	Help() string                 // needed to satisfy the ZCommander interface in ZFlags.
 	GetDescription() string       // needed to add a command to the parser, printed to the user. Printed to the user when they run the help command for a given module
 	Validate(args []string) error // needed to satisfy the ZCommander interface in ZFlags
@@ -165,7 +165,7 @@ func (lm *BasicLookupModule) NewFlags() interface{} {
 	return lm
 }
 
-func (lm *BasicLookupModule) Lookup(resolver *zdns.Resolver, lookupName, nameServer string) (interface{}, zdns.Trace, zdns.Status, error) {
+func (lm *BasicLookupModule) Lookup(resolver *zdns.Resolver, lookupName string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
 	if lm.LookupAllNameServers {
 		return resolver.LookupAllNameservers(&zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass}, nameServer)
 	}

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -548,7 +548,7 @@ func doLookupWorker(gc *CLIConf, rc *zdns.ResolverConfig, input <-chan string, o
 		res := zdns.Result{Results: make(map[string]zdns.SingleModuleResult, len(gc.ActiveModules))}
 		// get the fields that won't change for each lookup module
 		rawName := ""
-		nameServer := &zdns.NameServer{}
+		var nameServer *zdns.NameServer
 		nameServerString := ""
 		var rank int
 		var entryMetadata string
@@ -569,9 +569,11 @@ func doLookupWorker(gc *CLIConf, rc *zdns.ResolverConfig, input <-chan string, o
 			}
 		} else {
 			rawName, nameServerString = parseNormalInputLine(line)
-			nameServer, err = convertNameServerStringToNameServer(nameServerString)
-			if err != nil {
-				log.Fatal("unable to parse name server: ", line)
+			if len(nameServerString) != 0 {
+				nameServer, err = convertNameServerStringToNameServer(nameServerString)
+				if err != nil {
+					log.Fatal("unable to parse name server: ", line)
+				}
 			}
 		}
 		res.Name = rawName

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -322,7 +322,7 @@ func populateIPTransportMode(gc *CLIConf, config *zdns.ResolverConfig) (*zdns.Re
 func populateNameServers(gc *CLIConf, config *zdns.ResolverConfig) (*zdns.ResolverConfig, error) {
 	// Nameservers are populated in this order:
 	// 1. If user provided nameservers, use those
-	// 2. (External Only) If we can get the OS' default recursive resolver nameservers, use those
+	// 2. (External Only and NOT --name-server-mode) If we can get the OS' default recursive resolver nameservers, use those
 	// 3. Use ZDNS defaults
 
 	// Additionally, both Root and External nameservers must be populated, since the Resolver doesn't know we'll only
@@ -353,7 +353,7 @@ func populateNameServers(gc *CLIConf, config *zdns.ResolverConfig) (*zdns.Resolv
 		return config, nil
 	}
 	// User did not provide nameservers
-	if !gc.IterativeResolution {
+	if !gc.IterativeResolution && !gc.NameServerMode {
 		// Try to get the OS' default recursive resolver nameservers
 		var v4NameServers, v6NameServers []zdns.NameServer
 		v4NameServerStrings, v6NameServersStrings, err := zdns.GetDNSServers(config.DNSConfigFilePath)

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -215,7 +215,7 @@ func populateResolverConfig(gc *CLIConf) *zdns.ResolverConfig {
 	} else {
 		config.IterationIPPreference = zdns.GetIterationIPPreference(gc.PreferIPv4Iteration, gc.PreferIPv6Iteration)
 	}
-	// This must occur after setting the DNSConfigFilePath above and NameServers, so that ZDNS knows where to fetch the DNS Config
+	// This must occur after setting the DNSConfigFilePath above, so that ZDNS knows where to fetch the DNS Config
 	config, err := populateIPTransportMode(gc, config)
 	if err != nil {
 		log.Fatal("could not populate IP transport mode: ", err)
@@ -289,11 +289,11 @@ func populateIPTransportMode(gc *CLIConf, config *zdns.ResolverConfig) (*zdns.Re
 			} else if util.IsIPv6(&ns.IP) {
 				nameServersSupportIPv6 = true
 			} else {
-				log.Fatal("Invalid name server: ", ns.String())
+				log.Fatal("invalid name server: ", ns.String())
 			}
 		}
 		if !nameServersSupportIPv4 && !nameServersSupportIPv6 {
-			return nil, errors.New("no nameservers found with OS defaults. Please specify desired nameservers with --name-servers")
+			return nil, errors.New("no nameservers found. Please specify desired nameservers with --name-servers")
 		}
 		config.IPVersionMode = zdns.GetIPVersionMode(nameServersSupportIPv4, nameServersSupportIPv6)
 		return config, nil
@@ -311,9 +311,6 @@ func populateIPTransportMode(gc *CLIConf, config *zdns.ResolverConfig) (*zdns.Re
 	}
 	if len(ipv6NSStrings) > 0 {
 		nameServersSupportIPv6 = true
-	}
-	if !nameServersSupportIPv4 && !nameServersSupportIPv6 {
-		return nil, errors.New("no nameservers found with OS defaults. Please specify desired nameservers with --name-servers")
 	}
 	config.IPVersionMode = zdns.GetIPVersionMode(nameServersSupportIPv4, nameServersSupportIPv6)
 	return config, nil

--- a/src/cli/worker_manager_test.go
+++ b/src/cli/worker_manager_test.go
@@ -1,0 +1,96 @@
+/*
+ * ZDNS Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/zmap/zdns/src/zdns"
+)
+
+func TestConvertNameServerStringToNameServer(t *testing.T) {
+	tests := []struct {
+		nameServerString   string
+		expectedNameServer string
+	}{
+		{
+			"1.1.1.1",
+			"1.1.1.1:53",
+		}, {
+			"1.1.1.1:35",
+			"1.1.1.1:35",
+		}, {
+			"2606:4700:4700::1111",
+			"[2606:4700:4700::1111]:53",
+		}, {
+			"[2606:4700:4700::1111]:35",
+			"[2606:4700:4700::1111]:35",
+		},
+	}
+	for _, test := range tests {
+		nses, err := convertNameServerStringToNameServer(test.nameServerString, zdns.IPv4OrIPv6)
+		require.Nil(t, err)
+		require.Len(t, nses, 1)
+		if nses[0].String() != test.expectedNameServer {
+			t.Errorf("Expected %s, got %s", test.expectedNameServer, nses[0].String())
+		}
+	}
+	// need to convert these to use the .String method to test
+	t.Run("Domain Name as Name Server, both IPv4 and v6", func(t *testing.T) {
+		nses, err := convertNameServerStringToNameServer("one.one.one.one", zdns.IPv4OrIPv6)
+		require.Nil(t, err)
+		expectedNSes := []string{"1.1.1.1:53", "1.0.0.1:53", "[2606:4700:4700::1111]:53", "[2606:4700:4700::1001]:53"}
+		containsExpectedNameServerStrings(t, nses, expectedNSes)
+	})
+	t.Run("Domain Name as Name Server, just IPv4", func(t *testing.T) {
+		nses, err := convertNameServerStringToNameServer("one.one.one.one", zdns.IPv4Only)
+		require.Nil(t, err)
+		expectedNSes := []string{"1.1.1.1:53", "1.0.0.1:53"}
+		containsExpectedNameServerStrings(t, nses, expectedNSes)
+	})
+	t.Run("Domain Name as Name Server, just IPv6", func(t *testing.T) {
+		nses, err := convertNameServerStringToNameServer("one.one.one.one", zdns.IPv6Only)
+		require.Nil(t, err)
+		expectedNSes := []string{"[2606:4700:4700::1111]:53", "[2606:4700:4700::1001]:53"}
+		containsExpectedNameServerStrings(t, nses, expectedNSes)
+	})
+	t.Run("Domain Name as Name Server, port provided", func(t *testing.T) {
+		nses, err := convertNameServerStringToNameServer("one.one.one.one:2345", zdns.IPv4OrIPv6)
+		require.Nil(t, err)
+		expectedNSes := []string{"1.1.1.1:2345", "1.0.0.1:2345", "[2606:4700:4700::1111]:2345", "[2606:4700:4700::1001]:2345"}
+		containsExpectedNameServerStrings(t, nses, expectedNSes)
+	})
+}
+
+func containsExpectedNameServerStrings(t *testing.T, actualNSes []zdns.NameServer, expectedNameServers []string) {
+	require.Len(t, actualNSes, len(expectedNameServers))
+	currentNS := ""
+	var foundNS bool
+	for _, ns := range expectedNameServers {
+		currentNS = ns
+		foundNS = false
+		for _, actualNS := range actualNSes {
+			if actualNS.String() == ns {
+				foundNS = true
+				break
+			}
+		}
+		if !foundNS {
+			require.Fail(t, fmt.Sprintf("Expected nameserver %s not present in actual list", currentNS))
+		}
+	}
+}

--- a/src/cli/worker_manager_test.go
+++ b/src/cli/worker_manager_test.go
@@ -74,6 +74,14 @@ func TestConvertNameServerStringToNameServer(t *testing.T) {
 		expectedNSes := []string{"1.1.1.1:2345", "1.0.0.1:2345", "[2606:4700:4700::1111]:2345", "[2606:4700:4700::1001]:2345"}
 		containsExpectedNameServerStrings(t, nses, expectedNSes)
 	})
+	t.Run("Bad domain name", func(t *testing.T) {
+		_, err := convertNameServerStringToNameServer("bad.domain.name", zdns.IPv4OrIPv6)
+		require.Error(t, err)
+	})
+	t.Run("Bad IP address", func(t *testing.T) {
+		_, err := convertNameServerStringToNameServer("1.1.1.556", zdns.IPv4OrIPv6)
+		require.Error(t, err)
+	})
 }
 
 func containsExpectedNameServerStrings(t *testing.T, actualNSes []zdns.NameServer, expectedNameServers []string) {

--- a/src/cli/worker_manager_test.go
+++ b/src/cli/worker_manager_test.go
@@ -16,8 +16,9 @@ package cli
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/zmap/zdns/src/zdns"
 )

--- a/src/cli/worker_manager_test.go
+++ b/src/cli/worker_manager_test.go
@@ -103,3 +103,63 @@ func containsExpectedNameServerStrings(t *testing.T, actualNSes []zdns.NameServe
 		}
 	}
 }
+
+func TestRemoveDomainsFromNameServersString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		// Test with no name servers (empty list)
+		{
+			input:    "",
+			expected: []string{},
+		},
+		// Test with single IP only
+		{
+			input:    "1.1.1.1",
+			expected: []string{"1.1.1.1"},
+		},
+		// Test with single domain only
+		{
+			input:    "example.com",
+			expected: []string{},
+		},
+		// Test with single IP+Port
+		{
+			input:    "1.1.1.1:53",
+			expected: []string{"1.1.1.1:53"},
+		},
+		// Test with two IPs
+		{
+			input:    "1.1.1.1,8.8.8.8",
+			expected: []string{"1.1.1.1", "8.8.8.8"},
+		},
+		// Test with IP and domain
+		{
+			input:    "1.1.1.1,example.com",
+			expected: []string{"1.1.1.1"},
+		},
+		// Test with IP, IP+Port, and domain
+		{
+			input:    "1.1.1.1,example.com,8.8.8.8:53",
+			expected: []string{"1.1.1.1", "8.8.8.8:53"},
+		},
+		// Test with IPv6, domain, and IPv4
+		{
+			input:    "2001:4860:4860::8888,example.com,8.8.8.8",
+			expected: []string{"2001:4860:4860::8888", "8.8.8.8"},
+		},
+		// Test with IPv6+Port and domain
+		{
+			input:    "[2001:4860:4860::8888]:53,example.com",
+			expected: []string{"[2001:4860:4860::8888]:53"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			result := removeDomainsFromNameServersString(test.input)
+			require.Equal(t, result, test.expected)
+		})
+	}
+}

--- a/src/internal/util/util.go
+++ b/src/internal/util/util.go
@@ -16,7 +16,6 @@ package util
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"regexp"
 	"strconv"
@@ -70,30 +69,6 @@ func SplitHostPort(inaddr string) (net.IP, int, error) {
 	return ip, portInt, nil
 }
 
-// SplitIPv4AndIPv6Addrs splits a list of IP addresses (either with port attached or not) into IPv4 and IPv6 addresses.
-// Returns a slice of IPv4/IPv6 addresses that are guaranteed to be valid. If the port was attached, it'll be included.
-func SplitIPv4AndIPv6Addrs(addrs []string) (ipv4 []string, ipv6 []string, err error) {
-	for _, addr := range addrs {
-		ip, _, err := SplitHostPort(addr)
-		if err != nil {
-			// addr may be an IP without a port
-			ip = net.ParseIP(addr)
-		}
-		if ip == nil {
-			return nil, nil, fmt.Errorf("invalid IP address: %s", addr)
-		}
-		// ip is valid, check if it's IPv4 or IPv6
-		if ip.To4() != nil {
-			ipv4 = append(ipv4, addr)
-		} else if ip.To16() != nil {
-			ipv6 = append(ipv6, addr)
-		} else {
-			return nil, nil, fmt.Errorf("invalid IP address: %s", addr)
-		}
-	}
-	return ipv4, ipv6, nil
-}
-
 // IsStringValidDomainName checks if the given string is a valid domain name using regex
 func IsStringValidDomainName(domain string) bool {
 	var domainRegex = regexp.MustCompile(`^(?i)[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*\.[a-z]{2,}$`)
@@ -120,18 +95,6 @@ func Contains[T comparable](slice []T, entity T) bool {
 		}
 	}
 	return false
-}
-
-func RemoveDuplicates[T comparable](slice []T) []T {
-	lookup := make(map[T]struct{}, len(slice)) // prealloc for performance
-	result := make([]T, 0, len(slice))
-	for _, v := range slice {
-		if _, ok := lookup[v]; !ok {
-			lookup[v] = struct{}{}
-			result = append(result, v)
-		}
-	}
-	return result
 }
 
 // Concat returns a new slice concatenating the passed in slices.

--- a/src/internal/util/util_test.go
+++ b/src/internal/util/util_test.go
@@ -108,42 +108,6 @@ func TestContains(t *testing.T) {
 	}
 }
 
-func TestRemoveDuplicates(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []int
-		expected []int
-	}{
-		{
-			name:     "No duplicates",
-			input:    []int{1, 2, 3, 4, 5},
-			expected: []int{1, 2, 3, 4, 5},
-		},
-		{
-			name:     "All duplicates",
-			input:    []int{1, 1, 1, 1, 1},
-			expected: []int{1},
-		},
-		{
-			name:     "Some duplicates",
-			input:    []int{1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5},
-			expected: []int{1, 2, 3, 4, 5},
-		},
-		{
-			name:     "Empty slice",
-			input:    []int{},
-			expected: []int{},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			result := RemoveDuplicates(test.input)
-			require.Equal(t, test.expected, result)
-		})
-	}
-}
-
 func TestConcat(t *testing.T) {
 	inputSlice1 := make([]int, 0, 10)
 	for i := 0; i < 3; i++ {

--- a/src/modules/alookup/a_lookup.go
+++ b/src/modules/alookup/a_lookup.go
@@ -48,7 +48,7 @@ func (aMod *ALookupModule) Init(ipv4Lookup bool, ipv6Lookup bool) {
 	aMod.IPv6Lookup = ipv6Lookup
 }
 
-func (aMod *ALookupModule) Lookup(r *zdns.Resolver, lookupName, nameServer string) (interface{}, zdns.Trace, zdns.Status, error) {
+func (aMod *ALookupModule) Lookup(r *zdns.Resolver, lookupName string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
 	ipResult, trace, status, err := r.DoTargetedLookup(lookupName, nameServer, aMod.baseModule.IsIterative, aMod.IPv4Lookup, aMod.IPv6Lookup)
 	return ipResult, trace, status, err
 }

--- a/src/modules/bindversion/bindversion.go
+++ b/src/modules/bindversion/bindversion.go
@@ -45,7 +45,7 @@ func (bindVersionMod *BindVersionLookupModule) CLIInit(gc *cli.CLIConf, rc *zdns
 	return bindVersionMod.BasicLookupModule.CLIInit(gc, rc)
 }
 
-func (bindVersionMod *BindVersionLookupModule) Lookup(r *zdns.Resolver, lookupName, nameServer string) (interface{}, zdns.Trace, zdns.Status, error) {
+func (bindVersionMod *BindVersionLookupModule) Lookup(r *zdns.Resolver, lookupName string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
 	var innerRes *zdns.SingleQueryResult
 	var trace zdns.Trace
 	var status zdns.Status

--- a/src/modules/bindversion/bindversion_test.go
+++ b/src/modules/bindversion/bindversion_test.go
@@ -47,8 +47,8 @@ func (ml MockLookup) DoSingleDstServerLookup(r *zdns.Resolver, question zdns.Que
 func InitTest(t *testing.T) *zdns.Resolver {
 	mockResults = make(map[string]*zdns.SingleQueryResult)
 	rc := zdns.ResolverConfig{
-		ExternalNameServersV4: []zdns.NameServer{{IP: net.ParseIP("1.1.1.1:53"), Port: 53}},
-		RootNameServersV4:     []zdns.NameServer{{IP: net.ParseIP("1.1.1.1:53"), Port: 53}},
+		ExternalNameServersV4: []zdns.NameServer{{IP: net.ParseIP("1.1.1.1"), Port: 53}},
+		RootNameServersV4:     []zdns.NameServer{{IP: net.ParseIP("1.1.1.1"), Port: 53}},
 		LocalAddrsV4:          []net.IP{net.ParseIP("192.168.1.1")},
 		IPVersionMode:         zdns.IPv4Only,
 		LookupClient:          MockLookup{}}
@@ -69,7 +69,7 @@ func TestBindVersionLookup_Valid_1(t *testing.T) {
 	assert.Equal(t, queries[0].q.Class, uint16(dns.ClassCHAOS))
 	assert.Equal(t, queries[0].q.Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].q.Name, "VERSION.BIND")
-	assert.Equal(t, queries[0].NameServer, "1.2.3.4:53")
+	assert.Equal(t, queries[0].NameServer.String(), "1.2.3.4:53")
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).BindVersion, "Nominum Vantio 5.4.1.0")
@@ -85,7 +85,7 @@ func TestBindVersionLookup_NotValid_1(t *testing.T) {
 	assert.Equal(t, queries[0].q.Class, uint16(dns.ClassCHAOS))
 	assert.Equal(t, queries[0].q.Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].q.Name, "VERSION.BIND")
-	assert.Equal(t, queries[0].NameServer, "1.2.3.4:53")
+	assert.Equal(t, queries[0].NameServer.String(), "1.2.3.4:53")
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).BindVersion, "")

--- a/src/modules/dmarc/dmarc.go
+++ b/src/modules/dmarc/dmarc.go
@@ -48,7 +48,7 @@ func (dmarcMod *DmarcLookupModule) CLIInit(gc *cli.CLIConf, rc *zdns.ResolverCon
 	return dmarcMod.BasicLookupModule.CLIInit(gc, rc)
 }
 
-func (dmarcMod *DmarcLookupModule) Lookup(r *zdns.Resolver, lookupName, nameServer string) (interface{}, zdns.Trace, zdns.Status, error) {
+func (dmarcMod *DmarcLookupModule) Lookup(r *zdns.Resolver, lookupName string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
 	innerRes, trace, status, err := dmarcMod.BasicLookupModule.Lookup(r, lookupName, nameServer)
 	castedInnerRes, ok := innerRes.(*zdns.SingleQueryResult)
 	if !ok {

--- a/src/modules/dmarc/dmarc_test.go
+++ b/src/modules/dmarc/dmarc_test.go
@@ -27,7 +27,7 @@ import (
 
 type QueryRecord struct {
 	zdns.Question
-	NameServer string
+	NameServer *zdns.NameServer
 }
 
 var mockResults = make(map[string]*zdns.SingleQueryResult)
@@ -35,7 +35,7 @@ var queries []QueryRecord
 
 type MockLookup struct{}
 
-func (ml MockLookup) DoSingleDstServerLookup(r *zdns.Resolver, question zdns.Question, nameServer string, isIterative bool) (*zdns.SingleQueryResult, zdns.Trace, zdns.Status, error) {
+func (ml MockLookup) DoSingleDstServerLookup(r *zdns.Resolver, question zdns.Question, nameServer *zdns.NameServer, isIterative bool) (*zdns.SingleQueryResult, zdns.Trace, zdns.Status, error) {
 	queries = append(queries, QueryRecord{question, nameServer})
 	if res, ok := mockResults[question.Name]; ok {
 		return res, nil, zdns.StatusNoError, nil
@@ -47,8 +47,8 @@ func (ml MockLookup) DoSingleDstServerLookup(r *zdns.Resolver, question zdns.Que
 func InitTest(t *testing.T) *zdns.Resolver {
 	mockResults = make(map[string]*zdns.SingleQueryResult)
 	rc := zdns.ResolverConfig{
-		ExternalNameServersV4: []string{"127.0.0.1:53"},
-		RootNameServersV4:     []string{"127.0.0.53:53"},
+		RootNameServersV4:     []zdns.NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}},
+		ExternalNameServersV4: []zdns.NameServer{{IP: net.ParseIP("127.0.0.1"), Port: 53}},
 		LocalAddrsV4:          []net.IP{net.ParseIP("127.0.0.1")},
 		IPVersionMode:         zdns.IPv4Only,
 		LookupClient:          MockLookup{}}
@@ -68,7 +68,7 @@ func TestDmarcLookup_Valid_1(t *testing.T) {
 	dmarcMod := DmarcLookupModule{}
 	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
-	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
+	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", nil)
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
@@ -89,7 +89,7 @@ func TestDmarcLookup_Valid_2(t *testing.T) {
 	dmarcMod := DmarcLookupModule{}
 	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
-	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
+	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", nil)
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
@@ -110,7 +110,7 @@ func TestDmarcLookup_Valid_3(t *testing.T) {
 	dmarcMod := DmarcLookupModule{}
 	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
-	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
+	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", nil)
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
@@ -131,7 +131,7 @@ func TestDmarcLookup_NotValid_1(t *testing.T) {
 	dmarcMod := DmarcLookupModule{}
 	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
-	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
+	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", nil)
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
@@ -152,7 +152,7 @@ func TestDmarcLookup_NotValid_2(t *testing.T) {
 	dmarcMod := DmarcLookupModule{}
 	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
-	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
+	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", nil)
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
@@ -173,7 +173,7 @@ func TestDmarcLookup_NotValid_3(t *testing.T) {
 	dmarcMod := DmarcLookupModule{}
 	err := dmarcMod.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{})
 	assert.NilError(t, err)
-	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", "")
+	res, _, status, _ := dmarcMod.Lookup(resolver, "_dmarc.zdns-testing.com", nil)
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")

--- a/src/modules/dmarc/dmarc_test.go
+++ b/src/modules/dmarc/dmarc_test.go
@@ -72,7 +72,7 @@ func TestDmarcLookup_Valid_1(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
+	assert.Equal(t, queries[0].NameServer.String(), "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Dmarc, "v=DMARC1; p=none; rua=mailto:postmaster@censys.io")
@@ -93,7 +93,7 @@ func TestDmarcLookup_Valid_2(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
+	assert.Equal(t, queries[0].NameServer.String(), "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Dmarc, "V=DMARC1; p=none; rua=mailto:postmaster@censys.io")
@@ -114,7 +114,7 @@ func TestDmarcLookup_Valid_3(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
+	assert.Equal(t, queries[0].NameServer.String(), "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Dmarc, "v\t\t\t=\t\t  DMARC1\t\t; p=none; rua=mailto:postmaster@censys.io")
@@ -135,7 +135,7 @@ func TestDmarcLookup_NotValid_1(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
+	assert.Equal(t, queries[0].NameServer.String(), "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Dmarc, "")
@@ -156,7 +156,7 @@ func TestDmarcLookup_NotValid_2(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
+	assert.Equal(t, queries[0].NameServer.String(), "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Dmarc, "")
@@ -177,7 +177,7 @@ func TestDmarcLookup_NotValid_3(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "_dmarc.zdns-testing.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
+	assert.Equal(t, queries[0].NameServer.String(), "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Dmarc, "")

--- a/src/modules/mxlookup/mx_lookup.go
+++ b/src/modules/mxlookup/mx_lookup.go
@@ -84,7 +84,7 @@ func (mxMod *MXLookupModule) Init() {
 	mxMod.CacheHash.Init(mxMod.MXCacheSize)
 }
 
-func (mxMod *MXLookupModule) lookupIPs(r *zdns.Resolver, name, nameServer string, ipMode zdns.IPVersionMode) (CachedAddresses, zdns.Trace) {
+func (mxMod *MXLookupModule) lookupIPs(r *zdns.Resolver, name string, nameServer *zdns.NameServer, ipMode zdns.IPVersionMode) (CachedAddresses, zdns.Trace) {
 	mxMod.CHmu.Lock()
 	// TODO - Phillip this comment V is present in the original code and has been there since 2017 IIRC, so ask Zakir what to do
 	// XXX this should be changed to a miekglookup
@@ -105,7 +105,7 @@ func (mxMod *MXLookupModule) lookupIPs(r *zdns.Resolver, name, nameServer string
 	return retv, trace
 }
 
-func (mxMod *MXLookupModule) Lookup(r *zdns.Resolver, lookupName, nameServer string) (interface{}, zdns.Trace, zdns.Status, error) {
+func (mxMod *MXLookupModule) Lookup(r *zdns.Resolver, lookupName string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
 	ipMode := zdns.GetIPVersionMode(mxMod.IPv4Lookup, mxMod.IPv6Lookup)
 	retv := MXResult{Servers: []MXRecord{}}
 	var res *zdns.SingleQueryResult

--- a/src/modules/nslookup/ns_lookup.go
+++ b/src/modules/nslookup/ns_lookup.go
@@ -32,7 +32,7 @@ type NSLookupModule struct {
 	IPv4Lookup bool `long:"ipv4-lookup" description:"perform A lookups for each NS server"`
 	IPv6Lookup bool `long:"ipv6-lookup" description:"perform AAAA record lookups for each NS server"`
 	// used for mocking
-	testingLookup func(r *zdns.Resolver, lookupName string, nameServer string) (interface{}, zdns.Trace, zdns.Status, error)
+	testingLookup func(r *zdns.Resolver, lookupName string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error)
 }
 
 // CLIInit initializes the NSLookupModule with the given parameters, used to call NSLookup from the command line
@@ -55,12 +55,12 @@ func (nsMod *NSLookupModule) Init(ipv4Lookup, ipv6Lookup bool) {
 	nsMod.IPv6Lookup = ipv6Lookup
 }
 
-func (nsMod *NSLookupModule) Lookup(r *zdns.Resolver, lookupName string, nameServer string) (interface{}, zdns.Trace, zdns.Status, error) {
+func (nsMod *NSLookupModule) Lookup(r *zdns.Resolver, lookupName string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
 	if nsMod.testingLookup != nil {
 		// used for mocking
 		return nsMod.testingLookup(r, lookupName, nameServer)
 	}
-	if nsMod.IsIterative && nameServer != "" {
+	if nsMod.IsIterative && nameServer != nil {
 		log.Warn("iterative lookup requested with lookupName server, ignoring lookupName server")
 	}
 
@@ -80,7 +80,7 @@ func (nsMod *NSLookupModule) Validate(args []string) error {
 	return nil
 }
 
-func (nsMod *NSLookupModule) WithTestingLookup(f func(r *zdns.Resolver, lookupName string, nameServer string) (interface{}, zdns.Trace, zdns.Status, error)) {
+func (nsMod *NSLookupModule) WithTestingLookup(f func(r *zdns.Resolver, lookupName string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error)) {
 	nsMod.testingLookup = f
 }
 

--- a/src/modules/spf/spf.go
+++ b/src/modules/spf/spf.go
@@ -48,7 +48,7 @@ func (spfMod *SpfLookupModule) CLIInit(gc *cli.CLIConf, rc *zdns.ResolverConfig)
 	return spfMod.BasicLookupModule.CLIInit(gc, rc)
 }
 
-func (spfMod *SpfLookupModule) Lookup(r *zdns.Resolver, name, resolver string) (interface{}, zdns.Trace, zdns.Status, error) {
+func (spfMod *SpfLookupModule) Lookup(r *zdns.Resolver, name string, resolver *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
 	innerRes, trace, status, err := spfMod.BasicLookupModule.Lookup(r, name, resolver)
 	castedInnerRes, ok := innerRes.(*zdns.SingleQueryResult)
 	if !ok {

--- a/src/modules/spf/spf_test.go
+++ b/src/modules/spf/spf_test.go
@@ -27,7 +27,7 @@ import (
 
 type QueryRecord struct {
 	zdns.Question
-	NameServer string
+	NameServer *zdns.NameServer
 }
 
 var mockResults = make(map[string]*zdns.SingleQueryResult)
@@ -35,7 +35,7 @@ var queries []QueryRecord
 
 type MockLookup struct{}
 
-func (ml MockLookup) DoSingleDstServerLookup(r *zdns.Resolver, question zdns.Question, nameServer string, isIterative bool) (*zdns.SingleQueryResult, zdns.Trace, zdns.Status, error) {
+func (ml MockLookup) DoSingleDstServerLookup(r *zdns.Resolver, question zdns.Question, nameServer *zdns.NameServer, isIterative bool) (*zdns.SingleQueryResult, zdns.Trace, zdns.Status, error) {
 	queries = append(queries, QueryRecord{question, nameServer})
 	if res, ok := mockResults[question.Name]; ok {
 		return res, nil, zdns.StatusNoError, nil
@@ -48,8 +48,8 @@ func InitTest(t *testing.T) *zdns.Resolver {
 	mockResults = make(map[string]*zdns.SingleQueryResult)
 	queries = make([]QueryRecord, 0)
 	rc := zdns.ResolverConfig{
-		ExternalNameServersV4: []string{"127.0.0.1:53"},
-		RootNameServersV4:     []string{"127.0.0.53:53"},
+		RootNameServersV4:     []zdns.NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}},
+		ExternalNameServersV4: []zdns.NameServer{{IP: net.ParseIP("127.0.0.1"), Port: 53}},
 		LocalAddrsV4:          []net.IP{net.ParseIP("127.0.0.1")},
 		IPVersionMode:         zdns.IPv4Only,
 		LookupClient:          MockLookup{}}
@@ -69,7 +69,7 @@ func TestLookup_DoTxtLookup_Valid_1(t *testing.T) {
 	spfModule := SpfLookupModule{}
 	err := spfModule.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{LookupClient: MockLookup{}})
 	assert.NilError(t, err)
-	res, _, status, _ := spfModule.Lookup(resolver, "google.com", "")
+	res, _, status, _ := spfModule.Lookup(resolver, "google.com", nil)
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
@@ -89,7 +89,7 @@ func TestLookup_DoTxtLookup_Valid_2(t *testing.T) {
 	spfModule := SpfLookupModule{}
 	err := spfModule.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{LookupClient: MockLookup{}})
 	assert.NilError(t, err)
-	res, _, status, _ := spfModule.Lookup(resolver, "google.com", "")
+	res, _, status, _ := spfModule.Lookup(resolver, "google.com", nil)
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
@@ -109,7 +109,7 @@ func TestLookup_DoTxtLookup_NotValid_1(t *testing.T) {
 	spfModule := SpfLookupModule{}
 	err := spfModule.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{LookupClient: MockLookup{}})
 	assert.NilError(t, err)
-	res, _, status, _ := spfModule.Lookup(resolver, "google.com", "")
+	res, _, status, _ := spfModule.Lookup(resolver, "google.com", nil)
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
@@ -129,7 +129,7 @@ func TestLookup_DoTxtLookup_NotValid_2(t *testing.T) {
 	spfModule := SpfLookupModule{}
 	err := spfModule.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{LookupClient: MockLookup{}})
 	assert.NilError(t, err)
-	res, _, status, _ := spfModule.Lookup(resolver, "google.com", "")
+	res, _, status, _ := spfModule.Lookup(resolver, "google.com", nil)
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
@@ -144,7 +144,7 @@ func TestLookup_DoTxtLookup_NoTXT(t *testing.T) {
 	spfModule := SpfLookupModule{}
 	err := spfModule.CLIInit(&cli.CLIConf{}, &zdns.ResolverConfig{LookupClient: MockLookup{}})
 	assert.NilError(t, err)
-	res, _, status, _ := spfModule.Lookup(resolver, "example.com", "")
+	res, _, status, _ := spfModule.Lookup(resolver, "example.com", nil)
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "example.com")

--- a/src/modules/spf/spf_test.go
+++ b/src/modules/spf/spf_test.go
@@ -73,7 +73,7 @@ func TestLookup_DoTxtLookup_Valid_1(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
+	assert.Equal(t, queries[0].NameServer.String(), "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Spf, "v=spf1 mx include:_spf.google.com -all")
@@ -93,7 +93,7 @@ func TestLookup_DoTxtLookup_Valid_2(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
+	assert.Equal(t, queries[0].NameServer.String(), "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoError, status)
 	assert.Equal(t, res.(Result).Spf, "V=SpF1 mx include:_spf.google.com -all")
@@ -113,7 +113,7 @@ func TestLookup_DoTxtLookup_NotValid_1(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
+	assert.Equal(t, queries[0].NameServer.String(), "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Spf, "")
@@ -133,7 +133,7 @@ func TestLookup_DoTxtLookup_NotValid_2(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "google.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
+	assert.Equal(t, queries[0].NameServer.String(), "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoRecord, status)
 	assert.Equal(t, res.(Result).Spf, "")
@@ -148,7 +148,7 @@ func TestLookup_DoTxtLookup_NoTXT(t *testing.T) {
 	assert.Equal(t, queries[0].Class, uint16(dns.ClassINET))
 	assert.Equal(t, queries[0].Type, dns.TypeTXT)
 	assert.Equal(t, queries[0].Name, "example.com")
-	assert.Equal(t, queries[0].NameServer, "127.0.0.1:53")
+	assert.Equal(t, queries[0].NameServer.String(), "127.0.0.1:53")
 
 	assert.Equal(t, zdns.StatusNoAnswer, status)
 	assert.Equal(t, res.(Result).Spf, "")

--- a/src/zdns/alookup.go
+++ b/src/zdns/alookup.go
@@ -25,7 +25,7 @@ import (
 
 // DoTargetedLookup performs a lookup of the given domain name against the given nameserver, looking up both IPv4 and IPv6 addresses
 // Will follow CNAME records as well as A/AAAA records to get IP addresses
-func (r *Resolver) DoTargetedLookup(name, nameServer string, isIterative, lookupA, lookupAAAA bool) (*IPResult, Trace, Status, error) {
+func (r *Resolver) DoTargetedLookup(name string, nameServer *NameServer, isIterative, lookupA, lookupAAAA bool) (*IPResult, Trace, Status, error) {
 	name = strings.ToLower(name)
 	res := IPResult{}
 	singleQueryRes := &SingleQueryResult{}

--- a/src/zdns/conf.go
+++ b/src/zdns/conf.go
@@ -14,6 +14,8 @@
 
 package zdns
 
+import "net"
+
 //type Metadata struct {
 //	Names       int            `json:"names"`
 //	Status      map[string]int `json:"statuses"`
@@ -54,47 +56,48 @@ const (
 	StatusNoNeededGlue Status = "NONEEDEDGLUE" // When a nameserver is authoritative for itself and the parent nameserver doesn't provide the glue to look it up
 )
 
-var RootServersV4 = []string{
-	"198.41.0.4:53",     // A
-	"170.247.170.2:53",  // B - Changed several times, this is current as of July '24
-	"192.33.4.12:53",    // C
-	"199.7.91.13:53",    // D
-	"192.203.230.10:53", // E
-	"192.5.5.241:53",    // F
-	"192.112.36.4:53",   // G
-	"198.97.190.53:53",  // H
-	"192.36.148.17:53",  // I
-	"192.58.128.30:53",  // J
-	"193.0.14.129:53",   // K
-	"199.7.83.42:53",    // L
-	"202.12.27.33:53"}   // M
-
-var RootServersV6 = []string{
-	"[2001:503:ba3e::2:30]:53", // A
-	"[2801:1b8:10::b]:53",      // B
-	"[2001:500:2::c]:53",       // C
-	"[2001:500:2d::d]:53",      // D
-	"[2001:500:a8::e]:53",      // E
-	"[2001:500:2f::f]:53",      // F
-	"[2001:500:12::d0d]:53",    // G
-	"[2001:500:1::53]:53",      // H
-	"[2001:7fe::53]:53",        // I
-	"[2001:503:c27::2:30]:53",  // J
-	"[2001:7fd::1]:53",         // K
-	"[2001:500:9f::42]:53",     // L
-	"[2001:dc3::35]:53",        // M
+var RootServersV4 = []NameServer{
+	{IP: net.ParseIP("198.41.0.4"), Port: 53},     // A
+	{IP: net.ParseIP("170.247.170.2"), Port: 53},  // B - Changed several times, this is current as of July '24
+	{IP: net.ParseIP("192.33.4.12"), Port: 53},    // C
+	{IP: net.ParseIP("199.7.91.13"), Port: 53},    // D
+	{IP: net.ParseIP("192.203.230.10"), Port: 53}, // E
+	{IP: net.ParseIP("192.5.5.241"), Port: 53},    // F
+	{IP: net.ParseIP("192.112.36.4"), Port: 53},   // G
+	{IP: net.ParseIP("198.97.190.53"), Port: 53},  // H
+	{IP: net.ParseIP("192.36.148.17"), Port: 53},  // I
+	{IP: net.ParseIP("192.58.128.30"), Port: 53},  // J
+	{IP: net.ParseIP("193.0.14.129"), Port: 53},   // K
+	{IP: net.ParseIP("199.7.83.42"), Port: 53},    // L
+	{IP: net.ParseIP("202.12.27.33"), Port: 53},   // M
 }
 
-var DefaultExternalResolversV4 = []string{
-	"8.8.8.8:53",
-	"8.8.4.4:53",
-	"1.1.1.1:53",
-	"1.0.0.1:53",
+var RootServersV6 = []NameServer{
+	{IP: net.ParseIP("2001:503:ba3e::2:30"), Port: 53}, // A
+	{IP: net.ParseIP("2801:1b8:10::b"), Port: 53},      // B
+	{IP: net.ParseIP("2001:500:2::c"), Port: 53},       // C
+	{IP: net.ParseIP("2001:500:2d::d"), Port: 53},      // D
+	{IP: net.ParseIP("2001:500:a8::e"), Port: 53},      // E
+	{IP: net.ParseIP("2001:500:2f::f"), Port: 53},      // F
+	{IP: net.ParseIP("2001:500:12::d0d"), Port: 53},    // G
+	{IP: net.ParseIP("2001:500:1::53"), Port: 53},      // H
+	{IP: net.ParseIP("2001:7fe::53"), Port: 53},        // I
+	{IP: net.ParseIP("2001:503:c27::2:30"), Port: 53},  // J
+	{IP: net.ParseIP("2001:7fd::1"), Port: 53},         // K
+	{IP: net.ParseIP("2001:500:9f::42"), Port: 53},     // L
+	{IP: net.ParseIP("2001:dc3::35"), Port: 53},        // M
 }
 
-var DefaultExternalResolversV6 = []string{
-	"[2001:4860:4860::8888]:53",
-	"[2001:4860:4860::8844]:53",
-	"[2606:4700:4700::1111]:53",
-	"[2606:4700:4700::1001]:53",
+var DefaultExternalResolversV4 = []NameServer{
+	{IP: net.ParseIP("8.8.8.8"), Port: 53}, // Google
+	{IP: net.ParseIP("8.8.4.4"), Port: 53}, // Google
+	{IP: net.ParseIP("1.1.1.1"), Port: 53}, // Cloudflare
+	{IP: net.ParseIP("1.0.0.1"), Port: 53}, // Cloudflare
+}
+
+var DefaultExternalResolversV6 = []NameServer{
+	{IP: net.ParseIP("2001:4860:4860::8888"), Port: 53}, // Google
+	{IP: net.ParseIP("2001:4860:4860::8844"), Port: 53}, // Google
+	{IP: net.ParseIP("2606:4700:4700::1111"), Port: 53}, // Cloudflare
+	{IP: net.ParseIP("2606:4700:4700::1001"), Port: 53}, // Cloudflare
 }

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -61,30 +61,25 @@ func GetDNSServers(path string) (ipv4, ipv6 []string, err error) {
 
 // Lookup client interface for help in mocking
 type Lookuper interface {
-	DoSingleDstServerLookup(r *Resolver, q Question, nameServer string, isIterative bool) (*SingleQueryResult, Trace, Status, error)
+	DoSingleDstServerLookup(r *Resolver, q Question, nameServer *NameServer, isIterative bool) (*SingleQueryResult, Trace, Status, error)
 }
 
 type LookupClient struct{}
 
-func (lc LookupClient) DoSingleDstServerLookup(r *Resolver, q Question, nameServer string, isIterative bool) (*SingleQueryResult, Trace, Status, error) {
+func (lc LookupClient) DoSingleDstServerLookup(r *Resolver, q Question, nameServer *NameServer, isIterative bool) (*SingleQueryResult, Trace, Status, error) {
 	return r.doSingleDstServerLookup(q, nameServer, isIterative)
 }
 
-func (r *Resolver) doSingleDstServerLookup(q Question, nameServer string, isIterative bool) (*SingleQueryResult, Trace, Status, error) {
+func (r *Resolver) doSingleDstServerLookup(q Question, nameServer *NameServer, isIterative bool) (*SingleQueryResult, Trace, Status, error) {
 	var err error
-	// Check that nameserver isn't blacklisted
-	nameServerIPString, _, err := net.SplitHostPort(nameServer)
-	if err != nil {
-		return nil, nil, StatusIllegalInput, fmt.Errorf("could not split nameserver %s: %w", nameServer, err)
-	}
 	// nameserver is required
-	if nameServer == "" {
+	if nameServer == nil {
 		return nil, nil, StatusIllegalInput, errors.New("no nameserver specified")
 	}
 
 	// Stop if we hit a nameserver we don't want to hit
 	if r.blacklist != nil {
-		if blacklisted, blacklistedErr := r.blacklist.IsBlacklisted(nameServerIPString); blacklistedErr != nil {
+		if blacklisted, blacklistedErr := r.blacklist.IsBlacklisted(nameServer.IP.String()); blacklistedErr != nil {
 			var r SingleQueryResult
 			return &r, Trace{}, StatusError, fmt.Errorf("could not check blacklist for nameserver %s: %w", nameServer, err)
 		} else if blacklisted {
@@ -119,7 +114,7 @@ func (r *Resolver) doSingleDstServerLookup(q Question, nameServer string, isIter
 }
 
 // lookup performs a DNS lookup for a given question and nameserver taking care of iterative and external lookups
-func (r *Resolver) lookup(ctx context.Context, q Question, nameServer string, isIterative bool) (SingleQueryResult, Trace, Status, error) {
+func (r *Resolver) lookup(ctx context.Context, q Question, nameServer *NameServer, isIterative bool) (SingleQueryResult, Trace, Status, error) {
 	var res SingleQueryResult
 	var trace Trace
 	var status Status
@@ -142,7 +137,7 @@ func (r *Resolver) lookup(ctx context.Context, q Question, nameServer string, is
 		t.DNSType = q.Type
 		t.DNSClass = q.Class
 		t.Name = q.Name
-		t.NameServer = nameServer
+		t.NameServer = nameServer.String()
 		t.Layer = q.Name
 		t.Depth = 1
 		t.Cached = false
@@ -155,7 +150,7 @@ func (r *Resolver) lookup(ctx context.Context, q Question, nameServer string, is
 // followingLoopup follows CNAMEs and DNAMEs in a DNS lookup for either an iterative or external lookup
 // If an error occurs during the lookup, the last good result/status is returned along with the error and a full trace
 // If an error occurs on the first lookup, the bad result/status is returned along with the error and a full trace
-func (r *Resolver) followingLookup(ctx context.Context, q Question, nameServer string, isIterative bool) (*SingleQueryResult, Trace, Status, error) {
+func (r *Resolver) followingLookup(ctx context.Context, q Question, nameServer *NameServer, isIterative bool) (*SingleQueryResult, Trace, Status, error) {
 	var res SingleQueryResult
 	var trace Trace
 	var status Status
@@ -277,7 +272,7 @@ func isLookupComplete(originalName string, candidateSet map[string][]Answer, cNa
 // TODO - This is incomplete. We only lookup all nameservers for the initial name server lookup, then just send the DNS query to this set.
 // If we want to iteratively lookup all nameservers at each level of the query, we need to fix this.
 // Issue - https://github.com/zmap/zdns/issues/362
-func (r *Resolver) LookupAllNameservers(q *Question, nameServer string) (*CombinedResults, Trace, Status, error) {
+func (r *Resolver) LookupAllNameservers(q *Question, nameServer *NameServer) (*CombinedResults, Trace, Status, error) {
 	var retv CombinedResults
 	var curServer string
 
@@ -302,8 +297,11 @@ func (r *Resolver) LookupAllNameservers(q *Question, nameServer string) (*Combin
 		nameserver := nserver.Name
 		ips := util.Concat(nserver.IPv4Addresses, nserver.IPv6Addresses)
 		for _, ip := range ips {
-			curServer = net.JoinHostPort(ip, "53")
-			res, trace, status, err := r.ExternalLookup(q, curServer)
+			// construct the nameserver
+			res, trace, status, err := r.ExternalLookup(q, &NameServer{
+				IP:   net.ParseIP(ip),
+				Port: DefaultPort,
+			})
 			if err != nil {
 				// log and move on
 				log.Errorf("lookup for domain %s to nameserver %s failed with error %s. Continueing to next nameserver", q.Name, curServer, err)
@@ -322,10 +320,13 @@ func (r *Resolver) LookupAllNameservers(q *Question, nameServer string) (*Combin
 	return &retv, fullTrace, StatusNoError, nil
 }
 
-func (r *Resolver) iterativeLookup(ctx context.Context, q Question, nameServer string,
+func (r *Resolver) iterativeLookup(ctx context.Context, q Question, nameServer *NameServer,
 	depth int, layer string, trace Trace) (SingleQueryResult, Trace, Status, error) {
 	if log.GetLevel() == log.DebugLevel {
 		r.verboseLog(depth, "iterative lookup for ", q.Name, " (", q.Type, ") against ", nameServer, " layer ", layer)
+	}
+	if isValid, reason := nameServer.IsValid(); !isValid {
+		return SingleQueryResult{}, trace, StatusIllegalInput, fmt.Errorf("invalid nameserver (%s): %s", nameServer.String(), reason)
 	}
 	if depth > r.maxDepth {
 		var result SingleQueryResult
@@ -348,7 +349,7 @@ func (r *Resolver) iterativeLookup(ctx context.Context, q Question, nameServer s
 		t.DNSType = q.Type
 		t.DNSClass = q.Class
 		t.Name = q.Name
-		t.NameServer = nameServer
+		t.NameServer = nameServer.String()
 		t.Layer = layer
 		t.Depth = depth
 		t.Cached = isCached
@@ -389,7 +390,7 @@ func (r *Resolver) iterativeLookup(ctx context.Context, q Question, nameServer s
 	}
 }
 
-func (r *Resolver) cachedRetryingLookup(ctx context.Context, q Question, nameServer, layer string, depth int) (SingleQueryResult, IsCached, Status, int, error) {
+func (r *Resolver) cachedRetryingLookup(ctx context.Context, q Question, nameServer *NameServer, layer string, depth int) (SingleQueryResult, IsCached, Status, int, error) {
 	var isCached IsCached
 	isCached = false
 	r.verboseLog(depth+1, "Cached retrying lookup. Name: ", q, ", Layer: ", layer, ", Nameserver: ", nameServer)
@@ -401,16 +402,11 @@ func (r *Resolver) cachedRetryingLookup(ctx context.Context, q Question, nameSer
 		return cachedResult, isCached, StatusNoError, 0, nil
 	}
 
-	nameServerIP, _, err := net.SplitHostPort(nameServer)
-	if err != nil {
-		var r SingleQueryResult
-		return r, isCached, StatusError, 0, errors.Wrapf(err, "could not split nameserver %s to get IP", nameServer)
-	}
 	// Stop if we hit a nameserver we don't want to hit
 	if r.blacklist != nil {
-		if blacklisted, isBlacklistedErr := r.blacklist.IsBlacklisted(nameServerIP); isBlacklistedErr != nil {
+		if blacklisted, isBlacklistedErr := r.blacklist.IsBlacklisted(nameServer.IP.String()); isBlacklistedErr != nil {
 			var r SingleQueryResult
-			return r, isCached, StatusError, 0, errors.Wrapf(isBlacklistedErr, "could not check blacklist for nameserver IP: %s", nameServerIP)
+			return r, isCached, StatusError, 0, errors.Wrapf(isBlacklistedErr, "could not check blacklist for nameserver IP: %s", nameServer.IP.String())
 		} else if blacklisted {
 			var r SingleQueryResult
 			return r, isCached, StatusBlacklist, 0, nil
@@ -426,19 +422,15 @@ func (r *Resolver) cachedRetryingLookup(ctx context.Context, q Question, nameSer
 
 // retryingLookup wraps around wireLookup to perform a DNS lookup with retries
 // Returns the result, status, number of tries, and error
-func (r *Resolver) retryingLookup(ctx context.Context, q Question, nameServer string, recursive bool) (SingleQueryResult, Status, int, error) {
+func (r *Resolver) retryingLookup(ctx context.Context, q Question, nameServer *NameServer, recursive bool) (SingleQueryResult, Status, int, error) {
 	// nameserver is required
-	if nameServer == "" {
+	if nameServer == nil {
 		return SingleQueryResult{}, StatusIllegalInput, 0, errors.New("no nameserver specified")
 	}
-	nameServerIP, _, err := util.SplitHostPort(nameServer)
-	if err != nil {
-		return SingleQueryResult{}, StatusError, 0, errors.Wrapf(err, "could not split nameserver %s to get IP", nameServer)
-	}
 	var connInfo *ConnectionInfo
-	if nameServerIP.To4() != nil {
+	if nameServer.IP.To4() != nil {
 		connInfo = r.connInfoIPv4
-	} else if nameServerIP.To16() != nil {
+	} else if util.IsIPv6(&nameServer.IP) {
 		connInfo = r.connInfoIPv6
 	} else {
 		return SingleQueryResult{}, StatusError, 0, fmt.Errorf("could not determine IP version of nameserver: %s", nameServer)
@@ -448,7 +440,7 @@ func (r *Resolver) retryingLookup(ctx context.Context, q Question, nameServer st
 		return SingleQueryResult{}, StatusError, 0, fmt.Errorf("no connection info for nameserver: %s", nameServer)
 	}
 	// check loopback consistency
-	if nameServerIP.IsLoopback() != connInfo.localAddr.IsLoopback() {
+	if nameServer.IP.IsLoopback() != connInfo.localAddr.IsLoopback() {
 		return SingleQueryResult{}, StatusIllegalInput, 0, fmt.Errorf("nameserver %s must be reachable from the local address %s, ie. both must be loopback or not loopback", nameServer, connInfo.localAddr.String())
 	}
 	r.verboseLog(1, "****WIRE LOOKUP*** ", dns.TypeToString[q.Type], " ", q.Name, " ", nameServer)
@@ -457,7 +449,7 @@ func (r *Resolver) retryingLookup(ctx context.Context, q Question, nameServer st
 		if util.HasCtxExpired(&ctx) {
 			return SingleQueryResult{}, StatusTimeout, i + 1, nil
 		}
-		result, status, err := wireLookup(ctx, connInfo.udpClient, connInfo.tcpClient, connInfo.conn, q, nameServer, recursive, r.ednsOptions, r.dnsSecEnabled, r.checkingDisabledBit)
+		result, status, err := wireLookup(ctx, connInfo.udpClient, connInfo.tcpClient, connInfo.conn, q, nameServer, r.ednsOptions, recursive, r.dnsSecEnabled, r.checkingDisabledBit)
 		if status != StatusTimeout || i == r.retries {
 			return result, status, i + 1, err
 		}
@@ -468,9 +460,9 @@ func (r *Resolver) retryingLookup(ctx context.Context, q Question, nameServer st
 
 // wireLookup performs a DNS lookup on-the-wire with the given parameters
 // Attempts a UDP lookup first, then falls back to TCP if necessary (if the UDP response encounters an error or is truncated)
-func wireLookup(ctx context.Context, udp *dns.Client, tcp *dns.Client, conn *dns.Conn, q Question, nameServer string, recursive bool, ednsOptions []dns.EDNS0, dnssec bool, checkingDisabled bool) (SingleQueryResult, Status, error) {
+func wireLookup(ctx context.Context, udp *dns.Client, tcp *dns.Client, conn *dns.Conn, q Question, nameServer *NameServer, ednsOptions []dns.EDNS0, recursive, dnssec, checkingDisabled bool) (SingleQueryResult, Status, error) {
 	res := SingleQueryResult{Answers: []interface{}{}, Authorities: []interface{}{}, Additional: []interface{}{}}
-	res.Resolver = nameServer
+	res.Resolver = nameServer.String()
 
 	m := new(dns.Msg)
 	m.SetQuestion(dotName(q.Name), q.Type)
@@ -488,22 +480,22 @@ func wireLookup(ctx context.Context, udp *dns.Client, tcp *dns.Client, conn *dns
 	if udp != nil {
 		res.Protocol = "udp"
 		if conn != nil {
-			dst, _ := net.ResolveUDPAddr("udp", nameServer)
+			dst, _ := net.ResolveUDPAddr("udp", nameServer.String())
 			r, _, err = udp.ExchangeWithConnToContext(ctx, m, conn, dst)
 		} else {
-			r, _, err = udp.ExchangeContext(ctx, m, nameServer)
+			r, _, err = udp.ExchangeContext(ctx, m, nameServer.String())
 		}
 		// if record comes back truncated, but we have a TCP connection, try again with that
 		if r != nil && (r.Truncated || r.Rcode == dns.RcodeBadTrunc) {
 			if tcp != nil {
-				return wireLookup(ctx, nil, tcp, conn, q, nameServer, recursive, ednsOptions, dnssec, checkingDisabled)
+				return wireLookup(ctx, nil, tcp, conn, q, nameServer, ednsOptions, recursive, dnssec, checkingDisabled)
 			} else {
 				return res, StatusTruncated, err
 			}
 		}
 	} else {
 		res.Protocol = "tcp"
-		r, _, err = tcp.ExchangeContext(ctx, m, nameServer)
+		r, _, err = tcp.ExchangeContext(ctx, m, nameServer.String())
 	}
 	if err != nil || r == nil {
 		if nerr, ok := err.(net.Error); ok {
@@ -563,7 +555,7 @@ func (r *Resolver) iterateOnAuthorities(ctx context.Context, q Question, depth i
 	for i, elem := range result.Authorities {
 		r.verboseLog(depth+1, "Trying Authority: ", elem)
 		ns, nsStatus, newLayer, newTrace := r.extractAuthority(ctx, elem, layer, depth, &result, trace)
-		r.verboseLog((depth + 1), "Output from extract authorities: ", ns)
+		r.verboseLog((depth + 1), "Output from extract authorities: ", ns.String())
 		if nsStatus == StatusIterTimeout {
 			r.verboseLog((depth + 2), "--> Hit iterative timeout: ")
 			var r SingleQueryResult
@@ -613,17 +605,17 @@ func (r *Resolver) iterateOnAuthorities(ctx context.Context, q Question, depth i
 	panic("should not be able to reach here")
 }
 
-func (r *Resolver) extractAuthority(ctx context.Context, authority interface{}, layer string, depth int, result *SingleQueryResult, trace Trace) (string, Status, string, Trace) {
+func (r *Resolver) extractAuthority(ctx context.Context, authority interface{}, layer string, depth int, result *SingleQueryResult, trace Trace) (*NameServer, Status, string, Trace) {
 	// Is it an answer
 	ans, ok := authority.(Answer)
 	if !ok {
-		return "", StatusFormErr, layer, trace
+		return nil, StatusFormErr, layer, trace
 	}
 
 	// Is the layering correct
 	ok, layer = nameIsBeneath(ans.Name, layer)
 	if !ok {
-		return "", StatusAuthFail, layer, trace
+		return nil, StatusAuthFail, layer, trace
 	}
 
 	server := strings.TrimSuffix(ans.Answer, ".")
@@ -636,7 +628,7 @@ func (r *Resolver) extractAuthority(ctx context.Context, authority interface{}, 
 		if ok, _ = nameIsBeneath(server, layer); ok {
 			// The domain we're searching for is beneath us but no glue was returned. We cannot proceed without this Glue.
 			// Terminating
-			return "", StatusNoNeededGlue, "", trace
+			return nil, StatusNoNeededGlue, "", trace
 		}
 		// Fall through to normal query
 		var q Question
@@ -650,7 +642,7 @@ func (r *Resolver) extractAuthority(ctx context.Context, authority interface{}, 
 		res, trace, status, _ = r.iterativeLookup(ctx, q, r.randomRootNameServer(), depth+1, ".", trace)
 	}
 	if status == StatusIterTimeout || status == StatusNoNeededGlue {
-		return "", status, "", trace
+		return nil, status, "", trace
 	}
 	if status == StatusNoError {
 		// XXX we don't actually check the question here
@@ -659,16 +651,18 @@ func (r *Resolver) extractAuthority(ctx context.Context, authority interface{}, 
 			if !ok {
 				continue
 			}
-			if r.ipVersionMode != IPv6Only && innerAns.Type == "A" {
-				server := strings.TrimSuffix(innerAns.Answer, ".") + ":53"
-				return server, StatusNoError, layer, trace
-			} else if r.ipVersionMode != IPv4Only && innerAns.Type == "AAAA" {
-				server := "[" + strings.TrimSuffix(innerAns.Answer, ".") + "]:53"
-				return server, StatusNoError, layer, trace
+			aRecordAndIPv4Ok := r.ipVersionMode != IPv6Only && innerAns.Type == "A"
+			aaaaRecordAndIPv6Ok := r.ipVersionMode != IPv4Only && innerAns.Type == "AAAA"
+			if aRecordAndIPv4Ok || aaaaRecordAndIPv6Ok {
+				ns := new(NameServer)
+				parsedIPString := strings.TrimSuffix(innerAns.Answer, ".")
+				ns.IP = net.ParseIP(parsedIPString)
+				ns.PopulateDefaultPort()
+				return ns, StatusNoError, layer, trace
 			}
 		}
 	}
-	return "", StatusServFail, layer, trace
+	return nil, StatusServFail, layer, trace
 }
 
 // CheckTxtRecords common function for all modules based on search in TXT record

--- a/src/zdns/lookup_test.go
+++ b/src/zdns/lookup_test.go
@@ -40,8 +40,8 @@ var protocolStatus = make(map[domainNS]Status)
 
 type MockLookupClient struct{}
 
-func (mc MockLookupClient) DoSingleDstServerLookup(r *Resolver, q Question, nameServer string, isIterative bool) (*SingleQueryResult, Trace, Status, error) {
-	curDomainNs := domainNS{domain: q.Name, ns: nameServer}
+func (mc MockLookupClient) DoSingleDstServerLookup(r *Resolver, q Question, nameServer *NameServer, isIterative bool) (*SingleQueryResult, Trace, Status, error) {
+	curDomainNs := domainNS{domain: q.Name, ns: nameServer.String()}
 	if res, ok := mockResults[curDomainNs]; ok {
 		var status = StatusNoError
 		if protStatus, ok := protocolStatus[curDomainNs]; ok {
@@ -59,8 +59,8 @@ func InitTest(t *testing.T) *ResolverConfig {
 
 	mc := MockLookupClient{}
 	config := NewResolverConfig()
-	config.ExternalNameServersV4 = []string{"127.0.0.1:53"}
-	config.RootNameServersV4 = []string{"127.0.0.1:53"}
+	config.ExternalNameServersV4 = []NameServer{{IP: net.ParseIP("127.0.0.1"), Port: 53}}
+	config.RootNameServersV4 = []NameServer{{IP: net.ParseIP("127.0.0.1"), Port: 53}}
 	config.LocalAddrsV4 = []net.IP{net.ParseIP("127.0.0.1")}
 	config.IPVersionMode = IPv4Only
 	config.LookupClient = mc
@@ -627,8 +627,8 @@ func TestOneA(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{Answer{
@@ -655,8 +655,8 @@ func TestTwoA(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{Answer{
@@ -690,8 +690,8 @@ func TestQuadAWithoutFlag(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{Answer{
@@ -726,8 +726,8 @@ func TestOnlyQuadA(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{Answer{
@@ -756,8 +756,8 @@ func TestAandQuadA(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{Answer{
@@ -792,8 +792,8 @@ func TestTwoQuadA(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{Answer{
@@ -829,8 +829,8 @@ func TestNoResults(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers:     nil,
@@ -851,8 +851,8 @@ func TestQuadAWithCname(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "cname.example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{Answer{
@@ -886,8 +886,8 @@ func TestUnexpectedMxOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{Answer{
@@ -922,8 +922,8 @@ func TestMxAndAdditionals(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{Answer{
@@ -963,8 +963,8 @@ func TestMismatchIpType(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{Answer{
@@ -999,8 +999,8 @@ func TestEmptyNonTerminal(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "leaf.intermediate.example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{Answer{
@@ -1018,7 +1018,7 @@ func TestEmptyNonTerminal(t *testing.T) {
 
 	dom2 := "intermediate.example.com"
 
-	domainNS2 := domainNS{domain: dom2, ns: ns1}
+	domainNS2 := domainNS{domain: dom2, ns: ns1.String()}
 
 	mockResults[domainNS2] = SingleQueryResult{
 		Answers:     nil,
@@ -1042,7 +1042,7 @@ func TestNXDomain(t *testing.T) {
 	config := InitTest(t)
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
-	ns1 := config.ExternalNameServersV4[0]
+	ns1 := &config.ExternalNameServersV4[0]
 	res, _, status, _ := resolver.DoTargetedLookup("nonexistent.example.com", ns1, false, true, true)
 	if status != StatusNXDomain {
 		t.Errorf("Expected StatusNXDomain status, got %v", status)
@@ -1060,10 +1060,10 @@ func TestAandQuadADedup(t *testing.T) {
 	domain1 := "cname1.example.com"
 	domain2 := "cname2.example.com"
 	domain3 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
-	domainNS2 := domainNS{domain: domain2, ns: ns1}
-	domainNS3 := domainNS{domain: domain3, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
+	domainNS2 := domainNS{domain: domain2, ns: ns1.String()}
+	domainNS3 := domainNS{domain: domain3, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{Answer{
@@ -1156,8 +1156,8 @@ func TestServFail(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{}
 	name := "example.com"
@@ -1193,8 +1193,8 @@ func TestNsAInAdditional(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{
@@ -1236,8 +1236,8 @@ func TestTwoNSInAdditional(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{
@@ -1296,8 +1296,8 @@ func TestAandQuadAInAdditional(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{
@@ -1345,8 +1345,8 @@ func TestNsMismatchIpType(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{
@@ -1394,8 +1394,8 @@ func TestAandQuadALookup(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{
@@ -1415,7 +1415,7 @@ func TestAandQuadALookup(t *testing.T) {
 
 	dom2 := "ns1.example.com"
 
-	domainNS2 := domainNS{domain: dom2, ns: ns1}
+	domainNS2 := domainNS{domain: dom2, ns: ns1.String()}
 
 	mockResults[domainNS2] = SingleQueryResult{
 		Answers: []interface{}{
@@ -1454,7 +1454,7 @@ func TestNsNXDomain(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := config.ExternalNameServersV4[0]
+	ns1 := &config.ExternalNameServersV4[0]
 
 	_, _, status, _ := resolver.DoNSLookup("nonexistentexample.com", ns1, false, true, true)
 
@@ -1467,8 +1467,8 @@ func TestNsServFail(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{}
 	protocolStatus[domainNS1] = StatusServFail
@@ -1485,8 +1485,8 @@ func TestErrorInTargetedLookup(t *testing.T) {
 	require.NoError(t, err)
 
 	domain1 := "example.com"
-	ns1 := config.ExternalNameServersV4[0]
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	ns1 := &config.ExternalNameServersV4[0]
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{
@@ -1518,12 +1518,12 @@ func TestAllNsLookupOneNs(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := config.ExternalNameServersV4[0]
+	ns1 := &config.ExternalNameServersV4[0]
 	domain1 := "example.com"
 	nsDomain1 := "ns1.example.com"
 	ipv4_1 := "127.0.0.2"
 
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{
 			Answer{
@@ -1548,8 +1548,7 @@ func TestAllNsLookupOneNs(t *testing.T) {
 		Flags:       DNSFlags{},
 	}
 
-	ns2 := net.JoinHostPort(ipv4_1, "53")
-	domainNS2 := domainNS{domain: domain1, ns: ns2}
+	domainNS2 := domainNS{domain: domain1, ns: ipv4_1 + ":53"}
 	ipv4_2 := "127.0.0.3"
 	mockResults[domainNS2] = SingleQueryResult{
 		Answers: []interface{}{
@@ -1593,13 +1592,13 @@ func TestAllNsLookupOneNsMultipleIps(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := config.ExternalNameServersV4[0]
+	ns1 := &config.ExternalNameServersV4[0]
 	domain1 := "example.com"
 	nsDomain1 := "ns1.example.com"
 	ipv4_1 := "127.0.0.2"
 	ipv4_2 := "127.0.0.3"
 
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{
 			Answer{
@@ -1631,8 +1630,7 @@ func TestAllNsLookupOneNsMultipleIps(t *testing.T) {
 		Flags:       DNSFlags{},
 	}
 
-	ns2 := net.JoinHostPort(ipv4_1, "53")
-	domainNS2 := domainNS{domain: domain1, ns: ns2}
+	domainNS2 := domainNS{domain: domain1, ns: ipv4_1 + ":53"}
 	ipv4_3 := "127.0.0.4"
 	ipv6_1 := "::1"
 	mockResults[domainNS2] = SingleQueryResult{
@@ -1658,8 +1656,7 @@ func TestAllNsLookupOneNsMultipleIps(t *testing.T) {
 		Flags:       DNSFlags{},
 	}
 
-	ns3 := net.JoinHostPort(ipv4_2, "53")
-	domainNS3 := domainNS{domain: domain1, ns: ns3}
+	domainNS3 := domainNS{domain: domain1, ns: ipv4_2 + ":53"}
 	ipv4_4 := "127.0.0.5"
 	ipv6_2 := "::2"
 	mockResults[domainNS3] = SingleQueryResult{
@@ -1716,14 +1713,14 @@ func TestAllNsLookupTwoNs(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := config.ExternalNameServersV4[0]
+	ns1 := &config.ExternalNameServersV4[0]
 	domain1 := "example.com"
 	nsDomain1 := "ns1.example.com"
 	nsDomain2 := "ns2.example.com"
 	ipv4_1 := "127.0.0.2"
 	ipv4_2 := "127.0.0.3"
 
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{
 			Answer{
@@ -1762,8 +1759,7 @@ func TestAllNsLookupTwoNs(t *testing.T) {
 		Flags:       DNSFlags{},
 	}
 
-	ns2 := net.JoinHostPort(ipv4_1, "53")
-	domainNS2 := domainNS{domain: domain1, ns: ns2}
+	domainNS2 := domainNS{domain: domain1, ns: ipv4_1 + ":53"}
 	ipv4_3 := "127.0.0.4"
 	mockResults[domainNS2] = SingleQueryResult{
 		Answers: []interface{}{
@@ -1781,8 +1777,7 @@ func TestAllNsLookupTwoNs(t *testing.T) {
 		Flags:       DNSFlags{},
 	}
 
-	ns3 := net.JoinHostPort(ipv4_2, "53")
-	domainNS3 := domainNS{domain: domain1, ns: ns3}
+	domainNS3 := domainNS{domain: domain1, ns: ipv4_2 + ":53"}
 	ipv4_4 := "127.0.0.5"
 	mockResults[domainNS3] = SingleQueryResult{
 		Answers: []interface{}{
@@ -1832,13 +1827,13 @@ func TestAllNsLookupErrorInOne(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := config.ExternalNameServersV4[0]
+	ns1 := &config.ExternalNameServersV4[0]
 	domain1 := "example.com"
 	nsDomain1 := "ns1.example.com"
 	ipv4_1 := "127.0.0.2"
 	ipv4_2 := "127.0.0.3"
 
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 	mockResults[domainNS1] = SingleQueryResult{
 		Answers: []interface{}{
 			Answer{
@@ -1870,8 +1865,7 @@ func TestAllNsLookupErrorInOne(t *testing.T) {
 		Flags:       DNSFlags{},
 	}
 
-	ns2 := net.JoinHostPort(ipv4_1, "53")
-	domainNS2 := domainNS{domain: domain1, ns: ns2}
+	domainNS2 := domainNS{domain: domain1, ns: ipv4_1 + ":53"}
 	ipv4_3 := "127.0.0.4"
 	ipv6_1 := "::1"
 	mockResults[domainNS2] = SingleQueryResult{
@@ -1897,8 +1891,7 @@ func TestAllNsLookupErrorInOne(t *testing.T) {
 		Flags:       DNSFlags{},
 	}
 
-	ns3 := net.JoinHostPort(ipv4_2, "53")
-	domainNS3 := domainNS{domain: domain1, ns: ns3}
+	domainNS3 := domainNS{domain: domain1, ns: ipv4_2 + ":53"}
 	protocolStatus[domainNS3] = StatusServFail
 	mockResults[domainNS3] = SingleQueryResult{}
 
@@ -1932,7 +1925,7 @@ func TestAllNsLookupNXDomain(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := config.ExternalNameServersV4[0]
+	ns1 := &config.ExternalNameServersV4[0]
 	q := Question{
 		Type:  dns.TypeNS,
 		Class: dns.ClassINET,
@@ -1952,9 +1945,9 @@ func TestAllNsLookupServFail(t *testing.T) {
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 
-	ns1 := config.ExternalNameServersV4[0]
+	ns1 := &config.ExternalNameServersV4[0]
 	domain1 := "example.com"
-	domainNS1 := domainNS{domain: domain1, ns: ns1}
+	domainNS1 := domainNS{domain: domain1, ns: ns1.String()}
 
 	protocolStatus[domainNS1] = StatusServFail
 	mockResults[domainNS1] = SingleQueryResult{}
@@ -1974,7 +1967,7 @@ func TestAllNsLookupServFail(t *testing.T) {
 func TestInvalidInputsLookup(t *testing.T) {
 	config := InitTest(t)
 	config.LocalAddrsV4 = []net.IP{net.ParseIP("127.0.0.1")}
-	config.ExternalNameServersV4 = []string{"127.0.0.1:53"}
+	config.ExternalNameServersV4 = []NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}}
 	resolver, err := InitResolver(config)
 	require.NoError(t, err)
 	q := Question{
@@ -1984,18 +1977,18 @@ func TestInvalidInputsLookup(t *testing.T) {
 	}
 
 	t.Run("no port attached to nameserver", func(t *testing.T) {
-		_, _, _, err := resolver.ExternalLookup(&q, "127.0.0.53")
+		_, _, _, err := resolver.ExternalLookup(&q, &NameServer{IP: net.ParseIP("127.0.0.53")})
 		assert.Nil(t, err)
 	})
 	t.Run("using a loopback local addr with non-loopback nameserver", func(t *testing.T) {
-		result, trace, status, err := resolver.ExternalLookup(&q, "1.1.1.1:53")
+		result, trace, status, err := resolver.ExternalLookup(&q, &NameServer{IP: net.ParseIP("1.1.1.1"), Port: 53})
 		assert.Nil(t, result)
 		assert.Nil(t, trace)
 		assert.Equal(t, StatusIllegalInput, status)
 		assert.NotNil(t, err)
 	})
 	t.Run("invalid nameserver address", func(t *testing.T) {
-		result, trace, status, err := resolver.ExternalLookup(&q, "987.987.987.987:53")
+		result, trace, status, err := resolver.ExternalLookup(&q, &NameServer{IP: net.ParseIP("987.987.987.987"), Port: 53})
 		assert.Nil(t, result)
 		assert.Nil(t, trace)
 		assert.Equal(t, StatusIllegalInput, status)

--- a/src/zdns/nslookup.go
+++ b/src/zdns/nslookup.go
@@ -39,7 +39,7 @@ type NSResult struct {
 }
 
 // DoNSLookup performs a DNS NS lookup on the given name against the given name server.
-func (r *Resolver) DoNSLookup(lookupName, nameServer string, isIterative, lookupA, lookupAAAA bool) (*NSResult, Trace, Status, error) {
+func (r *Resolver) DoNSLookup(lookupName string, nameServer *NameServer, isIterative, lookupA, lookupAAAA bool) (*NSResult, Trace, Status, error) {
 	if len(lookupName) == 0 {
 		return nil, nil, "", errors.New("no name provided for NS lookup")
 	}

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -110,7 +110,6 @@ func (rc *ResolverConfig) Validate() error {
 
 	// Validate all nameservers have ports and are valid IPs
 	for _, ns := range util.Concat(rc.ExternalNameServersV4, rc.ExternalNameServersV6) {
-		ns.PopulateDefaultPort()
 		if isValid, reason := ns.IsValid(); !isValid {
 			return fmt.Errorf("invalid external name server: %s", reason)
 		}
@@ -127,7 +126,6 @@ func (rc *ResolverConfig) Validate() error {
 
 	// Validate all nameservers have ports and are valid IPs
 	for _, ns := range util.Concat(rc.RootNameServersV4, rc.RootNameServersV6) {
-		ns.PopulateDefaultPort()
 		if isValid, reason := ns.IsValid(); !isValid {
 			return fmt.Errorf("invalid root name server: %s", reason)
 		}

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -375,10 +375,8 @@ func InitResolver(config *ResolverConfig) (*Resolver, error) {
 	r.rootNameServers = make([]NameServer, 0, len(config.RootNameServersV4)+len(config.RootNameServersV6))
 	if r.ipVersionMode != IPv6Only && len(config.RootNameServersV4) == 0 {
 		// add IPv4 root servers
-		for _, rootNS := range RootServersV4 {
-			ns := NameServer{IP: net.ParseIP(rootNS)}
-			ns.PopulateDefaultPort()
-			r.rootNameServers = append(r.rootNameServers, ns)
+		for _, ns := range RootServersV4 {
+			r.rootNameServers = append(r.rootNameServers, *ns.DeepCopy())
 		}
 	} else if r.ipVersionMode != IPv6Only {
 		for _, ns := range config.RootNameServersV4 {
@@ -387,10 +385,8 @@ func InitResolver(config *ResolverConfig) (*Resolver, error) {
 	}
 	if r.ipVersionMode != IPv4Only && len(config.RootNameServersV6) == 0 {
 		// add IPv4 root servers
-		for _, rootNS := range RootServersV6 {
-			ns := NameServer{IP: net.ParseIP(rootNS)}
-			ns.PopulateDefaultPort()
-			r.rootNameServers = append(r.rootNameServers, ns)
+		for _, ns := range RootServersV6 {
+			r.rootNameServers = append(r.rootNameServers, *ns.DeepCopy())
 		}
 	} else if r.ipVersionMode != IPv4Only {
 		for _, ns := range config.RootNameServersV6 {

--- a/src/zdns/resolver_test.go
+++ b/src/zdns/resolver_test.go
@@ -24,8 +24,8 @@ import (
 func TestResolverConfig_Validate(t *testing.T) {
 	t.Run("Valid config with external/root name servers and local addr", func(t *testing.T) {
 		rc := &ResolverConfig{
-			ExternalNameServersV4: []string{"127.0.0.53:53"},
-			RootNameServersV4:     []string{"127.0.0.53:53"},
+			ExternalNameServersV4: []NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}},
+			RootNameServersV4:     []NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}},
 			LocalAddrsV4:          []net.IP{net.ParseIP("127.0.0.1")},
 		}
 		err := rc.Validate()
@@ -33,8 +33,8 @@ func TestResolverConfig_Validate(t *testing.T) {
 	})
 	t.Run("Using external nameserver with no port", func(t *testing.T) {
 		rc := &ResolverConfig{
-			ExternalNameServersV4: []string{"127.0.0.53"},
-			RootNameServersV4:     []string{"127.0.0.53:53"},
+			ExternalNameServersV4: []NameServer{{IP: net.ParseIP("127.0.0.53")}},
+			RootNameServersV4:     []NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}},
 			LocalAddrsV4:          []net.IP{net.ParseIP("127.0.0.1")},
 		}
 		err := rc.Validate()
@@ -42,8 +42,8 @@ func TestResolverConfig_Validate(t *testing.T) {
 	})
 	t.Run("Using root nameserver with no port", func(t *testing.T) {
 		rc := &ResolverConfig{
-			ExternalNameServersV4: []string{"127.0.0.53:53"},
-			RootNameServersV4:     []string{"127.0.0.53"},
+			ExternalNameServersV4: []NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}},
+			RootNameServersV4:     []NameServer{{IP: net.ParseIP("127.0.0.53")}},
 			LocalAddrsV4:          []net.IP{net.ParseIP("127.0.0.1")},
 		}
 		err := rc.Validate()
@@ -51,7 +51,7 @@ func TestResolverConfig_Validate(t *testing.T) {
 	})
 	t.Run("Missing external nameserver", func(t *testing.T) {
 		rc := &ResolverConfig{
-			RootNameServersV4: []string{"127.0.0.53:53"},
+			RootNameServersV4: []NameServer{{IP: net.ParseIP("127.0.0.53")}},
 			LocalAddrsV4:      []net.IP{net.ParseIP("127.0.0.1")},
 		}
 		err := rc.Validate()
@@ -59,7 +59,7 @@ func TestResolverConfig_Validate(t *testing.T) {
 	})
 	t.Run("Missing root nameserver", func(t *testing.T) {
 		rc := &ResolverConfig{
-			ExternalNameServersV4: []string{"127.0.0.53:53"},
+			ExternalNameServersV4: []NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}},
 			LocalAddrsV4:          []net.IP{net.ParseIP("127.0.0.1")},
 		}
 		err := rc.Validate()
@@ -67,8 +67,8 @@ func TestResolverConfig_Validate(t *testing.T) {
 	})
 	t.Run("Missing local addr", func(t *testing.T) {
 		rc := &ResolverConfig{
-			ExternalNameServersV4: []string{"127.0.0.53:53"},
-			RootNameServersV4:     []string{"127.0.0.53:53"},
+			ExternalNameServersV4: []NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}},
+			RootNameServersV4:     []NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}},
 		}
 		err := rc.Validate()
 		require.NotNil(t, err)
@@ -76,8 +76,8 @@ func TestResolverConfig_Validate(t *testing.T) {
 
 	t.Run("Cannot mix loopback addresses in nameservers", func(t *testing.T) {
 		rc := &ResolverConfig{
-			ExternalNameServersV4: []string{"127.0.0.53:53, 1.1.1.1:53"},
-			RootNameServersV4:     []string{"127.0.0.53:53"},
+			ExternalNameServersV4: []NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}, {IP: net.ParseIP("1.1.1.1"), Port: 53}},
+			RootNameServersV4:     []NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}},
 			LocalAddrsV4:          []net.IP{net.ParseIP("127.0.0.1")},
 		}
 		err := rc.Validate()
@@ -85,8 +85,8 @@ func TestResolverConfig_Validate(t *testing.T) {
 	})
 	t.Run("Cannot mix loopback addresses among nameservers", func(t *testing.T) {
 		rc := &ResolverConfig{
-			ExternalNameServersV4: []string{"1.1.1.1:53"},
-			RootNameServersV4:     []string{"127.0.0.53:53"},
+			ExternalNameServersV4: []NameServer{{IP: net.ParseIP("1.1.1.1"), Port: 53}},
+			RootNameServersV4:     []NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}},
 			LocalAddrsV4:          []net.IP{net.ParseIP("127.0.0.1")},
 		}
 		err := rc.Validate()
@@ -94,8 +94,8 @@ func TestResolverConfig_Validate(t *testing.T) {
 	})
 	t.Run("Cannot reach loopback NSes from non-loopback local address", func(t *testing.T) {
 		rc := &ResolverConfig{
-			ExternalNameServersV4: []string{"127.0.0.53:53"},
-			RootNameServersV4:     []string{"127.0.0.53:53"},
+			ExternalNameServersV4: []NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}},
+			RootNameServersV4:     []NameServer{{IP: net.ParseIP("127.0.0.53"), Port: 53}},
 			LocalAddrsV4:          []net.IP{net.ParseIP("192.168.1.2")},
 		}
 		err := rc.Validate()
@@ -103,8 +103,8 @@ func TestResolverConfig_Validate(t *testing.T) {
 	})
 	t.Run("Cannot reach non-loopback NSes from loopback local address", func(t *testing.T) {
 		rc := &ResolverConfig{
-			ExternalNameServersV4: []string{"1.1.1.1:53"},
-			RootNameServersV4:     []string{"1.1.1.1:53"},
+			ExternalNameServersV4: []NameServer{{IP: net.ParseIP("1.1.1.1"), Port: 53}},
+			RootNameServersV4:     []NameServer{{IP: net.ParseIP("1.1.1.1"), Port: 53}},
 			LocalAddrsV4:          []net.IP{net.ParseIP("127.0.0.1")},
 		}
 		err := rc.Validate()

--- a/src/zdns/types.go
+++ b/src/zdns/types.go
@@ -147,17 +147,3 @@ func (ns *NameServer) DeepCopy() *NameServer {
 		DomainName: ns.DomainName,
 	}
 }
-
-// Equal method to compare two NameServer structs
-func (ns NameServer) Equal(other NameServer) bool {
-	if !ns.IP.Equal(other.IP) {
-		return false
-	}
-	if ns.Port != other.Port {
-		return false
-	}
-	if ns.DomainName != other.DomainName {
-		return false
-	}
-	return true
-}

--- a/src/zdns/types.go
+++ b/src/zdns/types.go
@@ -28,6 +28,10 @@ const (
 	TCPOnly
 )
 
+const (
+	DefaultPort = 53
+)
+
 func GetTransportMode(useUDP, useTCP bool) transportMode {
 	if useUDP && useTCP {
 		return UDPOrTCP
@@ -118,7 +122,7 @@ func (ns *NameServer) String() string {
 
 func (ns *NameServer) PopulateDefaultPort() {
 	if ns.Port == 0 {
-		ns.Port = GetDefaultPort()
+		ns.Port = DefaultPort
 	}
 }
 

--- a/src/zdns/types.go
+++ b/src/zdns/types.go
@@ -147,3 +147,17 @@ func (ns *NameServer) DeepCopy() *NameServer {
 		DomainName: ns.DomainName,
 	}
 }
+
+// Equal method to compare two NameServer structs
+func (ns NameServer) Equal(other NameServer) bool {
+	if !ns.IP.Equal(other.IP) {
+		return false
+	}
+	if ns.Port != other.Port {
+		return false
+	}
+	if ns.DomainName != other.DomainName {
+		return false
+	}
+	return true
+}

--- a/src/zdns/types.go
+++ b/src/zdns/types.go
@@ -13,7 +13,12 @@
  */
 package zdns
 
-import "fmt"
+import (
+	"fmt"
+	"net"
+
+	"github.com/zmap/zdns/src/internal/util"
+)
 
 type transportMode int
 
@@ -91,4 +96,54 @@ func (iip IterationIPPreference) IsValid() (bool, string) {
 		return false, fmt.Sprintf("invalid iteration ip preference: %d", iip)
 	}
 	return true, ""
+}
+
+type NameServer struct {
+	IP         net.IP // ip address, required
+	Port       uint16 // udp/tcp port
+	DomainName string // used for SNI with TLS, required if you want to validate server certs
+}
+
+func (ns *NameServer) String() string {
+	if ns == nil || ns.IP == nil {
+		return ""
+	}
+	if ns.IP.To4() != nil {
+		return fmt.Sprintf("%s:%d", ns.IP.String(), ns.Port)
+	} else if util.IsIPv6(&ns.IP) {
+		return fmt.Sprintf("[%s]:%d", ns.IP.String(), ns.Port)
+	}
+	return ""
+}
+
+func (ns *NameServer) PopulateDefaultPort() {
+	if ns.Port == 0 {
+		ns.Port = GetDefaultPort()
+	}
+}
+
+func (ns *NameServer) IsValid() (bool, string) {
+	if ns.IP == nil {
+		return false, "missing IP address"
+	}
+	if ns.IP != nil && ns.IP.To4() == nil && ns.IP.To16() == nil {
+		return false, "invalid IP address"
+	}
+	if ns.Port == 0 {
+		return false, "missing port"
+	}
+	return true, ""
+}
+
+func (ns *NameServer) DeepCopy() *NameServer {
+	if ns == nil {
+		return nil
+	}
+	ip := make(net.IP, len(ns.IP))
+	copy(ip, ns.IP)
+	return &NameServer{
+		IP:         ip,
+		Port:       ns.Port,
+		DomainName: ns.DomainName,
+	}
 }

--- a/src/zdns/util.go
+++ b/src/zdns/util.go
@@ -24,10 +24,6 @@ import (
 	"github.com/zmap/dns"
 )
 
-const (
-	DefaultPort = 53
-)
-
 func dotName(name string) string {
 	return strings.Join([]string{name, "."}, "")
 }
@@ -187,8 +183,4 @@ func handleStatus(status Status, err error) (Status, error) {
 		var s Status
 		return s, nil
 	}
-}
-
-func GetDefaultPort() uint16 {
-	return DefaultPort
 }

--- a/src/zdns/util.go
+++ b/src/zdns/util.go
@@ -24,6 +24,10 @@ import (
 	"github.com/zmap/dns"
 )
 
+const (
+	DefaultPort = 53
+)
+
 func dotName(name string) string {
 	return strings.Join([]string{name, "."}, "")
 }
@@ -183,4 +187,8 @@ func handleStatus(status Status, err error) (Status, error) {
 		var s Status
 		return s, nil
 	}
+}
+
+func GetDefaultPort() uint16 {
+	return DefaultPort
 }

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1302,6 +1302,20 @@ class Tests(unittest.TestCase):
         os.remove(metadata_file_name)
         os.remove(ini_file_name)
 
+    def test_a_lookup_domain_as_name_server_string(self):
+        c = "A --name-servers=one.one.one.one"
+        name = "zdns-testing.com"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd, "A")
+        self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd, "A")
+
+    def test_a_lookup_domain_name_server_with_input(self):
+        c = "A"
+        name = "zdns-testing.com,one.one.one.one"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd, "A")
+        self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd, "A")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1289,7 +1289,7 @@ class Tests(unittest.TestCase):
         [A]
         [AAAA]
         """
-        metadata_file_name = "temp-metadata.json"
+        metadata_file_name = "temp-metadata-multi.json"
         ini_file_name = "./test_multiple_modules.ini"
         with open(ini_file_name, "w") as f:
             f.write(ini_file_contents)

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -782,7 +782,7 @@ class Tests(unittest.TestCase):
         ipv4-lookup=false
         ipv6-lookup = true
         """
-        file_name = "./test_multiple_modules.ini"
+        file_name = "./test_multiple_modules_special_modules.ini"
         with open(file_name, "w") as f:
             f.write(ini_file_contents)
         c = "MULTIPLE -c " + file_name
@@ -1290,7 +1290,7 @@ class Tests(unittest.TestCase):
         [AAAA]
         """
         metadata_file_name = "temp-metadata-multi.json"
-        ini_file_name = "./test_multiple_modules.ini"
+        ini_file_name = "test_metadata_file_multiple_modules.ini"
         with open(ini_file_name, "w") as f:
             f.write(ini_file_contents)
         c = ("MULTIPLE -c " + ini_file_name + " google.com yahoo.com cloudflare.com zdns-testing.com --metadata-file="


### PR DESCRIPTION
## Description

95% of the changes here introduce a new `NameServer` struct:
```
type NameServer struct {
	IP         net.IP // ip address, required
	Port       uint16 // udp/tcp port
	DomainName string // used for SNI with TLS, required if you want to validate server certs
}
```

This lets us have a bit more type safety than we had before with passing an arbitrary string as a `nameServer` into functions. 

Additionally, though, this adds the ability to specify nameservers by domain, ex: `./zdns A google.com --name-servers="one.one.one.one"`.
In this case, we'll query for the IPs (A and AAAA) and discard A if we're doing `--6` or AAAA if `--4`, and store these as our `resolver.NameServers`.

Finally, if a user is passing nameservers as domains in as input on a per-line basis:
```
yahoo.com,one.one.one.one
google.com,8.8.8.8
```
We'll choose a _random_ IP from `one.one.one.one`'s records and use that to query.

## Testing
Added a few unit tests and integration tests to test the new functionality.
