### PR TITLE
Fix linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.23'
       - name: Other lint
         run: |
           go install golang.org/x/tools/cmd/goimports@latest


### PR DESCRIPTION
Looks like the linter bumped it's required version to Go `1.23` based on [this](https://github.com/zmap/zdns/actions/runs/10799724962/job/29956125043). We still have the compilation/integration tests using our supported `v1.20` so this seems fine to me.