### PR TITLE
DoH/DoT/TCP-based lookups and connection re-use

### DIFF
--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -663,7 +663,7 @@ WorkerLoop:
 				break WorkerLoop
 			}
 			handleWorkerInput(gc, rc, task, resolver, &metadata, output)
-		case <-time.After(time.Millisecond * 10):
+		default:
 			// No tasks in its own resolver, wait on either
 			select {
 			case task, ok = <-preferredWorkChan:

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -511,8 +511,9 @@ func Run(gc CLIConf) {
 	// de-dupe
 	nsLookupMap := make(map[uint32]struct{})
 	uniqNameServers := make([]zdns.NameServer, 0, len(nameServers))
+	var hash uint32
 	for _, ns := range nameServers {
-		hash, err := ns.Hash()
+		hash, err = ns.Hash()
 		if err != nil {
 			log.Fatalf("could not hash name server %s: %v", ns.String(), err)
 		}

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -663,7 +663,7 @@ WorkerLoop:
 				break WorkerLoop
 			}
 			handleWorkerInput(gc, rc, task, resolver, &metadata, output)
-		default:
+		case <-time.After(time.Millisecond * 10):
 			// No tasks in its own resolver, wait on either
 			select {
 			case task, ok = <-preferredWorkChan:

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -441,7 +441,7 @@ type WorkerPools struct {
 func NewWorkerPools(numPools int) *WorkerPools {
 	workerPools := make([]chan *InputLineWithNameServer, numPools)
 	for i := 0; i < numPools; i++ {
-		workerPools[i] = make(chan *InputLineWithNameServer)
+		workerPools[i] = make(chan *InputLineWithNameServer, 10)
 	}
 	return &WorkerPools{WorkerPools: workerPools}
 }

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -458,7 +458,6 @@ type InputLineWithNameServer struct {
 // The goal is that a query for a single name server will consistently go to the same worker pool which 1+ threads will read from
 // This is especially useful for TLS/TCP/HTTPS based lookups where repeating the initial handshakes would be wasteful
 func inputDeMultiplexer(nameServers []zdns.NameServer, inChan <-chan string, workerPools *WorkerPools, wg *sync.WaitGroup) error {
-	wg.Add(1)
 	defer wg.Done()
 	// defer closing the worker pool chans
 	defer func() {
@@ -553,12 +552,16 @@ func Run(gc CLIConf) {
 			log.Fatal(fmt.Sprintf("could not feed input channel: %v", inErr))
 		}
 	}()
-	go func() {
-		plexErr := inputDeMultiplexer(uniqNameServers, inChan, workerPools, &routineWG)
-		if plexErr != nil {
-			log.Fatal(fmt.Sprintf("could not de-multiplex input channel: %v", plexErr))
-		}
-	}()
+	const numberOfDeMultiplexers = 5
+	for i := 0; i < numberOfDeMultiplexers; i++ {
+		go func() {
+			plexErr := inputDeMultiplexer(uniqNameServers, inChan, workerPools, &routineWG)
+			if plexErr != nil {
+				log.Fatal(fmt.Sprintf("could not de-multiplex input channel: %v", plexErr))
+			}
+		}()
+	}
+	routineWG.Add(numberOfDeMultiplexers)
 	go func() {
 		outErr := outHandler.WriteResults(outChan, &routineWG)
 		if outErr != nil {

--- a/src/modules/spf/spf.go
+++ b/src/modules/spf/spf.go
@@ -48,8 +48,8 @@ func (spfMod *SpfLookupModule) CLIInit(gc *cli.CLIConf, rc *zdns.ResolverConfig)
 	return spfMod.BasicLookupModule.CLIInit(gc, rc)
 }
 
-func (spfMod *SpfLookupModule) Lookup(r *zdns.Resolver, name string, resolver *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
-	innerRes, trace, status, err := spfMod.BasicLookupModule.Lookup(r, name, resolver)
+func (spfMod *SpfLookupModule) Lookup(r *zdns.Resolver, name string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
+	innerRes, trace, status, err := spfMod.BasicLookupModule.Lookup(r, name, nameServer)
 	castedInnerRes, ok := innerRes.(*zdns.SingleQueryResult)
 	if !ok {
 		return nil, trace, status, errors.New("lookup didn't return a single query result type")

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -456,10 +456,10 @@ func (r *Resolver) retryingLookup(ctx context.Context, q Question, nameServer *N
 			result, status, err = wireLookupUDP(ctx, connInfo, q, nameServer, r.ednsOptions, recursive, r.dnsSecEnabled, r.checkingDisabledBit)
 			if status == StatusTruncated && connInfo.tcpClient != nil {
 				// result truncated, try again with TCP
-				result, status, err = wireLookupTCP(ctx, connInfo, q, nameServer, r.ednsOptions, recursive, r.dnsSecEnabled, r.checkingDisabledBit, true)
+				result, status, err = wireLookupTCP(ctx, connInfo, q, nameServer, r.ednsOptions, recursive, r.dnsSecEnabled, r.checkingDisabledBit)
 			}
 		} else if connInfo.tcpClient != nil {
-			result, status, err = wireLookupTCP(ctx, connInfo, q, nameServer, r.ednsOptions, recursive, r.dnsSecEnabled, r.checkingDisabledBit, true)
+			result, status, err = wireLookupTCP(ctx, connInfo, q, nameServer, r.ednsOptions, recursive, r.dnsSecEnabled, r.checkingDisabledBit)
 		} else {
 			return SingleQueryResult{}, StatusError, 0, errors.New("no connection info for nameserver")
 		}
@@ -622,7 +622,7 @@ func doDoHLookup(ctx context.Context, httpClient *http.Client, q Question, nameS
 }
 
 // wireLookupTCP performs a DNS lookup on-the-wire over TCP with the given parameters
-func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, ednsOptions []dns.EDNS0, recursive, dnssec, checkingDisabled, retryOnConnClosing bool) (SingleQueryResult, Status, error) {
+func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, ednsOptions []dns.EDNS0, recursive, dnssec, checkingDisabled bool) (SingleQueryResult, Status, error) {
 	res := SingleQueryResult{Answers: []interface{}{}, Authorities: []interface{}{}, Additional: []interface{}{}}
 	res.Resolver = nameServer.String()
 
@@ -648,7 +648,7 @@ func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, na
 			return SingleQueryResult{}, StatusError, fmt.Errorf("could not resolve TCP address %s: %v", nameServer.String(), err)
 		}
 		r, _, err = connInfo.tcpClient.ExchangeWithConnToContext(ctx, m, connInfo.tcpConn, addr)
-		if retryOnConnClosing && err != nil && err.Error() == "EOF" {
+		if err != nil && err.Error() == "EOF" {
 			// EOF error means the connection was closed, we'll remove the connection (it'll be recreated on the next iteration)
 			// and try again
 			err = connInfo.tcpConn.Conn.Close()

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -657,7 +657,7 @@ func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, na
 			return wireLookupTCP(ctx, connInfo, q, nameServer, ednsOptions, recursive, dnssec, checkingDisabled, false)
 		}
 	} else {
-		// no pre-existing connection, create a ephemeral one
+		// no pre-existing connection, create an ephemeral one
 		res.Protocol = "tcp"
 		r, _, err = connInfo.tcpClient.ExchangeContext(ctx, m, nameServer.String())
 	}

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -472,7 +472,6 @@ func (r *Resolver) retryingLookup(ctx context.Context, q Question, nameServer *N
 }
 
 func doDoTLookup(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, recursive bool, ednsOptions []dns.EDNS0, dnssec bool, checkingDisabled bool) (SingleQueryResult, Status, error) {
-	return SingleQueryResult{}, StatusError, errors.New("DoT not implemented")
 	m := new(dns.Msg)
 	m.SetQuestion(dotName(q.Name), q.Type)
 	m.Question[0].Qclass = q.Class
@@ -624,6 +623,7 @@ func doDoHLookup(ctx context.Context, httpClient *http.Client, q Question, nameS
 
 // wireLookupTCP performs a DNS lookup on-the-wire over TCP with the given parameters
 func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, ednsOptions []dns.EDNS0, recursive, dnssec, checkingDisabled, retryOnConnClosing bool) (SingleQueryResult, Status, error) {
+	return SingleQueryResult{}, StatusError, errors.New("TCP not implemented")
 	res := SingleQueryResult{Answers: []interface{}{}, Authorities: []interface{}{}, Additional: []interface{}{}}
 	res.Resolver = nameServer.String()
 

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -16,17 +16,16 @@ package zdns
 import (
 	"context"
 	"fmt"
-	"io"
-	"net"
-	"regexp"
-	"strings"
-
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/dns"
 	"github.com/zmap/zcrypto/tls"
 	"github.com/zmap/zgrab2/lib/http"
 	"github.com/zmap/zgrab2/lib/output"
+	"io"
+	"net"
+	"regexp"
+	"strings"
 
 	"github.com/zmap/zdns/src/internal/util"
 )
@@ -623,7 +622,6 @@ func doDoHLookup(ctx context.Context, httpClient *http.Client, q Question, nameS
 
 // wireLookupTCP performs a DNS lookup on-the-wire over TCP with the given parameters
 func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, ednsOptions []dns.EDNS0, recursive, dnssec, checkingDisabled, retryOnConnClosing bool) (SingleQueryResult, Status, error) {
-	return SingleQueryResult{}, StatusError, errors.New("TCP not implemented")
 	res := SingleQueryResult{Answers: []interface{}{}, Authorities: []interface{}{}, Additional: []interface{}{}}
 	res.Resolver = nameServer.String()
 

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -16,16 +16,17 @@ package zdns
 import (
 	"context"
 	"fmt"
+	"io"
+	"net"
+	"regexp"
+	"strings"
+
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/dns"
 	"github.com/zmap/zcrypto/tls"
 	"github.com/zmap/zgrab2/lib/http"
 	"github.com/zmap/zgrab2/lib/output"
-	"io"
-	"net"
-	"regexp"
-	"strings"
 
 	"github.com/zmap/zdns/src/internal/util"
 )

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -700,7 +700,6 @@ func wireLookupUDP(ctx context.Context, connInfo *ConnectionInfo, q Question, na
 	} else {
 		r, _, err = connInfo.udpClient.ExchangeContext(ctx, m, nameServer.String())
 	}
-	// if record comes back truncated, but we have a TCP connection, try again with that
 	if r != nil && (r.Truncated || r.Rcode == dns.RcodeBadTrunc) {
 		return res, StatusTruncated, err
 	}

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -472,6 +472,7 @@ func (r *Resolver) retryingLookup(ctx context.Context, q Question, nameServer *N
 }
 
 func doDoTLookup(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, recursive bool, ednsOptions []dns.EDNS0, dnssec bool, checkingDisabled bool) (SingleQueryResult, Status, error) {
+	return SingleQueryResult{}, StatusError, errors.New("DoT not implemented")
 	m := new(dns.Msg)
 	m.SetQuestion(dotName(q.Name), q.Type)
 	m.Question[0].Qclass = q.Class

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -113,11 +113,11 @@ func (rc *ResolverConfig) Validate() error {
 	// External Nameservers
 	if rc.IPVersionMode != IPv6Only && len(rc.ExternalNameServersV4) == 0 {
 		// If IPv4 is supported, we require at least one IPv4 external nameserver
-		return errors.New("must have at least one external IPv4 name server if IPv4 mode is enabled")
+		return errors.New("must have at least one external IPv4 name server if IPv4 mode is enabled. Use IPv6 only if you don't have IPv4 nameservers")
 	}
 	if rc.IPVersionMode != IPv4Only && len(rc.ExternalNameServersV6) == 0 {
 		// If IPv6 is supported, we require at least one IPv6 external nameserver
-		return errors.New("must have at least one external IPv6 name server if IPv6 mode is enabled")
+		return errors.New("must have at least one external IPv6 name server if IPv6 mode is enabled. Use IPv4 only if you don't have IPv6 nameservers")
 	}
 
 	// Validate all nameservers have ports and are valid IPs

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -113,11 +113,11 @@ func (rc *ResolverConfig) Validate() error {
 	// External Nameservers
 	if rc.IPVersionMode != IPv6Only && len(rc.ExternalNameServersV4) == 0 {
 		// If IPv4 is supported, we require at least one IPv4 external nameserver
-		return errors.New("must have at least one external IPv4 name server if IPv4 mode is enabled. Use IPv6 only if you don't have IPv4 nameservers")
+		return errors.New("must have at least one external IPv4 name server if IPv4 mode is enabled. Use IPv6-only if you don't have IPv4 nameservers")
 	}
 	if rc.IPVersionMode != IPv4Only && len(rc.ExternalNameServersV6) == 0 {
 		// If IPv6 is supported, we require at least one IPv6 external nameserver
-		return errors.New("must have at least one external IPv6 name server if IPv6 mode is enabled. Use IPv4 only if you don't have IPv6 nameservers")
+		return errors.New("must have at least one external IPv6 name server if IPv6 mode is enabled. Use IPv4-only if you don't have IPv6 nameservers")
 	}
 
 	// Validate all nameservers have ports and are valid IPs
@@ -234,7 +234,7 @@ type ConnectionInfo struct {
 	udpClient    *dns.Client
 	tcpClient    *dns.Client
 	udpConn      *dns.Conn            // for socket re-use with UDP
-	tcpConn      *dns.Conn            // for socket re-use with TCP, if RemoteAddr doesn't change, we don't re-handshake
+	tcpConn      *dns.Conn            // for socket re-use with TCP
 	httpsClient  *http.Client         // for DoH
 	tlsConn      *dns.Conn            // for DoT
 	tlsHandshake *tls.ServerHandshake // for DoT, used to print TLS handshake to user

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -531,6 +531,12 @@ func (r *Resolver) getConnectionInfo(nameServer *NameServer) (*ConnectionInfo, e
 }
 
 func getNewTCPConn(nameServer *NameServer, connInfo *ConnectionInfo) error {
+	// close any existing TCP connection
+	if connInfo.tcpConn != nil {
+		if err := connInfo.tcpConn.Close(); err != nil {
+			return fmt.Errorf("error closing existing TCP connection: %w", err)
+		}
+	}
 	// create persistent TCP connection to nameserver
 	conn, err := net.DialTCP("tcp", &net.TCPAddr{IP: connInfo.localAddr}, &net.TCPAddr{IP: nameServer.IP, Port: int(nameServer.Port)})
 	if err != nil {
@@ -583,24 +589,52 @@ func (r *Resolver) IterativeLookup(q *Question) (*SingleQueryResult, Trace, Stat
 // Close cleans up any resources used by the resolver. This should be called when the resolver is no longer needed.
 // Lookup will panic if called after Close.
 func (r *Resolver) Close() {
-	if r.connInfoIPv4Internet != nil && r.connInfoIPv4Internet.udpConn != nil {
-		if err := r.connInfoIPv4Internet.udpConn.Close(); err != nil {
-			log.Errorf("error closing IPv4 connection: %v", err)
+	if r.connInfoIPv4Internet != nil {
+		if r.connInfoIPv4Internet.udpConn != nil {
+			if err := r.connInfoIPv4Internet.udpConn.Close(); err != nil {
+				log.Errorf("error closing UDP IPv4 connection: %v", err)
+			}
+		}
+		if r.connInfoIPv4Internet.tcpConn != nil {
+			if err := r.connInfoIPv4Internet.tcpConn.Close(); err != nil {
+				log.Errorf("error closing TCP IPv4 connection: %v", err)
+			}
 		}
 	}
-	if r.connInfoIPv6Internet != nil && r.connInfoIPv6Internet.udpConn != nil {
-		if err := r.connInfoIPv6Internet.udpConn.Close(); err != nil {
-			log.Errorf("error closing IPv6 connection: %v", err)
+	if r.connInfoIPv6Internet != nil {
+		if r.connInfoIPv6Internet.udpConn != nil {
+			if err := r.connInfoIPv6Internet.udpConn.Close(); err != nil {
+				log.Errorf("error closing UDP IPv6 connection: %v", err)
+			}
+		}
+		if r.connInfoIPv6Internet.tcpConn != nil {
+			if err := r.connInfoIPv6Internet.tcpConn.Close(); err != nil {
+				log.Errorf("error closing TCP IPv6 connection: %v", err)
+			}
 		}
 	}
-	if r.connInfoIPv4Loopback != nil && r.connInfoIPv4Loopback.udpConn != nil {
-		if err := r.connInfoIPv4Loopback.udpConn.Close(); err != nil {
-			log.Errorf("error closing IPv4 loopback connection: %v", err)
+	if r.connInfoIPv4Loopback != nil {
+		if r.connInfoIPv4Loopback.udpConn != nil {
+			if err := r.connInfoIPv4Loopback.udpConn.Close(); err != nil {
+				log.Errorf("error closing IPv4 UDP loopback connection: %v", err)
+			}
+		}
+		if r.connInfoIPv4Loopback.tcpConn != nil {
+			if err := r.connInfoIPv4Loopback.tcpConn.Close(); err != nil {
+				log.Errorf("error closing IPv4 TCP loopback connection: %v", err)
+			}
 		}
 	}
-	if r.connInfoIPv6Loopback != nil && r.connInfoIPv6Loopback.udpConn != nil {
-		if err := r.connInfoIPv6Loopback.udpConn.Close(); err != nil {
-			log.Errorf("error closing IPv6 loopback connection: %v", err)
+	if r.connInfoIPv6Loopback != nil {
+		if r.connInfoIPv6Loopback.udpConn != nil {
+			if err := r.connInfoIPv6Loopback.udpConn.Close(); err != nil {
+				log.Errorf("error closing IPv6 UDP loopback connection: %v", err)
+			}
+		}
+		if r.connInfoIPv6Loopback.tcpConn != nil {
+			if err := r.connInfoIPv6Loopback.tcpConn.Close(); err != nil {
+				log.Errorf("error closing IPv6 TCP loopback connection: %v", err)
+			}
 		}
 	}
 }

--- a/src/zdns/types.go
+++ b/src/zdns/types.go
@@ -15,9 +15,10 @@ package zdns
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"hash/fnv"
 	"net"
+
+	"github.com/pkg/errors"
 
 	"github.com/zmap/zdns/src/internal/util"
 )

--- a/src/zdns/types.go
+++ b/src/zdns/types.go
@@ -15,6 +15,8 @@ package zdns
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
+	"hash/fnv"
 	"net"
 
 	"github.com/zmap/zdns/src/internal/util"
@@ -120,6 +122,31 @@ func (ns *NameServer) String() string {
 		return fmt.Sprintf("[%s]:%d", ns.IP.String(), ns.Port)
 	}
 	return ""
+}
+
+func (ns *NameServer) Hash() (uint32, error) {
+	h := fnv.New32a()
+
+	// Hash the IP address
+	_, err := h.Write(ns.IP)
+	if err != nil {
+		return 0, errors.Wrap(err, "unable to hash IP address")
+	}
+
+	// Hash the Port
+	portBytes := []byte{byte(ns.Port >> 8), byte(ns.Port & 0xff)}
+	_, err = h.Write(portBytes)
+	if err != nil {
+		return 0, errors.Wrap(err, "unable to hash port")
+	}
+
+	// Hash the DomainName
+	_, err = h.Write([]byte(ns.DomainName))
+	if err != nil {
+		return 0, errors.Wrap(err, "unable to hash domain name")
+	}
+
+	return h.Sum32(), nil
 }
 
 func (ns *NameServer) PopulateDefaultPort(usingDoT, usingDoH bool) {


### PR DESCRIPTION
Adds "name server stickiness" to lookups so Resolvers will prioritize processing queries from the same nameserver to avoid having to re-handshake TCP/TLS/HTTPS.


## Changes
- added persistent TCP connections since they were created as one-offs before and immediately thrown away
    - As long as a nameserver matches the IP/Port of the existing TCP connection, it'll be re-used
- refactored `wireLookup` into `wireLookupTCP` and `wireLookupUDP` so the TCP variant could have connection info
- added a priority queue and a global queue for each worker. Workers will prioritize work from their priority queue (which all share a single nameserver) but if no work is available, they'll context switch to connecting to another nameserver from the global queue.
- Edge Cases
    - `AXFR` - `AXFR` is unique in that if the user doesn't provide a name server, it first does an NS lookups for that domain. This means we _should not_ suggest a NameServer for these lookups. It's a little gross, but I added a check inside the worker thread to discard the name server "suggestion" if we're doing AXFR. If a user specifies a name server (as opposed to our suggestion), this shouldn't be thrown away
    - To handle the case where we have more name servers (and ordinarily more `WorkerPools`) than workers, I capped the number of pools at the `--threads` count. Using nameservers > thread count will result in a performance penalty since we can't send the same name server lookups to the same workers anymore.

## Overview
In #431 (which this branch is based on, wanted to have this logic reviewed before merging into that to break up this larger feature), I added functionality with DoH and DoT connections that a given resolver would only re-handshake if the nameserver was different than the remote address on it's existing connection.

The issue is that in `ExternalLookup` [here](https://github.com/zmap/zdns/blob/main/src/zdns/resolver.go#L474), if the user didn't provide a nameserver then a random one would be selected. Let's look at an example to see how this causes us to unnecessarily tear-down connections:

`./zdns google.com yahoo.com eBay.com --threads=2 --name-servers=1.1.1.1,8.8.8.8` --tls
And let's say that after the random NS selection, this gives us
- google.com @1.1.1.1 with thread #0
- yahoo.com @8.8.8.8 with thread #0
- eBay.com @8.8.8.8 with thread #1

In this toy example, thread #0 would tear down it's TLS connection and re-establish one to `8.8.8.8` even though thread #1 already has a connection to `8.8.8.8`.

## Load Imbalance
As another design consideration, all external resolvers do not behave equally.


I measured the resolution time for 7k queries and to what resolver they were sent to.
```
        IP        mean          max         std  count
0  1.0.0.1   94.638474  3996.846985  243.672404   1752
1  1.1.1.1  112.375685  5456.484652  313.006790   1781
2  8.8.4.4   35.020819  2615.063632  101.810439   1732
3  8.8.8.8   31.811647  1253.615863   70.430397   1711
```

This led to the threads responsible for Google queries sitting idle while the Cloudflare ones were busy working. 

## Design
To address both re-using TCP connections and dealing with load imbalance, this PR implements a Priority and Global work queue.

A new `inputDeMultiplexor` chooses an external NS for each input line and passes it to the assigned priority queue. Each priority queue is for queries to a specific name-server, ex: @1.1.1.1. If the priority queue is full, then the demultiplexer will block on both the Priority/Global queue. In this way, we prioritize sending work to the threads which have a pre-existing connection to the name server, but also avoid large work imbalance issues.

Similarly, threads will prefer to read from their Priority queue, before blocking on both Priority and Global queues.

## Tradeoff: Work Imbalance vs. Connection Re-use

Every time a worker chooses a work item from the `Global` queue, it will have to re-handshake. However, without this Global/Priority queue split, workers with Priority on a very fast nameserver will sit idle when they could be doing work too. To showcase this, see the below experiment.

I ran an experiment to check different points on this spectrum:
- `main` - no TCP connection re-use
- `this branch` - first try to pull from Priority, then either Global/Priority
- 10 ms. wait - try to pull from Priority for 10 ms., then check either Global/Priority
- 1 s. wait

As the blocking time increases, the odds that a non-Priority thread will need to take an item from the Global queue to load-balance decreases. This decreases new TCP handshakes but increases the runtime.

<img width="1274" alt="image" src="https://github.com/user-attachments/assets/6ef7aaac-f258-4db7-911f-1c6088065003">

3x runs per condition
7,000 domains run with `"A", "--verbosity=3", "--threads=100", "--tcp-only", "--name-servers=1.1.1.1,1.0.0.1,8.8.8.8,8.8.4.4",`


## Unaffected
`--iterative` lookups will ignore this suggestion and chose a random root server. Since we don't support `--tls` or `--https` with `--iterative` anyway, this isn't a concern.

## Performance
Using the benchmark (7k domains), edited the command to use `./zdns A --name-servers=1.0.0.1,1.1.1.1,8.8.8.8,8.8.4.4 --threads=100` (external lookups)
- `main` branch
    - Normal, UDP-based - `8.31 s.` / 14,006 packets on lab VM (varies between 8-10s)
    - TCP-based - `9.82 s.` / 70,012 packets
- This branch
    - UDP-based - `6.60 s.`/ 14004 packets
    - TCP-based - `10.29 s.`/ 44,226 packets

## Testing
- Tested `--no-recycle-sockets --tcp-only` to be sure that we're not creating persistent TCP connections if the user doesn't want that