### PR TITLE
Fix `--dnssec` and add a test

### DIFF
--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -192,11 +192,7 @@ func (r *Resolver) followingLookup(ctx context.Context, q Question, nameServer *
 		// populateResults will parse the Answers and update the candidateSet, cnameSet, and garbage caching maps
 		populateResults(res.Answers, q.Type, candidateSet, cnameSet, dnameSet, garbage)
 		for _, ans := range res.Answers {
-			answer, ok := ans.(Answer)
-			if !ok {
-				continue
-			}
-			allAnswerSet = append(allAnswerSet, answer)
+			allAnswerSet = append(allAnswerSet, ans)
 		}
 
 		if isLookupComplete(originalName, candidateSet, cnameSet, dnameSet) {

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -191,9 +191,7 @@ func (r *Resolver) followingLookup(ctx context.Context, q Question, nameServer *
 
 		// populateResults will parse the Answers and update the candidateSet, cnameSet, and garbage caching maps
 		populateResults(res.Answers, q.Type, candidateSet, cnameSet, dnameSet, garbage)
-		for _, ans := range res.Answers {
-			allAnswerSet = append(allAnswerSet, ans)
-		}
+		allAnswerSet = append(allAnswerSet, res.Answers...)
 
 		if isLookupComplete(originalName, candidateSet, cnameSet, dnameSet) {
 			return &SingleQueryResult{

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1351,6 +1351,19 @@ class Tests(unittest.TestCase):
         self.assertEqual(res["results"]["A"]["data"]["resolver"], "8.8.8.8:53", "user-supplied name server with input "
                                                                                 "should take precedence")
 
+    def test_dnssec_option(self):
+        c = "A --dnssec --name-servers=1.0.0.1"
+        name = "cloudflare.com"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd, "A")
+        hasRRSIG = False
+        for record in res["results"]["A"]["data"]["answers"]:
+            if record["type"] == "RRSIG":
+                hasRRSIG = True
+                break
+        self.assertTrue(hasRRSIG, "DNSSEC option should return an RRSIG record")
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Noticed that `./zdns A Cloudflare.com --dnssec --name-servers=1.1.1.1` wasn't returning an RRSIG record like it should. This PR fixes that.

When adding the CNAME/DNAME following code, I checked the type on all records as `ans.(Answer)`. This meant that `RRSIGAnswer` (along with many other more complex types, I'm sure) wouldn't be captured.

This PR removes that type check and adds an integration test for DNSSEC.