### PR TITLE
Preserve TCP/TLS/HTTPS Connections

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -76,9 +76,11 @@ type NetworkOptions struct {
 	DisableRecycleSockets bool   `long:"no-recycle-sockets" description:"do not create long-lived unbound UDP socket for each thread at launch and reuse for all (UDP) queries"`
 	PreferIPv4Iteration   bool   `long:"prefer-ipv4-iteration" description:"Prefer IPv4/A record lookups during iterative resolution. Ignored unless used with both IPv4 and IPv6 query transport"`
 	PreferIPv6Iteration   bool   `long:"prefer-ipv6-iteration" description:"Prefer IPv6/AAAA record lookups during iterative resolution. Ignored unless used with both IPv4 and IPv6 query transport"`
+	RootCAsFile           string `long:"root-cas-file" description:"Path to a file containing PEM-encoded root CAs to use for verifying server certificates, required for --verify-server-cert"`
 	TCPOnly               bool   `long:"tcp-only" description:"Only perform lookups over TCP"`
 	DNSOverTLS            bool   `long:"tls" description:"Use DNS over TLS for lookups, mutually exclusive with --udp-only, --iterative, and --https"`
 	UDPOnly               bool   `long:"udp-only" description:"Only perform lookups over UDP"`
+	VerifyServerCert      bool   `long:"verify-server-cert" description:"Verify the server's certificate when using DNS over TLS or DNS over HTTPS"`
 }
 
 // InputOutputOptions options for controlling the input and output behavior of zdns. Applicable to all modules.

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -663,7 +663,7 @@ WorkerLoop:
 				break WorkerLoop
 			}
 			handleWorkerInput(gc, rc, task, resolver, &metadata, output)
-		case <-time.After(time.Millisecond * 10):
+		default:
 			// No tasks in its own resolver, wait on either
 			select {
 			case task, ok = <-preferredWorkChan:

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -511,8 +511,9 @@ func Run(gc CLIConf) {
 	// de-dupe
 	nsLookupMap := make(map[uint32]struct{})
 	uniqNameServers := make([]zdns.NameServer, 0, len(nameServers))
+	var hash uint32
 	for _, ns := range nameServers {
-		hash, err := ns.Hash()
+		hash, err = ns.Hash()
 		if err != nil {
 			log.Fatalf("could not hash name server %s: %v", ns.String(), err)
 		}

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -663,7 +663,7 @@ WorkerLoop:
 				break WorkerLoop
 			}
 			handleWorkerInput(gc, rc, task, resolver, &metadata, output)
-		default:
+		case <-time.After(time.Millisecond * 10):
 			// No tasks in its own resolver, wait on either
 			select {
 			case task, ok = <-preferredWorkChan:

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -17,7 +17,6 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
-	"github.com/zmap/zcrypto/x509"
 	"io"
 	"math/rand"
 	"net"
@@ -27,6 +26,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/zmap/zcrypto/x509"
 
 	"github.com/hashicorp/go-version"
 	"github.com/liip/sheriff"

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -441,7 +441,7 @@ type WorkerPools struct {
 func NewWorkerPools(numPools int) *WorkerPools {
 	workerPools := make([]chan *InputLineWithNameServer, numPools)
 	for i := 0; i < numPools; i++ {
-		workerPools[i] = make(chan *InputLineWithNameServer)
+		workerPools[i] = make(chan *InputLineWithNameServer, 10)
 	}
 	return &WorkerPools{WorkerPools: workerPools}
 }

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -458,7 +458,6 @@ type InputLineWithNameServer struct {
 // The goal is that a query for a single name server will consistently go to the same worker pool which 1+ threads will read from
 // This is especially useful for TLS/TCP/HTTPS based lookups where repeating the initial handshakes would be wasteful
 func inputDeMultiplexer(nameServers []zdns.NameServer, inChan <-chan string, workerPools *WorkerPools, wg *sync.WaitGroup) error {
-	wg.Add(1)
 	defer wg.Done()
 	// defer closing the worker pool chans
 	defer func() {
@@ -553,12 +552,16 @@ func Run(gc CLIConf) {
 			log.Fatal(fmt.Sprintf("could not feed input channel: %v", inErr))
 		}
 	}()
-	go func() {
-		plexErr := inputDeMultiplexer(uniqNameServers, inChan, workerPools, &routineWG)
-		if plexErr != nil {
-			log.Fatal(fmt.Sprintf("could not de-multiplex input channel: %v", plexErr))
-		}
-	}()
+	const numberOfDeMultiplexers = 5
+	for i := 0; i < numberOfDeMultiplexers; i++ {
+		go func() {
+			plexErr := inputDeMultiplexer(uniqNameServers, inChan, workerPools, &routineWG)
+			if plexErr != nil {
+				log.Fatal(fmt.Sprintf("could not de-multiplex input channel: %v", plexErr))
+			}
+		}()
+	}
+	routineWG.Add(numberOfDeMultiplexers)
 	go func() {
 		outErr := outHandler.WriteResults(outChan, &routineWG)
 		if outErr != nil {

--- a/src/modules/spf/spf.go
+++ b/src/modules/spf/spf.go
@@ -48,8 +48,8 @@ func (spfMod *SpfLookupModule) CLIInit(gc *cli.CLIConf, rc *zdns.ResolverConfig)
 	return spfMod.BasicLookupModule.CLIInit(gc, rc)
 }
 
-func (spfMod *SpfLookupModule) Lookup(r *zdns.Resolver, name string, resolver *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
-	innerRes, trace, status, err := spfMod.BasicLookupModule.Lookup(r, name, resolver)
+func (spfMod *SpfLookupModule) Lookup(r *zdns.Resolver, name string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
+	innerRes, trace, status, err := spfMod.BasicLookupModule.Lookup(r, name, nameServer)
 	castedInnerRes, ok := innerRes.(*zdns.SingleQueryResult)
 	if !ok {
 		return nil, trace, status, errors.New("lookup didn't return a single query result type")

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -651,6 +651,7 @@ func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, na
 		if err != nil && err.Error() == "EOF" {
 			// EOF error means the connection was closed, we'll remove the connection (it'll be recreated on the next iteration)
 			// and try again
+			log.Errorf("EOF error on TCP connection to %s, retrying", nameServer.String())
 			err = connInfo.tcpConn.Conn.Close()
 			if err != nil {
 				log.Errorf("error closing TCP connection: %v", err)

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -456,10 +456,10 @@ func (r *Resolver) retryingLookup(ctx context.Context, q Question, nameServer *N
 			result, status, err = wireLookupUDP(ctx, connInfo, q, nameServer, r.ednsOptions, recursive, r.dnsSecEnabled, r.checkingDisabledBit)
 			if status == StatusTruncated && connInfo.tcpClient != nil {
 				// result truncated, try again with TCP
-				result, status, err = wireLookupTCP(ctx, connInfo, q, nameServer, r.ednsOptions, recursive, r.dnsSecEnabled, r.checkingDisabledBit, true)
+				result, status, err = wireLookupTCP(ctx, connInfo, q, nameServer, r.ednsOptions, recursive, r.dnsSecEnabled, r.checkingDisabledBit)
 			}
 		} else if connInfo.tcpClient != nil {
-			result, status, err = wireLookupTCP(ctx, connInfo, q, nameServer, r.ednsOptions, recursive, r.dnsSecEnabled, r.checkingDisabledBit, true)
+			result, status, err = wireLookupTCP(ctx, connInfo, q, nameServer, r.ednsOptions, recursive, r.dnsSecEnabled, r.checkingDisabledBit)
 		} else {
 			return SingleQueryResult{}, StatusError, 0, errors.New("no connection info for nameserver")
 		}
@@ -622,7 +622,7 @@ func doDoHLookup(ctx context.Context, httpClient *http.Client, q Question, nameS
 }
 
 // wireLookupTCP performs a DNS lookup on-the-wire over TCP with the given parameters
-func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, ednsOptions []dns.EDNS0, recursive, dnssec, checkingDisabled, retryOnConnClosing bool) (SingleQueryResult, Status, error) {
+func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, ednsOptions []dns.EDNS0, recursive, dnssec, checkingDisabled bool) (SingleQueryResult, Status, error) {
 	res := SingleQueryResult{Answers: []interface{}{}, Authorities: []interface{}{}, Additional: []interface{}{}}
 	res.Resolver = nameServer.String()
 
@@ -648,7 +648,7 @@ func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, na
 			return SingleQueryResult{}, StatusError, fmt.Errorf("could not resolve TCP address %s: %v", nameServer.String(), err)
 		}
 		r, _, err = connInfo.tcpClient.ExchangeWithConnToContext(ctx, m, connInfo.tcpConn, addr)
-		if retryOnConnClosing && err != nil && err.Error() == "EOF" {
+		if err != nil && err.Error() == "EOF" {
 			// EOF error means the connection was closed, we'll remove the connection (it'll be recreated on the next iteration)
 			// and try again
 			err = connInfo.tcpConn.Conn.Close()

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -657,7 +657,7 @@ func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, na
 			return wireLookupTCP(ctx, connInfo, q, nameServer, ednsOptions, recursive, dnssec, checkingDisabled, false)
 		}
 	} else {
-		// no pre-existing connection, create a ephemeral one
+		// no pre-existing connection, create an ephemeral one
 		res.Protocol = "tcp"
 		r, _, err = connInfo.tcpClient.ExchangeContext(ctx, m, nameServer.String())
 	}

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -472,7 +472,6 @@ func (r *Resolver) retryingLookup(ctx context.Context, q Question, nameServer *N
 }
 
 func doDoTLookup(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, recursive bool, ednsOptions []dns.EDNS0, dnssec bool, checkingDisabled bool) (SingleQueryResult, Status, error) {
-	return SingleQueryResult{}, StatusError, errors.New("DoT not implemented")
 	m := new(dns.Msg)
 	m.SetQuestion(dotName(q.Name), q.Type)
 	m.Question[0].Qclass = q.Class
@@ -624,6 +623,7 @@ func doDoHLookup(ctx context.Context, httpClient *http.Client, q Question, nameS
 
 // wireLookupTCP performs a DNS lookup on-the-wire over TCP with the given parameters
 func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, ednsOptions []dns.EDNS0, recursive, dnssec, checkingDisabled, retryOnConnClosing bool) (SingleQueryResult, Status, error) {
+	return SingleQueryResult{}, StatusError, errors.New("TCP not implemented")
 	res := SingleQueryResult{Answers: []interface{}{}, Authorities: []interface{}{}, Additional: []interface{}{}}
 	res.Resolver = nameServer.String()
 

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -16,17 +16,16 @@ package zdns
 import (
 	"context"
 	"fmt"
-	"io"
-	"net"
-	"regexp"
-	"strings"
-
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/dns"
 	"github.com/zmap/zcrypto/tls"
 	"github.com/zmap/zgrab2/lib/http"
 	"github.com/zmap/zgrab2/lib/output"
+	"io"
+	"net"
+	"regexp"
+	"strings"
 
 	"github.com/zmap/zdns/src/internal/util"
 )
@@ -623,7 +622,6 @@ func doDoHLookup(ctx context.Context, httpClient *http.Client, q Question, nameS
 
 // wireLookupTCP performs a DNS lookup on-the-wire over TCP with the given parameters
 func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, ednsOptions []dns.EDNS0, recursive, dnssec, checkingDisabled, retryOnConnClosing bool) (SingleQueryResult, Status, error) {
-	return SingleQueryResult{}, StatusError, errors.New("TCP not implemented")
 	res := SingleQueryResult{Answers: []interface{}{}, Authorities: []interface{}{}, Additional: []interface{}{}}
 	res.Resolver = nameServer.String()
 

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -651,7 +651,6 @@ func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, na
 		if err != nil && err.Error() == "EOF" {
 			// EOF error means the connection was closed, we'll remove the connection (it'll be recreated on the next iteration)
 			// and try again
-			log.Errorf("EOF error on TCP connection to %s, retrying", nameServer.String())
 			err = connInfo.tcpConn.Conn.Close()
 			if err != nil {
 				log.Errorf("error closing TCP connection: %v", err)

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -16,16 +16,17 @@ package zdns
 import (
 	"context"
 	"fmt"
+	"io"
+	"net"
+	"regexp"
+	"strings"
+
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/dns"
 	"github.com/zmap/zcrypto/tls"
 	"github.com/zmap/zgrab2/lib/http"
 	"github.com/zmap/zgrab2/lib/output"
-	"io"
-	"net"
-	"regexp"
-	"strings"
 
 	"github.com/zmap/zdns/src/internal/util"
 )

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -700,7 +700,6 @@ func wireLookupUDP(ctx context.Context, connInfo *ConnectionInfo, q Question, na
 	} else {
 		r, _, err = connInfo.udpClient.ExchangeContext(ctx, m, nameServer.String())
 	}
-	// if record comes back truncated, but we have a TCP connection, try again with that
 	if r != nil && (r.Truncated || r.Rcode == dns.RcodeBadTrunc) {
 		return res, StatusTruncated, err
 	}

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -472,6 +472,7 @@ func (r *Resolver) retryingLookup(ctx context.Context, q Question, nameServer *N
 }
 
 func doDoTLookup(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, recursive bool, ednsOptions []dns.EDNS0, dnssec bool, checkingDisabled bool) (SingleQueryResult, Status, error) {
+	return SingleQueryResult{}, StatusError, errors.New("DoT not implemented")
 	m := new(dns.Msg)
 	m.SetQuestion(dotName(q.Name), q.Type)
 	m.Question[0].Qclass = q.Class

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -16,11 +16,12 @@ package zdns
 import (
 	"context"
 	"fmt"
-	"github.com/zmap/zcrypto/x509"
 	"io"
 	"net"
 	"regexp"
 	"strings"
+
+	"github.com/zmap/zcrypto/x509"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -113,11 +113,11 @@ func (rc *ResolverConfig) Validate() error {
 	// External Nameservers
 	if rc.IPVersionMode != IPv6Only && len(rc.ExternalNameServersV4) == 0 {
 		// If IPv4 is supported, we require at least one IPv4 external nameserver
-		return errors.New("must have at least one external IPv4 name server if IPv4 mode is enabled")
+		return errors.New("must have at least one external IPv4 name server if IPv4 mode is enabled. Use IPv6 only if you don't have IPv4 nameservers")
 	}
 	if rc.IPVersionMode != IPv4Only && len(rc.ExternalNameServersV6) == 0 {
 		// If IPv6 is supported, we require at least one IPv6 external nameserver
-		return errors.New("must have at least one external IPv6 name server if IPv6 mode is enabled")
+		return errors.New("must have at least one external IPv6 name server if IPv6 mode is enabled. Use IPv4 only if you don't have IPv6 nameservers")
 	}
 
 	// Validate all nameservers have ports and are valid IPs

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -113,11 +113,11 @@ func (rc *ResolverConfig) Validate() error {
 	// External Nameservers
 	if rc.IPVersionMode != IPv6Only && len(rc.ExternalNameServersV4) == 0 {
 		// If IPv4 is supported, we require at least one IPv4 external nameserver
-		return errors.New("must have at least one external IPv4 name server if IPv4 mode is enabled. Use IPv6 only if you don't have IPv4 nameservers")
+		return errors.New("must have at least one external IPv4 name server if IPv4 mode is enabled. Use IPv6-only if you don't have IPv4 nameservers")
 	}
 	if rc.IPVersionMode != IPv4Only && len(rc.ExternalNameServersV6) == 0 {
 		// If IPv6 is supported, we require at least one IPv6 external nameserver
-		return errors.New("must have at least one external IPv6 name server if IPv6 mode is enabled. Use IPv4 only if you don't have IPv6 nameservers")
+		return errors.New("must have at least one external IPv6 name server if IPv6 mode is enabled. Use IPv4-only if you don't have IPv6 nameservers")
 	}
 
 	// Validate all nameservers have ports and are valid IPs
@@ -234,7 +234,7 @@ type ConnectionInfo struct {
 	udpClient    *dns.Client
 	tcpClient    *dns.Client
 	udpConn      *dns.Conn            // for socket re-use with UDP
-	tcpConn      *dns.Conn            // for socket re-use with TCP, if RemoteAddr doesn't change, we don't re-handshake
+	tcpConn      *dns.Conn            // for socket re-use with TCP
 	httpsClient  *http.Client         // for DoH
 	tlsConn      *dns.Conn            // for DoT
 	tlsHandshake *tls.ServerHandshake // for DoT, used to print TLS handshake to user

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -16,11 +16,12 @@ package zdns
 
 import (
 	"fmt"
-	"github.com/zmap/zcrypto/x509"
 	"math/rand"
 	"net"
 	"strings"
 	"time"
+
+	"github.com/zmap/zcrypto/x509"
 
 	"github.com/pkg/errors"
 

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -531,6 +531,12 @@ func (r *Resolver) getConnectionInfo(nameServer *NameServer) (*ConnectionInfo, e
 }
 
 func getNewTCPConn(nameServer *NameServer, connInfo *ConnectionInfo) error {
+	// close any existing TCP connection
+	if connInfo.tcpConn != nil {
+		if err := connInfo.tcpConn.Close(); err != nil {
+			return fmt.Errorf("error closing existing TCP connection: %w", err)
+		}
+	}
 	// create persistent TCP connection to nameserver
 	conn, err := net.DialTCP("tcp", &net.TCPAddr{IP: connInfo.localAddr}, &net.TCPAddr{IP: nameServer.IP, Port: int(nameServer.Port)})
 	if err != nil {
@@ -583,24 +589,52 @@ func (r *Resolver) IterativeLookup(q *Question) (*SingleQueryResult, Trace, Stat
 // Close cleans up any resources used by the resolver. This should be called when the resolver is no longer needed.
 // Lookup will panic if called after Close.
 func (r *Resolver) Close() {
-	if r.connInfoIPv4Internet != nil && r.connInfoIPv4Internet.udpConn != nil {
-		if err := r.connInfoIPv4Internet.udpConn.Close(); err != nil {
-			log.Errorf("error closing IPv4 connection: %v", err)
+	if r.connInfoIPv4Internet != nil {
+		if r.connInfoIPv4Internet.udpConn != nil {
+			if err := r.connInfoIPv4Internet.udpConn.Close(); err != nil {
+				log.Errorf("error closing UDP IPv4 connection: %v", err)
+			}
+		}
+		if r.connInfoIPv4Internet.tcpConn != nil {
+			if err := r.connInfoIPv4Internet.tcpConn.Close(); err != nil {
+				log.Errorf("error closing TCP IPv4 connection: %v", err)
+			}
 		}
 	}
-	if r.connInfoIPv6Internet != nil && r.connInfoIPv6Internet.udpConn != nil {
-		if err := r.connInfoIPv6Internet.udpConn.Close(); err != nil {
-			log.Errorf("error closing IPv6 connection: %v", err)
+	if r.connInfoIPv6Internet != nil {
+		if r.connInfoIPv6Internet.udpConn != nil {
+			if err := r.connInfoIPv6Internet.udpConn.Close(); err != nil {
+				log.Errorf("error closing UDP IPv6 connection: %v", err)
+			}
+		}
+		if r.connInfoIPv6Internet.tcpConn != nil {
+			if err := r.connInfoIPv6Internet.tcpConn.Close(); err != nil {
+				log.Errorf("error closing TCP IPv6 connection: %v", err)
+			}
 		}
 	}
-	if r.connInfoIPv4Loopback != nil && r.connInfoIPv4Loopback.udpConn != nil {
-		if err := r.connInfoIPv4Loopback.udpConn.Close(); err != nil {
-			log.Errorf("error closing IPv4 loopback connection: %v", err)
+	if r.connInfoIPv4Loopback != nil {
+		if r.connInfoIPv4Loopback.udpConn != nil {
+			if err := r.connInfoIPv4Loopback.udpConn.Close(); err != nil {
+				log.Errorf("error closing IPv4 UDP loopback connection: %v", err)
+			}
+		}
+		if r.connInfoIPv4Loopback.tcpConn != nil {
+			if err := r.connInfoIPv4Loopback.tcpConn.Close(); err != nil {
+				log.Errorf("error closing IPv4 TCP loopback connection: %v", err)
+			}
 		}
 	}
-	if r.connInfoIPv6Loopback != nil && r.connInfoIPv6Loopback.udpConn != nil {
-		if err := r.connInfoIPv6Loopback.udpConn.Close(); err != nil {
-			log.Errorf("error closing IPv6 loopback connection: %v", err)
+	if r.connInfoIPv6Loopback != nil {
+		if r.connInfoIPv6Loopback.udpConn != nil {
+			if err := r.connInfoIPv6Loopback.udpConn.Close(); err != nil {
+				log.Errorf("error closing IPv6 UDP loopback connection: %v", err)
+			}
+		}
+		if r.connInfoIPv6Loopback.tcpConn != nil {
+			if err := r.connInfoIPv6Loopback.tcpConn.Close(); err != nil {
+				log.Errorf("error closing IPv6 TCP loopback connection: %v", err)
+			}
 		}
 	}
 }

--- a/src/zdns/types.go
+++ b/src/zdns/types.go
@@ -15,9 +15,10 @@ package zdns
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"hash/fnv"
 	"net"
+
+	"github.com/pkg/errors"
 
 	"github.com/zmap/zdns/src/internal/util"
 )

--- a/src/zdns/types.go
+++ b/src/zdns/types.go
@@ -15,10 +15,7 @@ package zdns
 
 import (
 	"fmt"
-	"hash/fnv"
 	"net"
-
-	"github.com/pkg/errors"
 
 	"github.com/zmap/zdns/src/internal/util"
 )
@@ -123,31 +120,6 @@ func (ns *NameServer) String() string {
 		return fmt.Sprintf("[%s]:%d", ns.IP.String(), ns.Port)
 	}
 	return ""
-}
-
-func (ns *NameServer) Hash() (uint32, error) {
-	h := fnv.New32a()
-
-	// Hash the IP address
-	_, err := h.Write(ns.IP)
-	if err != nil {
-		return 0, errors.Wrap(err, "unable to hash IP address")
-	}
-
-	// Hash the Port
-	portBytes := []byte{byte(ns.Port >> 8), byte(ns.Port & 0xff)}
-	_, err = h.Write(portBytes)
-	if err != nil {
-		return 0, errors.Wrap(err, "unable to hash port")
-	}
-
-	// Hash the DomainName
-	_, err = h.Write([]byte(ns.DomainName))
-	if err != nil {
-		return 0, errors.Wrap(err, "unable to hash domain name")
-	}
-
-	return h.Sum32(), nil
 }
 
 func (ns *NameServer) PopulateDefaultPort(usingDoT, usingDoH bool) {

--- a/src/zdns/types.go
+++ b/src/zdns/types.go
@@ -15,6 +15,8 @@ package zdns
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
+	"hash/fnv"
 	"net"
 
 	"github.com/zmap/zdns/src/internal/util"
@@ -120,6 +122,31 @@ func (ns *NameServer) String() string {
 		return fmt.Sprintf("[%s]:%d", ns.IP.String(), ns.Port)
 	}
 	return ""
+}
+
+func (ns *NameServer) Hash() (uint32, error) {
+	h := fnv.New32a()
+
+	// Hash the IP address
+	_, err := h.Write(ns.IP)
+	if err != nil {
+		return 0, errors.Wrap(err, "unable to hash IP address")
+	}
+
+	// Hash the Port
+	portBytes := []byte{byte(ns.Port >> 8), byte(ns.Port & 0xff)}
+	_, err = h.Write(portBytes)
+	if err != nil {
+		return 0, errors.Wrap(err, "unable to hash port")
+	}
+
+	// Hash the DomainName
+	_, err = h.Write([]byte(ns.DomainName))
+	if err != nil {
+		return 0, errors.Wrap(err, "unable to hash domain name")
+	}
+
+	return h.Sum32(), nil
 }
 
 func (ns *NameServer) PopulateDefaultPort(usingDoT, usingDoH bool) {


### PR DESCRIPTION
## Changes
With `--tls`, `--tcp-only`, and `--https` in `--iterative=false`,each thread/`Resolver` will pick a random NameServer at the beginning. For subsequent lookups, If the user doesn't over-ride this (echo "google.com,1.1.1.1" | ./zdns) the resolver will just re-use the connection.

As an example:


`./zdns google.com eBay.com amazon.com yahoo.com --threads=1 --name-servers=1.1.1.1,8.8.8.8 --tcp-only`


1. Thread #1 starts, chooses `1.1.1.1` as the name-server, sets up a TCP connection to Cloudflare and queries for google.com
2. Thread #2 starts, chooses `8.8.8.8` as the name-server, sets up a TCP conn. to Google, and queries for eBay.com
3. Thread #1 re-uses connection to Cloudflare, queries for amazon.com
4. Thread #2 re-uses connection to Google, queries for yahoo.com

## Server-Cert Verification
Similar to ZGrab2, we have `--verify-server-cert` and `--root-cas-file` to allow the TLS library to verify the recursive resolvers cert.


```
$ echo "cloudflare.com" | ./zdns A --threads=2 --https --verify-server-cert --root-cas-file="/Users/phillip/Desktop/macos-root-certs.pem" 
{"name":"cloudflare.com","results":{"A":{"data":{"additionals":[{"flags":"","type":"EDNS0","udpsize":512,"version":0}],"answers":[{"answer":"104.16.133.229","class":"IN","name":"cloudflare.com","ttl":300,"type":"A"},{"answer":"104.16.132.229","class":"IN","name":"cloudflare.com","ttl":300,"type":"A"}],"protocol":"DoH","resolver":"dns.google","tls_handshake":{"handshake_log":{"client_finished":{"verify_data":"IlEzQTdWZXJjME5iaS85Lzci"},"client_key_exchange":{"ecdh_params":{"client_private":{"length":32,"value":"IkN6N0dmT2FGNTFhZXpoNkl3Y3Q4aXhxejROUlVQRkZ1OVJOL2FTYjBPZnc9Ig=="},"client_public":{"X":{},"Y":{}},"curve_id":23}},"key_material":{"master_secret":{"length":48,"value":"IkZ1L2lzK21YSDVoYUk3bVZ3RTd4dVN6aTB6eHhPUzNSRDBiekxnSWRjb05jUUZ0d2tweFBlb3NKKzJLbHB4blki"},"pre_master_secret":{"length":32,"value":"IjN0ZTdkZmRLQ0grWm5qSXFyVjVxQzJ1cFFXQ2ZSb2xsWVZwMnB4VFJPeUk9Ig=="}},"server_certificates":{"certificate":{"parsed":{"AuthorityKeyId":"IjNoc2U3WGtWMUQ0M0pNTWh1K3cwT1cxQ3NqQT0i","BasicConstraintsValid":true,"CABFOrganizationIdentifier":null,"CPSuri":[[]],"CRLDistributionPoints":["http://c.pki.goog/wr2/GSyT1N4PBrg.crl"],"DNSNames":["dns.google","dns.google.com","*.dns.google.com","8888.google","dns64.dns.google"],"DirectoryNames":[],"EDIPartyNames":[],"EmailAddresses":[],"ExcludedDNSNames":[],"ExcludedDirectoryNames":[],"ExcludedEdiPartyNames":[],"ExcludedEmailAddresses":[],"ExcludedIPAddresses":[],"ExcludedRegisteredIDs":[],"ExcludedURIs":[],"ExcludedX400Addresses":[],"ExplicitTexts":[[]],"ExtKeyUsage":[48],"Extensions":[{"Critical":true,"Id":[2,5,29,15],"Value":"IkF3SUhnQT09Ig=="},{"Critical":false,"Id":[2,5,29,37],"Value":"Ik1Bb0dDQ3NHQVFVRkJ3TUIi"},{"Critical":true,"Id":[2,5,29,19],"Value":"Ik1BQT0i"},{"Critical":false,"Id":[2,5,29,14],"Value":"IkJCUzl1WnZsck5mRnd2M2JDbGdmQnVFNEhwbzFnUT09Ig=="},{"Critical":false,"Id":[2,5,29,35],"Value":"Ik1CYUFGTjRiSHUxNUZkUStOeVRESWJ2c05EbHRRckl3Ig=="},{"Critical":false,"Id":[1,3,6,1,5,5,7,1,1],"Value":"Ik1Fb3dJUVlJS3dZQkJRVUhNQUdHRldoMGRIQTZMeTl2TG5CcmFTNW5iMjluTDNkeU1qQWxCZ2dyQmdFRkJRY3dBb1laYUhSMGNEb3ZMMmt1Y0d0cExtZHZiMmN2ZDNJeUxtTnlkQT09Ig=="},{"Critical":false,"Id":[2,5,29,17],"Value":"Ik1JR2hnZ3BrYm5NdVoyOXZaMnhsZ2c1a2JuTXVaMjl2WjJ4bExtTnZiWUlRS2k1a2JuTXVaMjl2WjJ4bExtTnZiWUlMT0RnNE9DNW5iMjluYkdXQ0VHUnVjelkwTG1SdWN5NW5iMjluYkdXSEJBZ0lDQWlIQkFnSUJBU0hFQ0FCU0dCSVlBQUFBQUFBQUFBQWlJaUhFQ0FCU0dCSVlBQUFBQUFBQUFBQWlFU0hFQ0FCU0dCSVlBQUFBQUFBQUFBQVpHU0hFQ0FCU0dCSVlBQUFBQUFBQUFBQUFHUT0i"},{"Critical":false,"Id":[2,5,29,32],"Value":"Ik1Bb3dDQVlHWjRFTUFRSUIi"},{"Critical":false,"Id":[2,5,29,31],"Value":"Ik1DMHdLNkFwb0NlR0pXaDBkSEE2THk5akxuQnJhUzVuYjI5bkwzZHlNaTlIVTNsVU1VNDBVRUp5Wnk1amNtdz0i"},{"Critical":false,"Id":[1,3,6,1,4,1,11129,2,4,2],"Value":"IkJJSHhBTzhBZGdCMi80Zy9DcmI3bFZIQ1ljejFoN28wdEtUTnV5bmNhRUlLbitablRGbzZkQUFBQVpGRnJDenVBQUFFQXdCSE1FVUNJQm1Ia1NQY1FBcXdMa0U3bWp1TGFpKzFDTkc0ZlRRWEFnR25YKzNldng3c0FpRUExU25HSDhrRE1vQXVVc29IMG5OZS9pOXJ2TllnNFZROEFIbi9UQ2RWbXNJQWRRRGF0cjlyUDdXMklwK2J3cnRjYStod2tYRnN1MUdFaFRTOXBEMHdTTmY3cXdBQUFaRkZyRERPQUFBRUF3QkdNRVFDSUREcVBvUCsrQjl6N3hvdmcxZTVRRWg2dTZBRU1RTi9HdVl6UXMrbzlCVFFBaUJiSHJSenlVU3BIMkMvNFhHTXF2WE55ZE9mS0xzcVFFaFZsTFpSRk5oOENRPT0i"}],"ExtensionsMap":{"1.3.6.1.4.1.11129.2.4.2":{"Critical":false,"Id":[1,3,6,1,4,1,11129,2,4,2],"Value":"IkJJSHhBTzhBZGdCMi80Zy9DcmI3bFZIQ1ljejFoN28wdEtUTnV5bmNhRUlLbitablRGbzZkQUFBQVpGRnJDenVBQUFFQXdCSE1FVUNJQm1Ia1NQY1FBcXdMa0U3bWp1TGFpKzFDTkc0ZlRRWEFnR25YKzNldng3c0FpRUExU25HSDhrRE1vQXVVc29IMG5OZS9pOXJ2TllnNFZROEFIbi9UQ2RWbXNJQWRRRGF0cjlyUDdXMklwK2J3cnRjYStod2tYRnN1MUdFaFRTOXBEMHdTTmY3cXdBQUFaRkZyRERPQUFBRUF3QkdNRVFDSUREcVBvUCsrQjl6N3hvdmcxZTVRRWg2dTZBRU1RTi9HdVl6UXMrbzlCVFFBaUJiSHJSenlVU3BIMkMvNFhHTXF2WE55ZE9mS0xzcVFFaFZsTFpSRk5oOENRPT0i"},"1.3.6.1.5.5.7.1.1":{"Critical":false,"Id":[1,3,6,1,5,5,7,1,1],"Value":"Ik1Fb3dJUVlJS3dZQkJRVUhNQUdHRldoMGRIQTZMeTl2TG5CcmFTNW5iMjluTDNkeU1qQWxCZ2dyQmdFRkJRY3dBb1laYUhSMGNEb3ZMMmt1Y0d0cExtZHZiMmN2ZDNJeUxtTnlkQT09Ig=="},"2.5.29.14":{"Critical":false,"Id":[2,5,29,14],"Value":"IkJCUzl1WnZsck5mRnd2M2JDbGdmQnVFNEhwbzFnUT09Ig=="},"2.5.29.15":{"Critical":true,"Id":[2,5,29,15],"Value":"IkF3SUhnQT09Ig=="},"2.5.29.17":{"Critical":false,"Id":[2,5,29,17],"Value":"Ik1JR2hnZ3BrYm5NdVoyOXZaMnhsZ2c1a2JuTXVaMjl2WjJ4bExtTnZiWUlRS2k1a2JuTXVaMjl2WjJ4bExtTnZiWUlMT0RnNE9DNW5iMjluYkdXQ0VHUnVjelkwTG1SdWN5NW5iMjluYkdXSEJBZ0lDQWlIQkFnSUJBU0hFQ0FCU0dCSVlBQUFBQUFBQUFBQWlJaUhFQ0FCU0dCSVlBQUFBQUFBQUFBQWlFU0hFQ0FCU0dCSVlBQUFBQUFBQUFBQVpHU0hFQ0FCU0dCSVlBQUFBQUFBQUFBQUFHUT0i"},"2.5.29.19":{"Critical":true,"Id":[2,5,29,19],"Value":"Ik1BQT0i"},"2.5.29.31":{"Critical":false,"Id":[2,5,29,31],"Value":"Ik1DMHdLNkFwb0NlR0pXaDBkSEE2THk5akxuQnJhUzVuYjI5bkwzZHlNaTlIVTNsVU1VNDBVRUp5Wnk1amNtdz0i"},"2.5.29.32":{"Critical":false,"Id":[2,5,29,32],"Value":"Ik1Bb3dDQVlHWjRFTUFRSUIi"},"2.5.29.35":{"Critical":false,"Id":[2,5,29,35],"Value":"Ik1CYUFGTjRiSHUxNUZkUStOeVRESWJ2c05EbHRRckl3Ig=="},"2.5.29.37":{"Critical":false,"Id":[2,5,29,37],"Value":"Ik1Bb0dDQ3NHQVFVRkJ3TUIi"}},"ExtraExtensions":[],"FailedToParseNames":[],"FingerprintMD5":"ImpsTVdZaEZzOFRiM1RxNE5EYWxVSFE9PSI=","FingerprintNoCT":"IktJLzBpa2Y4UlFhTzFYNDRVZ21SdnlKVVRHRlVsaXFBRWpING9WSDFVb3M9Ig==","FingerprintSHA1":"Ims1L1ZXVE8wUFd5eHNIMmJ1aEQ3N1p6akcvYz0i","FingerprintSHA256":"IkV5L3V0ZjFFQ1IzcmRTOGRyY1FORkhkVTRVRWJLWTVxMWV2MkxWYWNENVk9Ig==","IANDNSNames":[],"IANDirectoryNames":[],"IANEDIPartyNames":[],"IANEmailAddresses":[],"IANIPAddresses":[],"IANOtherNames":[],"IANRegisteredIDs":[],"IANURIs":[],"IPAddresses":["8.8.8.8","8.8.4.4","2001:4860:4860::8888","2001:4860:4860::8844","2001:4860:4860::6464","2001:4860:4860::64"],"IsCA":false,"IsPrecert":false,"Issuer":{"Country":["US"],"Organization":["Google Trust Services"],"OrganizationalUnit":null,"Locality":null,"Province":null,"StreetAddress":null,"PostalCode":null,"DomainComponent":null,"EmailAddress":null,"SerialNumber":"","CommonName":"WR2","SerialNumbers":null,"CommonNames":["WR2"],"GivenName":null,"Surname":null,"OrganizationIDs":null,"JurisdictionLocality":null,"JurisdictionProvince":null,"JurisdictionCountry":null,"Names":[{"type":"2.5.4.6","value":"US"},{"type":"2.5.4.10","value":"Google Trust Services"},{"type":"2.5.4.3","value":"WR2"}],"ExtraNames":null,"OriginalRDNS":[[{"type":"2.5.4.6","value":"US"}],[{"type":"2.5.4.10","value":"Google Trust Services"}],[{"type":"2.5.4.3","value":"WR2"}]]},"IssuerUniqueId":{"BitLength":0,"Bytes":[]},"IssuingCertificateURL":["http://i.pki.goog/wr2.crt"],"KeyUsage":{"digital_signature":true,"value":1},"MaxPathLen":-1,"MaxPathLenZero":false,"NameConstraintsCritical":false,"NotAfter":"2024-11-04T07:19:54Z","NotBefore":"2024-08-12T07:19:55Z","NoticeRefNumbers":[[]],"NoticeRefOrgnization":[[]],"OCSPServer":["http://o.pki.goog/wr2"],"OtherNames":[],"ParsedExplicitTexts":[[]],"ParsedNoticeRefOrganization":[[]],"PermittedDNSNames":[],"PermittedDirectoryNames":[],"PermittedEdiPartyNames":[],"PermittedEmailAddresses":[],"PermittedIPAddresses":[],"PermittedRegisteredIDs":[],"PermittedURIs":[],"PermittedX400Addresses":[],"PolicyIdentifiers":[[2,23,140,1,2,1]],"PublicKey":{"Pub":{"Curve":{},"X":{},"Y":{}},"Raw":{"BitLength":520,"Bytes":"IkJOM0V3NUhXUDZkNlRROWJ5ZFNUUE1rSDE2R2c5Nnc1a0hCcDNTSmRTVVIxMUJXNDZkTEdtZXVHZ0lBd1V4YldiS3ZhWEwwUlJNNzZiTTJpdGs2MVd4Yz0i"}},"PublicKeyAlgorithm":3,"PublicKeyAlgorithmOID":[1,2,840,10045,2,1],"QCStatements":null,"QualifierId":[[]],"Raw":"Ik1JSUU1VENDQTgyZ0F3SUJBZ0lRZE0xVnpjTCtUVHNReUxiMW9qVWs1VEFOQmdrcWhraUc5dzBCQVFzRkFEQTdNUXN3Q1FZRFZRUUdFd0pWVXpFZU1Cd0dBMVVFQ2hNVlIyOXZaMnhsSUZSeWRYTjBJRk5sY25acFkyVnpNUXd3Q2dZRFZRUURFd05YVWpJd0hoY05NalF3T0RFeU1EY3hPVFUxV2hjTk1qUXhNVEEwTURjeE9UVTBXakFWTVJNd0VRWURWUVFERXdwa2JuTXVaMjl2WjJ4bE1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRTNjVERrZFkvcDNwTkQxdkoxSk04eVFmWG9hRDNyRG1RY0duZElsMUpSSFhVRmJqcDBzYVo2NGFBZ0RCVEZ0WnNxOXBjdlJGRXp2cHN6YUsyVHJWYkY2T0NBdFF3Z2dMUU1BNEdBMVVkRHdFQi93UUVBd0lIZ0RBVEJnTlZIU1VFRERBS0JnZ3JCZ0VGQlFjREFUQU1CZ05WSFJNQkFmOEVBakFBTUIwR0ExVWREZ1FXQkJTOXVadmxyTmZGd3YzYkNsZ2ZCdUU0SHBvMWdUQWZCZ05WSFNNRUdEQVdnQlRlR3g3dGVSWFVQamNrd3lHNzdEUTViVUt5TURCWUJnZ3JCZ0VGQlFjQkFRUk1NRW93SVFZSUt3WUJCUVVITUFHR0ZXaDBkSEE2THk5dkxuQnJhUzVuYjI5bkwzZHlNakFsQmdnckJnRUZCUWN3QW9ZWmFIUjBjRG92TDJrdWNHdHBMbWR2YjJjdmQzSXlMbU55ZERDQnJBWURWUjBSQklHa01JR2hnZ3BrYm5NdVoyOXZaMnhsZ2c1a2JuTXVaMjl2WjJ4bExtTnZiWUlRS2k1a2JuTXVaMjl2WjJ4bExtTnZiWUlMT0RnNE9DNW5iMjluYkdXQ0VHUnVjelkwTG1SdWN5NW5iMjluYkdXSEJBZ0lDQWlIQkFnSUJBU0hFQ0FCU0dCSVlBQUFBQUFBQUFBQWlJaUhFQ0FCU0dCSVlBQUFBQUFBQUFBQWlFU0hFQ0FCU0dCSVlBQUFBQUFBQUFBQVpHU0hFQ0FCU0dCSVlBQUFBQUFBQUFBQUFHUXdFd1lEVlIwZ0JBd3dDakFJQmdabmdRd0JBZ0V3TmdZRFZSMGZCQzh3TFRBcm9DbWdKNFlsYUhSMGNEb3ZMMk11Y0d0cExtZHZiMmN2ZDNJeUwwZFRlVlF4VGpSUVFuSm5MbU55YkRDQ0FRTUdDaXNHQVFRQjFua0NCQUlFZ2ZRRWdmRUE3d0IyQUhiL2lEOEt0dnVWVWNKaHpQV0h1alMwcE0yN0tkeG9RZ3FmNW1kTVdqcDBBQUFCa1VXc0xPNEFBQVFEQUVjd1JRSWdHWWVSSTl4QUNyQXVRVHVhTzR0cUw3VUkwYmg5TkJjQ0FhZGY3ZDYvSHV3Q0lRRFZLY1lmeVFNeWdDNVN5Z2ZTYzE3K0wydTgxaURoVkR3QWVmOU1KMVdhd2dCMUFOcTJ2MnMvdGJZaW41dkN1MXhyNkhDUmNXeTdVWVNGTkwya1BUQkkxL3VyQUFBQmtVV3NNTTRBQUFRREFFWXdSQUlnTU9vK2cvNzRIM1B2R2krRFY3bEFTSHE3b0FReEEzOGE1ak5DejZqMEZOQUNJRnNldEhQSlJLa2ZZTC9oY1l5cTljM0owNThvdXlwQVNGV1V0bEVVMkh3Sk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ2NnbmNia3FPUWZ4a3Y0ekNVWm1hQWpONHZRT2ZZTTVqaWdwREE1Y2hKRldsV0RIR1VBaFA0R2xUV1FBQkk0TUQ2Y2NDeE00bVIzM3FkQ2o0clZnekV1anhmZS80N0VjVFNOVFYzR3kwWlBodTMrd0J5MDV2RnBQSnNwRHErMHVJYkdzSCtKWEhJN2R1TmI3QUNuelA3TzQ5aWZSSkFRaXpDUXpNZ1NnMmNZa21WaWNGeDBwNDY2cjZMQVBoZWhOcUVSS0pNMXhDWDlXTWg3d2RROW1uWjhhdWYzOTVzdWFmL3hFNjVCSzNvS0tnZDBpMytnMG1EODdaMUJSd2lGNTZvT09zVFhpOCszQm1KS2NMQXRBVVE5UC8vNkNHUGdQZzFMckY2U29yeGJ4aGhiaHJ5alhhVit1WlNkRWhPOHJXTGtCN3lQcHQwY0JOUzNYbG9WOVBGIg==","RawIssuer":"Ik1Ec3hDekFKQmdOVkJBWVRBbFZUTVI0d0hBWURWUVFLRXhWSGIyOW5iR1VnVkhKMWMzUWdVMlZ5ZG1salpYTXhEREFLQmdOVkJBTVRBMWRTTWc9PSI=","RawSubject":"Ik1CVXhFekFSQmdOVkJBTVRDbVJ1Y3k1bmIyOW5iR1U9Ig==","RawSubjectPublicKeyInfo":"Ik1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRTNjVERrZFkvcDNwTkQxdkoxSk04eVFmWG9hRDNyRG1RY0duZElsMUpSSFhVRmJqcDBzYVo2NGFBZ0RCVEZ0WnNxOXBjdlJGRXp2cHN6YUsyVHJWYkZ3PT0i","RawTBSCertificate":"Ik1JSUR6YUFEQWdFQ0FoQjB6VlhOd3Y1Tk94REl0dldpTlNUbE1BMEdDU3FHU0liM0RRRUJDd1VBTURzeEN6QUpCZ05WQkFZVEFsVlRNUjR3SEFZRFZRUUtFeFZIYjI5bmJHVWdWSEoxYzNRZ1UyVnlkbWxqWlhNeEREQUtCZ05WQkFNVEExZFNNakFlRncweU5EQTRNVEl3TnpFNU5UVmFGdzB5TkRFeE1EUXdOekU1TlRSYU1CVXhFekFSQmdOVkJBTVRDbVJ1Y3k1bmIyOW5iR1V3V1RBVEJnY3Foa2pPUFFJQkJnZ3Foa2pPUFFNQkJ3TkNBQVRkeE1PUjFqK25lazBQVzhuVWt6ekpCOWVob1Blc09aQndhZDBpWFVsRWRkUVZ1T25TeHBucmhvQ0FNRk1XMW15cjJseTlFVVRPK216Tm9yWk90VnNYbzRJQzFEQ0NBdEF3RGdZRFZSMFBBUUgvQkFRREFnZUFNQk1HQTFVZEpRUU1NQW9HQ0NzR0FRVUZCd01CTUF3R0ExVWRFd0VCL3dRQ01BQXdIUVlEVlIwT0JCWUVGTDI1bStXczE4WEMvZHNLV0I4RzRUZ2VtaldCTUI4R0ExVWRJd1FZTUJhQUZONGJIdTE1RmRRK055VERJYnZzTkRsdFFySXdNRmdHQ0NzR0FRVUZCd0VCQkV3d1NqQWhCZ2dyQmdFRkJRY3dBWVlWYUhSMGNEb3ZMMjh1Y0d0cExtZHZiMmN2ZDNJeU1DVUdDQ3NHQVFVRkJ6QUNoaGxvZEhSd09pOHZhUzV3YTJrdVoyOXZaeTkzY2pJdVkzSjBNSUdzQmdOVkhSRUVnYVF3Z2FHQ0NtUnVjeTVuYjI5bmJHV0NEbVJ1Y3k1bmIyOW5iR1V1WTI5dGdoQXFMbVJ1Y3k1bmIyOW5iR1V1WTI5dGdnczRPRGc0TG1kdmIyZHNaWUlRWkc1ek5qUXVaRzV6TG1kdmIyZHNaWWNFQ0FnSUNJY0VDQWdFQkljUUlBRklZRWhnQUFBQUFBQUFBQUNJaUljUUlBRklZRWhnQUFBQUFBQUFBQUNJUkljUUlBRklZRWhnQUFBQUFBQUFBQUJrWkljUUlBRklZRWhnQUFBQUFBQUFBQUFBWkRBVEJnTlZIU0FFRERBS01BZ0dCbWVCREFFQ0FUQTJCZ05WSFI4RUx6QXRNQ3VnS2FBbmhpVm9kSFJ3T2k4dll5NXdhMmt1WjI5dlp5OTNjakl2UjFONVZERk9ORkJDY21jdVkzSnNNSUlCQXdZS0t3WUJCQUhXZVFJRUFnU0I5QVNCOFFEdkFIWUFkditJUHdxMis1VlJ3bUhNOVllNk5MU2t6YnNwM0doQ0NwL21aMHhhT25RQUFBR1JSYXdzN2dBQUJBTUFSekJGQWlBWmg1RWozRUFLc0M1Qk81bzdpMm92dFFqUnVIMDBGd0lCcDEvdDNyOGU3QUloQU5VcHhoL0pBektBTGxMS0I5SnpYdjR2YTd6V0lPRlVQQUI1LzB3blZackNBSFVBMnJhL2F6KzF0aUtmbThLN1hHdm9jSkZ4Ykx0UmhJVTB2YVE5TUVqWCs2c0FBQUdSUmF3d3pnQUFCQU1BUmpCRUFpQXc2ajZEL3ZnZmMrOGFMNE5YdVVCSWVydWdCREVEZnhybU0wTFBxUFFVMEFJZ1d4NjBjOGxFcVI5Z3YrRnhqS3IxemNuVG55aTdLa0JJVlpTMlVSVFlmQWs9Ig==","RegisteredIDs":[],"SPKIFingerprint":"ImtLODM1emRWYUFEbm5OckhCT242ZlBIWEJNMDloUzNiNlVKb1RqUk53Tzg9Ig==","SPKISubjectFingerprint":"Ild6dUVha2xBSmp5RWRsdktYUzZYcnFld2I1Q1hXVkxZdGdyUHNCSnpKWEk9Ig==","SelfSigned":false,"SerialNumber":{},"Signature":"Im5JSjNHNUtqa0g4WkwrTXdsR1ptZ0l6ZUwwRG4yRE9ZNG9LUXdPWElTUlZwVmd4eGxBSVQrQnBVMWtBQVNPREErbkhBc1RPSmtkOTZuUW8rSzFZTXhMbzhYM3YrT3hIRTBqVTFkeHN0R1Q0YnQvc0FjdE9ieGFUeWJLUTZ2dExpR3hyQi9pVnh5TzNialcrd0FwOHorenVQWW4wU1FFSXN3a016SUVvTm5HSkpsWW5CY2RLZU91cStpd0Q0WG9UYWhFU2lUTmNRbC9WakllOEhVUFpwMmZHcm45L2ViTG1uLzhST3VRU3Q2Q2lvSGRJdC9vTkpnL08yZFFVY0loZWVxRGpyRTE0dlB0d1ppU25Dd0xRRkVQVC8vK2doajRENE5TNnhla3FLOFc4WVlXNGE4bzEybGZybVVuUklUdksxaTVBZThqNmJkSEFUVXQxNWFGZlR4UT09Ig==","SignatureAlgorithm":4,"SignatureAlgorithmOID":[1,2,840,113549,1,1,11],"SignedCertificateTimestampList":[{"version":0,"log_id":"dv+IPwq2+5VRwmHM9Ye6NLSkzbsp3GhCCp/mZ0xaOnQ=","timestamp":1723450797,"signature":"BAMARzBFAiAZh5Ej3EAKsC5BO5o7i2ovtQjRuH00FwIBp1/t3r8e7AIhANUpxh/JAzKALlLKB9JzXv4va7zWIOFUPAB5/0wnVZrC"},{"version":0,"log_id":"2ra/az+1tiKfm8K7XGvocJFxbLtRhIU0vaQ9MEjX+6s=","timestamp":1723450798,"signature":"BAMARjBEAiAw6j6D/vgfc+8aL4NXuUBIerugBDEDfxrmM0LPqPQU0AIgWx60c8lEqR9gv+FxjKr1zcnTnyi7KkBIVZS2URTYfAk="}],"Subject":{"Country":null,"Organization":null,"OrganizationalUnit":null,"Locality":null,"Province":null,"StreetAddress":null,"PostalCode":null,"DomainComponent":null,"EmailAddress":null,"SerialNumber":"","CommonName":"dns.google","SerialNumbers":null,"CommonNames":["dns.google"],"GivenName":null,"Surname":null,"OrganizationIDs":null,"JurisdictionLocality":null,"JurisdictionProvince":null,"JurisdictionCountry":null,"Names":[{"type":"2.5.4.3","value":"dns.google"}],"ExtraNames":null,"OriginalRDNS":[[{"type":"2.5.4.3","value":"dns.google"}]]},"SubjectKeyId":"InZibWI1YXpYeGNMOTJ3cFlId2JoT0I2YU5ZRT0i","SubjectUniqueId":{"BitLength":0,"Bytes":[]},"TBSCertificateFingerprint":"IkNEZ2pHR3hhc0YybHdqRVdXVjlvRDB3Y3pXdWpsK09mamM3cVlpK0JCdW89Ig==","TorServiceDescriptors":[],"URIs":[],"UnhandledCriticalExtensions":[],"UnknownExtKeyUsage":[],"ValidationLevel":1,"ValidityPeriod":7257599,"Version":3},"raw":"Ik1JSUU1VENDQTgyZ0F3SUJBZ0lRZE0xVnpjTCtUVHNReUxiMW9qVWs1VEFOQmdrcWhraUc5dzBCQVFzRkFEQTdNUXN3Q1FZRFZRUUdFd0pWVXpFZU1Cd0dBMVVFQ2hNVlIyOXZaMnhsSUZSeWRYTjBJRk5sY25acFkyVnpNUXd3Q2dZRFZRUURFd05YVWpJd0hoY05NalF3T0RFeU1EY3hPVFUxV2hjTk1qUXhNVEEwTURjeE9UVTBXakFWTVJNd0VRWURWUVFERXdwa2JuTXVaMjl2WjJ4bE1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRTNjVERrZFkvcDNwTkQxdkoxSk04eVFmWG9hRDNyRG1RY0duZElsMUpSSFhVRmJqcDBzYVo2NGFBZ0RCVEZ0WnNxOXBjdlJGRXp2cHN6YUsyVHJWYkY2T0NBdFF3Z2dMUU1BNEdBMVVkRHdFQi93UUVBd0lIZ0RBVEJnTlZIU1VFRERBS0JnZ3JCZ0VGQlFjREFUQU1CZ05WSFJNQkFmOEVBakFBTUIwR0ExVWREZ1FXQkJTOXVadmxyTmZGd3YzYkNsZ2ZCdUU0SHBvMWdUQWZCZ05WSFNNRUdEQVdnQlRlR3g3dGVSWFVQamNrd3lHNzdEUTViVUt5TURCWUJnZ3JCZ0VGQlFjQkFRUk1NRW93SVFZSUt3WUJCUVVITUFHR0ZXaDBkSEE2THk5dkxuQnJhUzVuYjI5bkwzZHlNakFsQmdnckJnRUZCUWN3QW9ZWmFIUjBjRG92TDJrdWNHdHBMbWR2YjJjdmQzSXlMbU55ZERDQnJBWURWUjBSQklHa01JR2hnZ3BrYm5NdVoyOXZaMnhsZ2c1a2JuTXVaMjl2WjJ4bExtTnZiWUlRS2k1a2JuTXVaMjl2WjJ4bExtTnZiWUlMT0RnNE9DNW5iMjluYkdXQ0VHUnVjelkwTG1SdWN5NW5iMjluYkdXSEJBZ0lDQWlIQkFnSUJBU0hFQ0FCU0dCSVlBQUFBQUFBQUFBQWlJaUhFQ0FCU0dCSVlBQUFBQUFBQUFBQWlFU0hFQ0FCU0dCSVlBQUFBQUFBQUFBQVpHU0hFQ0FCU0dCSVlBQUFBQUFBQUFBQUFHUXdFd1lEVlIwZ0JBd3dDakFJQmdabmdRd0JBZ0V3TmdZRFZSMGZCQzh3TFRBcm9DbWdKNFlsYUhSMGNEb3ZMMk11Y0d0cExtZHZiMmN2ZDNJeUwwZFRlVlF4VGpSUVFuSm5MbU55YkRDQ0FRTUdDaXNHQVFRQjFua0NCQUlFZ2ZRRWdmRUE3d0IyQUhiL2lEOEt0dnVWVWNKaHpQV0h1alMwcE0yN0tkeG9RZ3FmNW1kTVdqcDBBQUFCa1VXc0xPNEFBQVFEQUVjd1JRSWdHWWVSSTl4QUNyQXVRVHVhTzR0cUw3VUkwYmg5TkJjQ0FhZGY3ZDYvSHV3Q0lRRFZLY1lmeVFNeWdDNVN5Z2ZTYzE3K0wydTgxaURoVkR3QWVmOU1KMVdhd2dCMUFOcTJ2MnMvdGJZaW41dkN1MXhyNkhDUmNXeTdVWVNGTkwya1BUQkkxL3VyQUFBQmtVV3NNTTRBQUFRREFFWXdSQUlnTU9vK2cvNzRIM1B2R2krRFY3bEFTSHE3b0FReEEzOGE1ak5DejZqMEZOQUNJRnNldEhQSlJLa2ZZTC9oY1l5cTljM0owNThvdXlwQVNGV1V0bEVVMkh3Sk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ2NnbmNia3FPUWZ4a3Y0ekNVWm1hQWpONHZRT2ZZTTVqaWdwREE1Y2hKRldsV0RIR1VBaFA0R2xUV1FBQkk0TUQ2Y2NDeE00bVIzM3FkQ2o0clZnekV1anhmZS80N0VjVFNOVFYzR3kwWlBodTMrd0J5MDV2RnBQSnNwRHErMHVJYkdzSCtKWEhJN2R1TmI3QUNuelA3TzQ5aWZSSkFRaXpDUXpNZ1NnMmNZa21WaWNGeDBwNDY2cjZMQVBoZWhOcUVSS0pNMXhDWDlXTWg3d2RROW1uWjhhdWYzOTVzdWFmL3hFNjVCSzNvS0tnZDBpMytnMG1EODdaMUJSd2lGNTZvT09zVFhpOCszQm1KS2NMQXRBVVE5UC8vNkNHUGdQZzFMckY2U29yeGJ4aGhiaHJ5alhhVit1WlNkRWhPOHJXTGtCN3lQcHQwY0JOUzNYbG9WOVBGIg=="},"chain":[{"parsed":{"AuthorityKeyId":"IjVLOHJKbkVhSzBnbmhTOVNaaXp2OElrVGNUND0i","BasicConstraintsValid":true,"CABFOrganizationIdentifier":null,"CPSuri":[[]],"CRLDistributionPoints":["http://c.pki.goog/r/r1.crl"],"DNSNames":[],"DirectoryNames":[],"EDIPartyNames":[],"EmailAddresses":[],"ExcludedDNSNames":[],"ExcludedDirectoryNames":[],"ExcludedEdiPartyNames":[],"ExcludedEmailAddresses":[],"ExcludedIPAddresses":[],"ExcludedRegisteredIDs":[],"ExcludedURIs":[],"ExcludedX400Addresses":[],"ExplicitTexts":[[]],"ExtKeyUsage":[48,53],"Extensions":[{"Critical":true,"Id":[2,5,29,15],"Value":"IkF3SUJoZz09Ig=="},{"Critical":false,"Id":[2,5,29,37],"Value":"Ik1CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBZz09Ig=="},{"Critical":true,"Id":[2,5,29,19],"Value":"Ik1BWUJBZjhDQVFBPSI="},{"Critical":false,"Id":[2,5,29,14],"Value":"IkJCVGVHeDd0ZVJYVVBqY2t3eUc3N0RRNWJVS3lNQT09Ig=="},{"Critical":false,"Id":[2,5,29,35],"Value":"Ik1CYUFGT1N2S3laeEdpdElKNFV2VW1ZczcvQ0pFM0UrIg=="},{"Critical":false,"Id":[1,3,6,1,5,5,7,1,1],"Value":"Ik1DWXdKQVlJS3dZQkJRVUhNQUtHR0doMGRIQTZMeTlwTG5CcmFTNW5iMjluTDNJeExtTnlkQT09Ig=="},{"Critical":false,"Id":[2,5,29,31],"Value":"Ik1DSXdJS0Flb0J5R0dtaDBkSEE2THk5akxuQnJhUzVuYjI5bkwzSXZjakV1WTNKcyI="},{"Critical":false,"Id":[2,5,29,32],"Value":"Ik1Bb3dDQVlHWjRFTUFRSUIi"}],"ExtensionsMap":{"1.3.6.1.5.5.7.1.1":{"Critical":false,"Id":[1,3,6,1,5,5,7,1,1],"Value":"Ik1DWXdKQVlJS3dZQkJRVUhNQUtHR0doMGRIQTZMeTlwTG5CcmFTNW5iMjluTDNJeExtTnlkQT09Ig=="},"2.5.29.14":{"Critical":false,"Id":[2,5,29,14],"Value":"IkJCVGVHeDd0ZVJYVVBqY2t3eUc3N0RRNWJVS3lNQT09Ig=="},"2.5.29.15":{"Critical":true,"Id":[2,5,29,15],"Value":"IkF3SUJoZz09Ig=="},"2.5.29.19":{"Critical":true,"Id":[2,5,29,19],"Value":"Ik1BWUJBZjhDQVFBPSI="},"2.5.29.31":{"Critical":false,"Id":[2,5,29,31],"Value":"Ik1DSXdJS0Flb0J5R0dtaDBkSEE2THk5akxuQnJhUzVuYjI5bkwzSXZjakV1WTNKcyI="},"2.5.29.32":{"Critical":false,"Id":[2,5,29,32],"Value":"Ik1Bb3dDQVlHWjRFTUFRSUIi"},"2.5.29.35":{"Critical":false,"Id":[2,5,29,35],"Value":"Ik1CYUFGT1N2S3laeEdpdElKNFV2VW1ZczcvQ0pFM0UrIg=="},"2.5.29.37":{"Critical":false,"Id":[2,5,29,37],"Value":"Ik1CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBZz09Ig=="}},"ExtraExtensions":[],"FailedToParseNames":[],"FingerprintMD5":"Ik9DOVJhbjk5K3NVNWNhdEczaUJWbXc9PSI=","FingerprintNoCT":"InNLS0tFNEV3dnRJYk5qR2phZ0kyNjA3RWRLU1ZIb3dZWnR5dkQ5aVBya2s9Ig==","FingerprintSHA1":"Ilp1UVdFbUN4QVA3ZzNpaDZtbEtUdE1JaVN1WT0i","FingerprintSHA256":"IjV2NGl2MFhrOE5PNFhGbmdMQTlKVkJqaDY0MHlFUGVJMUl6VjRjdFVmTlE9Ig==","IANDNSNames":[],"IANDirectoryNames":[],"IANEDIPartyNames":[],"IANEmailAddresses":[],"IANIPAddresses":[],"IANOtherNames":[],"IANRegisteredIDs":[],"IANURIs":[],"IPAddresses":[],"IsCA":true,"IsPrecert":false,"Issuer":{"Country":["US"],"Organization":["Google Trust Services LLC"],"OrganizationalUnit":null,"Locality":null,"Province":null,"StreetAddress":null,"PostalCode":null,"DomainComponent":null,"EmailAddress":null,"SerialNumber":"","CommonName":"GTS Root R1","SerialNumbers":null,"CommonNames":["GTS Root R1"],"GivenName":null,"Surname":null,"OrganizationIDs":null,"JurisdictionLocality":null,"JurisdictionProvince":null,"JurisdictionCountry":null,"Names":[{"type":"2.5.4.6","value":"US"},{"type":"2.5.4.10","value":"Google Trust Services LLC"},{"type":"2.5.4.3","value":"GTS Root R1"}],"ExtraNames":null,"OriginalRDNS":[[{"type":"2.5.4.6","value":"US"}],[{"type":"2.5.4.10","value":"Google Trust Services LLC"}],[{"type":"2.5.4.3","value":"GTS Root R1"}]]},"IssuerUniqueId":{"BitLength":0,"Bytes":[]},"IssuingCertificateURL":["http://i.pki.goog/r1.crt"],"KeyUsage":{"digital_signature":true,"certificate_sign":true,"crl_sign":true,"value":97},"MaxPathLen":0,"MaxPathLenZero":true,"NameConstraintsCritical":false,"NotAfter":"2029-02-20T14:00:00Z","NotBefore":"2023-12-13T09:00:00Z","NoticeRefNumbers":[[]],"NoticeRefOrgnization":[[]],"OCSPServer":[],"OtherNames":[],"ParsedExplicitTexts":[[]],"ParsedNoticeRefOrganization":[[]],"PermittedDNSNames":[],"PermittedDirectoryNames":[],"PermittedEdiPartyNames":[],"PermittedEmailAddresses":[],"PermittedIPAddresses":[],"PermittedRegisteredIDs":[],"PermittedURIs":[],"PermittedX400Addresses":[],"PolicyIdentifiers":[[2,23,140,1,2,1]],"PublicKey":{"E":65537,"N":{}},"PublicKeyAlgorithm":1,"PublicKeyAlgorithmOID":[1,2,840,113549,1,1,1],"QCStatements":null,"QualifierId":[[]],"Raw":"Ik1JSUZDekNDQXZPZ0F3SUJBZ0lRZi9BRm9IeE0zdEVBcloxbXBSQjdtREFOQmdrcWhraUc5dzBCQVFzRkFEQkhNUXN3Q1FZRFZRUUdFd0pWVXpFaU1DQUdBMVVFQ2hNWlIyOXZaMnhsSUZSeWRYTjBJRk5sY25acFkyVnpJRXhNUXpFVU1CSUdBMVVFQXhNTFIxUlRJRkp2YjNRZ1VqRXdIaGNOTWpNeE1qRXpNRGt3TURBd1doY05Namt3TWpJd01UUXdNREF3V2pBN01Rc3dDUVlEVlFRR0V3SlZVekVlTUJ3R0ExVUVDaE1WUjI5dloyeGxJRlJ5ZFhOMElGTmxjblpwWTJWek1Rd3dDZ1lEVlFRREV3TlhVakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRQ3AvNXgvUlI1d3FGT2Z5dG5sRGQ1R1YxZDl2SSthV3F4RzhZU2F1NUhieWZzdkFmdVNDUUFXWHFBYytNR3IrWGd2U3N6WWhhTFlXVHdPMHhqN3NmVWtEU2J1dGx0a2Rud1V4eTk2enFoTXQvVFpDUHpmaHlNMUlLamlhZUtNVGoreFdmcGdvaDZ6eVNCVEdZTEtObE50WUUzcEFKSDhkbzFjQ0E4S3d0enhjMnZGRTI0S1QzckM4Z0ljTHJSamc5b3g5aTExTUxMN3E4SnUyNm5BRHJuNVo5VERKVmQwNndXMDZZNjEzaWpOekhvVTVIRUR5MDFoTG1GWHhSbXBDNWlFR3VoNUtkbXlqUy8vVjJwbTRNNnJsYWdwbG1Od0VtY2VPdUhic0NGeDEzeWUvYW9YYnY0cit6Z1hGTkZtcDYrYXRYRE15R09CT296QUtxbDJOODdqQWdNQkFBR2pnZjR3Z2Zzd0RnWURWUjBQQVFIL0JBUURBZ0dHTUIwR0ExVWRKUVFXTUJRR0NDc0dBUVVGQndNQkJnZ3JCZ0VGQlFjREFqQVNCZ05WSFJNQkFmOEVDREFHQVFIL0FnRUFNQjBHQTFVZERnUVdCQlRlR3g3dGVSWFVQamNrd3lHNzdEUTViVUt5TURBZkJnTlZIU01FR0RBV2dCVGtyeXNtY1JvclNDZUZMMUptTE8vd2lSTnhQakEwQmdnckJnRUZCUWNCQVFRb01DWXdKQVlJS3dZQkJRVUhNQUtHR0doMGRIQTZMeTlwTG5CcmFTNW5iMjluTDNJeExtTnlkREFyQmdOVkhSOEVKREFpTUNDZ0hxQWNoaHBvZEhSd09pOHZZeTV3YTJrdVoyOXZaeTl5TDNJeExtTnliREFUQmdOVkhTQUVEREFLTUFnR0JtZUJEQUVDQVRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQWdFQVJYV0w1Ujg3UkJPV0dxdFk4VFhKYnozUzBETktoak82VjFGUDdzUTAyaFlTVEw4VG53M1VWT2xJZWNBd1BKUWw4aHIwdWpLVXRqTnlDNFh1Q1JFbE5KVGhiMExiZ3B0N2Z5cWFxZjkvcWRMZVNpRExzL3NEQTdqNEJ3WGFXWkl2R0VhWXpxOXl2aVFtc1I0QVRiMElyWk5CUkFxN3g5VUJoYitUVitQZmRCSlREaEVsMDV2YzNzc25iclBDdVROaU9jTGdOZUZicHdrdUdjdVJLblpjOGQvS0k0UkFwVy8vbWtIZ3RlOHkwWVd1cnlVSjhHTEZic0xJYmpMOXVOcml6a3FSU3ZPRlZVNnhkZFpJTXk5dmhOa1NYSi9VY1poakpZMXBYQXByZmZKQnZlaTdqK1FpMTUxbFJlaE1Db2ZhNldCbWlBNGZ4K0ZPVnNWMi83UjZWMm55QWlJSkprRWQyblNpNVNuenhKcmxYZGFxZXYzaHR5dG1PUHZvS1dhNjc2QVRML2h6ZnZEYVFCRWNYZDJQcHZ5KzI3NVcrREtjSDBGQmJYNjJ4ZXZHaXphM0Y0eWR6eGw2Tko4aGs4UitkRFhTcXYxTWJSVDF5YkI1VzBrODg3OFhTT2p2bWlZVERJZnljOWFjeFZKclkvY3lrSGlwYSt0ZTFwT2h2N3dZUFl0WjlvckdCVjVTR09KbTROckIzSzFhSmFyMFJmenhDM2lrcjdEeWM2UXdxRFRCVTM5Q2x1VklRZXVRUmd3RzNNdVN4bDd6UkVSRFJpbEdvS2I4dVk0NUp6bXhXdUt4cmZ3VC80NzhKdUhVL29UeFVGcU9sMnN0S25uN1FHVHE4ejI5VytHZ0JMQ1hTQnhDOWVwYUhNMG15RkgvRkpsbmlYSmZIZXl0V3QwPSI=","RawIssuer":"Ik1FY3hDekFKQmdOVkJBWVRBbFZUTVNJd0lBWURWUVFLRXhsSGIyOW5iR1VnVkhKMWMzUWdVMlZ5ZG1salpYTWdURXhETVJRd0VnWURWUVFERXd0SFZGTWdVbTl2ZENCU01RPT0i","RawSubject":"Ik1Ec3hDekFKQmdOVkJBWVRBbFZUTVI0d0hBWURWUVFLRXhWSGIyOW5iR1VnVkhKMWMzUWdVMlZ5ZG1salpYTXhEREFLQmdOVkJBTVRBMWRTTWc9PSI=","RawSubjectPublicKeyInfo":"Ik1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBcWYrY2YwVWVjS2hUbjhyWjVRM2VSbGRYZmJ5UG1scXNSdkdFbXJ1UjI4bjdMd0g3a2drQUZsNmdIUGpCcS9sNEwwck0ySVdpMkZrOER0TVkrN0gxSkEwbTdyWmJaSFo4Rk1jdmVzNm9UTGYwMlFqODM0Y2pOU0NvNG1uaWpFNC9zVm42WUtJZXM4a2dVeG1DeWpaVGJXQk42UUNSL0hhTlhBZ1BDc0xjOFhOcnhSTnVDazk2d3ZJQ0hDNjBZNFBhTWZZdGRUQ3krNnZDYnR1cHdBNjUrV2ZVd3lWWGRPc0Z0T21PdGQ0b3pjeDZGT1J4QTh0TllTNWhWOFVacVF1WWhCcm9lU25ac28wdi8xZHFadURPcTVXb0taWmpjQkpuSGpyaDI3QWhjZGQ4bnYycUYyNytLL3M0RnhUUlpxZXZtclZ3ek1oamdUcU13Q3FwZGpmTzR3SURBUUFCIg==","RawTBSCertificate":"Ik1JSUM4NkFEQWdFQ0FoQi84QVdnZkV6ZTBRQ3RuV2FsRUh1WU1BMEdDU3FHU0liM0RRRUJDd1VBTUVjeEN6QUpCZ05WQkFZVEFsVlRNU0l3SUFZRFZRUUtFeGxIYjI5bmJHVWdWSEoxYzNRZ1UyVnlkbWxqWlhNZ1RFeERNUlF3RWdZRFZRUURFd3RIVkZNZ1VtOXZkQ0JTTVRBZUZ3MHlNekV5TVRNd09UQXdNREJhRncweU9UQXlNakF4TkRBd01EQmFNRHN4Q3pBSkJnTlZCQVlUQWxWVE1SNHdIQVlEVlFRS0V4VkhiMjluYkdVZ1ZISjFjM1FnVTJWeWRtbGpaWE14RERBS0JnTlZCQU1UQTFkU01qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQUtuL25IOUZIbkNvVTUvSzJlVU4za1pYVjMyOGo1cGFyRWJ4aEpxN2tkdkoreThCKzVJSkFCWmVvQno0d2F2NWVDOUt6TmlGb3RoWlBBN1RHUHV4OVNRTkp1NjJXMlIyZkJUSEwzck9xRXkzOU5rSS9OK0hJelVncU9KcDRveE9QN0ZaK21DaUhyUEpJRk1aZ3NvMlUyMWdUZWtBa2Z4MmpWd0lEd3JDM1BGemE4VVRiZ3BQZXNMeUFod3V0R09EMmpIMkxYVXdzdnVyd203YnFjQU91ZmxuMU1NbFYzVHJCYlRwanJYZUtNM01laFRrY1FQTFRXRXVZVmZGR2FrTG1JUWE2SGtwMmJLTkwvOVhhbWJnenF1VnFDbVdZM0FTWng0NjRkdXdJWEhYZko3OXFoZHUvaXY3T0JjVTBXYW5yNXExY016SVk0RTZqTUFxcVhZM3p1TUNBd0VBQWFPQi9qQ0IrekFPQmdOVkhROEJBZjhFQkFNQ0FZWXdIUVlEVlIwbEJCWXdGQVlJS3dZQkJRVUhBd0VHQ0NzR0FRVUZCd01DTUJJR0ExVWRFd0VCL3dRSU1BWUJBZjhDQVFBd0hRWURWUjBPQkJZRUZONGJIdTE1RmRRK055VERJYnZzTkRsdFFySXdNQjhHQTFVZEl3UVlNQmFBRk9Tdkt5WnhHaXRJSjRVdlVtWXM3L0NKRTNFK01EUUdDQ3NHQVFVRkJ3RUJCQ2d3SmpBa0JnZ3JCZ0VGQlFjd0FvWVlhSFIwY0Rvdkwya3VjR3RwTG1kdmIyY3ZjakV1WTNKME1Dc0dBMVVkSHdRa01DSXdJS0Flb0J5R0dtaDBkSEE2THk5akxuQnJhUzVuYjI5bkwzSXZjakV1WTNKc01CTUdBMVVkSUFRTU1Bb3dDQVlHWjRFTUFRSUIi","RegisteredIDs":[],"SPKIFingerprint":"IllQdEhhZnRMdzYvMHZuYzJCbk5LR0Y1NHhpQ0EyOFdGY2NjamtBNHlwQ009Ig==","SPKISubjectFingerprint":"ImxiRklyOFRDU2RNVUJuVW5nVDFEbHpWMCtPRWFrRkJBeUlGUkFDYXVkUGs9Ig==","SelfSigned":false,"SerialNumber":{},"Signature":"IlJYV0w1Ujg3UkJPV0dxdFk4VFhKYnozUzBETktoak82VjFGUDdzUTAyaFlTVEw4VG53M1VWT2xJZWNBd1BKUWw4aHIwdWpLVXRqTnlDNFh1Q1JFbE5KVGhiMExiZ3B0N2Z5cWFxZjkvcWRMZVNpRExzL3NEQTdqNEJ3WGFXWkl2R0VhWXpxOXl2aVFtc1I0QVRiMElyWk5CUkFxN3g5VUJoYitUVitQZmRCSlREaEVsMDV2YzNzc25iclBDdVROaU9jTGdOZUZicHdrdUdjdVJLblpjOGQvS0k0UkFwVy8vbWtIZ3RlOHkwWVd1cnlVSjhHTEZic0xJYmpMOXVOcml6a3FSU3ZPRlZVNnhkZFpJTXk5dmhOa1NYSi9VY1poakpZMXBYQXByZmZKQnZlaTdqK1FpMTUxbFJlaE1Db2ZhNldCbWlBNGZ4K0ZPVnNWMi83UjZWMm55QWlJSkprRWQyblNpNVNuenhKcmxYZGFxZXYzaHR5dG1PUHZvS1dhNjc2QVRML2h6ZnZEYVFCRWNYZDJQcHZ5KzI3NVcrREtjSDBGQmJYNjJ4ZXZHaXphM0Y0eWR6eGw2Tko4aGs4UitkRFhTcXYxTWJSVDF5YkI1VzBrODg3OFhTT2p2bWlZVERJZnljOWFjeFZKclkvY3lrSGlwYSt0ZTFwT2h2N3dZUFl0WjlvckdCVjVTR09KbTROckIzSzFhSmFyMFJmenhDM2lrcjdEeWM2UXdxRFRCVTM5Q2x1VklRZXVRUmd3RzNNdVN4bDd6UkVSRFJpbEdvS2I4dVk0NUp6bXhXdUt4cmZ3VC80NzhKdUhVL29UeFVGcU9sMnN0S25uN1FHVHE4ejI5VytHZ0JMQ1hTQnhDOWVwYUhNMG15RkgvRkpsbmlYSmZIZXl0V3QwPSI=","SignatureAlgorithm":4,"SignatureAlgorithmOID":[1,2,840,113549,1,1,11],"SignedCertificateTimestampList":[],"Subject":{"Country":["US"],"Organization":["Google Trust Services"],"OrganizationalUnit":null,"Locality":null,"Province":null,"StreetAddress":null,"PostalCode":null,"DomainComponent":null,"EmailAddress":null,"SerialNumber":"","CommonName":"WR2","SerialNumbers":null,"CommonNames":["WR2"],"GivenName":null,"Surname":null,"OrganizationIDs":null,"JurisdictionLocality":null,"JurisdictionProvince":null,"JurisdictionCountry":null,"Names":[{"type":"2.5.4.6","value":"US"},{"type":"2.5.4.10","value":"Google Trust Services"},{"type":"2.5.4.3","value":"WR2"}],"ExtraNames":null,"OriginalRDNS":[[{"type":"2.5.4.6","value":"US"}],[{"type":"2.5.4.10","value":"Google Trust Services"}],[{"type":"2.5.4.3","value":"WR2"}]]},"SubjectKeyId":"IjNoc2U3WGtWMUQ0M0pNTWh1K3cwT1cxQ3NqQT0i","SubjectUniqueId":{"BitLength":0,"Bytes":[]},"TBSCertificateFingerprint":"InNLS0tFNEV3dnRJYk5qR2phZ0kyNjA3RWRLU1ZIb3dZWnR5dkQ5aVBya2s9Ig==","TorServiceDescriptors":[],"URIs":[],"UnhandledCriticalExtensions":[],"UnknownExtKeyUsage":[],"ValidationLevel":1,"ValidityPeriod":163832400,"Version":3},"raw":"Ik1JSUZDekNDQXZPZ0F3SUJBZ0lRZi9BRm9IeE0zdEVBcloxbXBSQjdtREFOQmdrcWhraUc5dzBCQVFzRkFEQkhNUXN3Q1FZRFZRUUdFd0pWVXpFaU1DQUdBMVVFQ2hNWlIyOXZaMnhsSUZSeWRYTjBJRk5sY25acFkyVnpJRXhNUXpFVU1CSUdBMVVFQXhNTFIxUlRJRkp2YjNRZ1VqRXdIaGNOTWpNeE1qRXpNRGt3TURBd1doY05Namt3TWpJd01UUXdNREF3V2pBN01Rc3dDUVlEVlFRR0V3SlZVekVlTUJ3R0ExVUVDaE1WUjI5dloyeGxJRlJ5ZFhOMElGTmxjblpwWTJWek1Rd3dDZ1lEVlFRREV3TlhVakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRQ3AvNXgvUlI1d3FGT2Z5dG5sRGQ1R1YxZDl2SSthV3F4RzhZU2F1NUhieWZzdkFmdVNDUUFXWHFBYytNR3IrWGd2U3N6WWhhTFlXVHdPMHhqN3NmVWtEU2J1dGx0a2Rud1V4eTk2enFoTXQvVFpDUHpmaHlNMUlLamlhZUtNVGoreFdmcGdvaDZ6eVNCVEdZTEtObE50WUUzcEFKSDhkbzFjQ0E4S3d0enhjMnZGRTI0S1QzckM4Z0ljTHJSamc5b3g5aTExTUxMN3E4SnUyNm5BRHJuNVo5VERKVmQwNndXMDZZNjEzaWpOekhvVTVIRUR5MDFoTG1GWHhSbXBDNWlFR3VoNUtkbXlqUy8vVjJwbTRNNnJsYWdwbG1Od0VtY2VPdUhic0NGeDEzeWUvYW9YYnY0cit6Z1hGTkZtcDYrYXRYRE15R09CT296QUtxbDJOODdqQWdNQkFBR2pnZjR3Z2Zzd0RnWURWUjBQQVFIL0JBUURBZ0dHTUIwR0ExVWRKUVFXTUJRR0NDc0dBUVVGQndNQkJnZ3JCZ0VGQlFjREFqQVNCZ05WSFJNQkFmOEVDREFHQVFIL0FnRUFNQjBHQTFVZERnUVdCQlRlR3g3dGVSWFVQamNrd3lHNzdEUTViVUt5TURBZkJnTlZIU01FR0RBV2dCVGtyeXNtY1JvclNDZUZMMUptTE8vd2lSTnhQakEwQmdnckJnRUZCUWNCQVFRb01DWXdKQVlJS3dZQkJRVUhNQUtHR0doMGRIQTZMeTlwTG5CcmFTNW5iMjluTDNJeExtTnlkREFyQmdOVkhSOEVKREFpTUNDZ0hxQWNoaHBvZEhSd09pOHZZeTV3YTJrdVoyOXZaeTl5TDNJeExtTnliREFUQmdOVkhTQUVEREFLTUFnR0JtZUJEQUVDQVRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQWdFQVJYV0w1Ujg3UkJPV0dxdFk4VFhKYnozUzBETktoak82VjFGUDdzUTAyaFlTVEw4VG53M1VWT2xJZWNBd1BKUWw4aHIwdWpLVXRqTnlDNFh1Q1JFbE5KVGhiMExiZ3B0N2Z5cWFxZjkvcWRMZVNpRExzL3NEQTdqNEJ3WGFXWkl2R0VhWXpxOXl2aVFtc1I0QVRiMElyWk5CUkFxN3g5VUJoYitUVitQZmRCSlREaEVsMDV2YzNzc25iclBDdVROaU9jTGdOZUZicHdrdUdjdVJLblpjOGQvS0k0UkFwVy8vbWtIZ3RlOHkwWVd1cnlVSjhHTEZic0xJYmpMOXVOcml6a3FSU3ZPRlZVNnhkZFpJTXk5dmhOa1NYSi9VY1poakpZMXBYQXByZmZKQnZlaTdqK1FpMTUxbFJlaE1Db2ZhNldCbWlBNGZ4K0ZPVnNWMi83UjZWMm55QWlJSkprRWQyblNpNVNuenhKcmxYZGFxZXYzaHR5dG1PUHZvS1dhNjc2QVRML2h6ZnZEYVFCRWNYZDJQcHZ5KzI3NVcrREtjSDBGQmJYNjJ4ZXZHaXphM0Y0eWR6eGw2Tko4aGs4UitkRFhTcXYxTWJSVDF5YkI1VzBrODg3OFhTT2p2bWlZVERJZnljOWFjeFZKclkvY3lrSGlwYSt0ZTFwT2h2N3dZUFl0WjlvckdCVjVTR09KbTROckIzSzFhSmFyMFJmenhDM2lrcjdEeWM2UXdxRFRCVTM5Q2x1VklRZXVRUmd3RzNNdVN4bDd6UkVSRFJpbEdvS2I4dVk0NUp6bXhXdUt4cmZ3VC80NzhKdUhVL29UeFVGcU9sMnN0S25uN1FHVHE4ejI5VytHZ0JMQ1hTQnhDOWVwYUhNMG15RkgvRkpsbmlYSmZIZXl0V3QwPSI="},{"parsed":{"AuthorityKeyId":"IllIdG1Ha1VObDhxSlVDOTlCTTAwcVAvOC9Vcz0i","BasicConstraintsValid":true,"CABFOrganizationIdentifier":null,"CPSuri":[[],[],[],[]],"CRLDistributionPoints":["http://crl.pki.goog/gsr1/gsr1.crl"],"DNSNames":[],"DirectoryNames":[],"EDIPartyNames":[],"EmailAddresses":[],"ExcludedDNSNames":[],"ExcludedDirectoryNames":[],"ExcludedEdiPartyNames":[],"ExcludedEmailAddresses":[],"ExcludedIPAddresses":[],"ExcludedRegisteredIDs":[],"ExcludedURIs":[],"ExcludedX400Addresses":[],"ExplicitTexts":[[],[],[],[]],"ExtKeyUsage":[],"Extensions":[{"Critical":true,"Id":[2,5,29,15],"Value":"IkF3SUJoZz09Ig=="},{"Critical":true,"Id":[2,5,29,19],"Value":"Ik1BTUJBZjg9Ig=="},{"Critical":false,"Id":[2,5,29,14],"Value":"IkJCVGtyeXNtY1JvclNDZUZMMUptTE8vd2lSTnhQZz09Ig=="},{"Critical":false,"Id":[2,5,29,35],"Value":"Ik1CYUFGR0I3WmhwRkRaZktpVkF2ZlFUTk5Lai8vUDFMIg=="},{"Critical":false,"Id":[1,3,6,1,5,5,7,1,1],"Value":"Ik1GSXdKUVlJS3dZQkJRVUhNQUdHR1doMGRIQTZMeTl2WTNOd0xuQnJhUzVuYjI5bkwyZHpjakV3S1FZSUt3WUJCUVVITUFLR0hXaDBkSEE2THk5d2Eya3VaMjl2Wnk5bmMzSXhMMmR6Y2pFdVkzSjAi"},{"Critical":false,"Id":[2,5,29,31],"Value":"Ik1Da3dKNkFsb0NPR0lXaDBkSEE2THk5amNtd3VjR3RwTG1kdmIyY3ZaM055TVM5bmMzSXhMbU55YkE9PSI="},{"Critical":false,"Id":[2,5,29,32],"Value":"Ik1ESXdDQVlHWjRFTUFRSUJNQWdHQm1lQkRBRUNBakFOQmdzckJnRUVBZFo1QWdVREFqQU5CZ3NyQmdFRUFkWjVBZ1VEQXc9PSI="}],"ExtensionsMap":{"1.3.6.1.5.5.7.1.1":{"Critical":false,"Id":[1,3,6,1,5,5,7,1,1],"Value":"Ik1GSXdKUVlJS3dZQkJRVUhNQUdHR1doMGRIQTZMeTl2WTNOd0xuQnJhUzVuYjI5bkwyZHpjakV3S1FZSUt3WUJCUVVITUFLR0hXaDBkSEE2THk5d2Eya3VaMjl2Wnk5bmMzSXhMMmR6Y2pFdVkzSjAi"},"2.5.29.14":{"Critical":false,"Id":[2,5,29,14],"Value":"IkJCVGtyeXNtY1JvclNDZUZMMUptTE8vd2lSTnhQZz09Ig=="},"2.5.29.15":{"Critical":true,"Id":[2,5,29,15],"Value":"IkF3SUJoZz09Ig=="},"2.5.29.19":{"Critical":true,"Id":[2,5,29,19],"Value":"Ik1BTUJBZjg9Ig=="},"2.5.29.31":{"Critical":false,"Id":[2,5,29,31],"Value":"Ik1Da3dKNkFsb0NPR0lXaDBkSEE2THk5amNtd3VjR3RwTG1kdmIyY3ZaM055TVM5bmMzSXhMbU55YkE9PSI="},"2.5.29.32":{"Critical":false,"Id":[2,5,29,32],"Value":"Ik1ESXdDQVlHWjRFTUFRSUJNQWdHQm1lQkRBRUNBakFOQmdzckJnRUVBZFo1QWdVREFqQU5CZ3NyQmdFRUFkWjVBZ1VEQXc9PSI="},"2.5.29.35":{"Critical":false,"Id":[2,5,29,35],"Value":"Ik1CYUFGR0I3WmhwRkRaZktpVkF2ZlFUTk5Lai8vUDFMIg=="}},"ExtraExtensions":[],"FailedToParseNames":[],"FingerprintMD5":"Ik5vSzJ3T3VCbFo1TFJGamZ1MlhVOXc9PSI=","FingerprintNoCT":"ImFsQmlzTkY0MVZieFk3RTdHdzhaUTEwQ1dJS1J6SFZZbmY3bTZ4SEkxY009Ig==","FingerprintSHA1":"IkNIUlVoK2lSd1o0d2VNSHlvSDVGS1ZEdk52WT0i","FingerprintSHA256":"IlB1QW5qZmNmbzhFbHhNMUlmd0hYZEdsT2I4VitETmxNSk8vWGFSTTVHT1U9Ig==","IANDNSNames":[],"IANDirectoryNames":[],"IANEDIPartyNames":[],"IANEmailAddresses":[],"IANIPAddresses":[],"IANOtherNames":[],"IANRegisteredIDs":[],"IANURIs":[],"IPAddresses":[],"IsCA":true,"IsPrecert":false,"Issuer":{"Country":["BE"],"Organization":["GlobalSign nv-sa"],"OrganizationalUnit":["Root CA"],"Locality":null,"Province":null,"StreetAddress":null,"PostalCode":null,"DomainComponent":null,"EmailAddress":null,"SerialNumber":"","CommonName":"GlobalSign Root CA","SerialNumbers":null,"CommonNames":["GlobalSign Root CA"],"GivenName":null,"Surname":null,"OrganizationIDs":null,"JurisdictionLocality":null,"JurisdictionProvince":null,"JurisdictionCountry":null,"Names":[{"type":"2.5.4.6","value":"BE"},{"type":"2.5.4.10","value":"GlobalSign nv-sa"},{"type":"2.5.4.11","value":"Root CA"},{"type":"2.5.4.3","value":"GlobalSign Root CA"}],"ExtraNames":null,"OriginalRDNS":[[{"type":"2.5.4.6","value":"BE"}],[{"type":"2.5.4.10","value":"GlobalSign nv-sa"}],[{"type":"2.5.4.11","value":"Root CA"}],[{"type":"2.5.4.3","value":"GlobalSign Root CA"}]]},"IssuerUniqueId":{"BitLength":0,"Bytes":[]},"IssuingCertificateURL":["http://pki.goog/gsr1/gsr1.crt"],"KeyUsage":{"digital_signature":true,"certificate_sign":true,"crl_sign":true,"value":97},"MaxPathLen":-1,"MaxPathLenZero":false,"NameConstraintsCritical":false,"NotAfter":"2028-01-28T00:00:42Z","NotBefore":"2020-06-19T00:00:42Z","NoticeRefNumbers":[[],[],[],[]],"NoticeRefOrgnization":[[],[],[],[]],"OCSPServer":["http://ocsp.pki.goog/gsr1"],"OtherNames":[],"ParsedExplicitTexts":[[],[],[],[]],"ParsedNoticeRefOrganization":[[],[],[],[]],"PermittedDNSNames":[],"PermittedDirectoryNames":[],"PermittedEdiPartyNames":[],"PermittedEmailAddresses":[],"PermittedIPAddresses":[],"PermittedRegisteredIDs":[],"PermittedURIs":[],"PermittedX400Addresses":[],"PolicyIdentifiers":[[2,23,140,1,2,1],[2,23,140,1,2,2],[1,3,6,1,4,1,11129,2,5,3,2],[1,3,6,1,4,1,11129,2,5,3,3]],"PublicKey":{"E":65537,"N":{}},"PublicKeyAlgorithm":1,"PublicKeyAlgorithmOID":[1,2,840,113549,1,1,1],"QCStatements":null,"QualifierId":[[],[],[],[]],"Raw":"Ik1JSUZZakNDQkVxZ0F3SUJBZ0lRZDcwTmJOczIrUnJxSVEvRThGalREVEFOQmdrcWhraUc5dzBCQVFzRkFEQlhNUXN3Q1FZRFZRUUdFd0pDUlRFWk1CY0dBMVVFQ2hNUVIyeHZZbUZzVTJsbmJpQnVkaTF6WVRFUU1BNEdBMVVFQ3hNSFVtOXZkQ0JEUVRFYk1Ca0dBMVVFQXhNU1IyeHZZbUZzVTJsbmJpQlNiMjkwSUVOQk1CNFhEVEl3TURZeE9UQXdNREEwTWxvWERUSTRNREV5T0RBd01EQTBNbG93UnpFTE1Ba0dBMVVFQmhNQ1ZWTXhJakFnQmdOVkJBb1RHVWR2YjJkc1pTQlVjblZ6ZENCVFpYSjJhV05sY3lCTVRFTXhGREFTQmdOVkJBTVRDMGRVVXlCU2IyOTBJRkl4TUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUF0aEVDaXg3am9YZWJPOXkvbEQ2M2xhZEFQS0g5Z3ZsOU1nYUNjZmIyakgvNzZOdThhaTZYbDZPTVMva3I5ckg1em9RZHNmbkZsOTd2dWZLajZid1NpVjZucWxLcitDTW55NlN4bkdQYjE1bCs4QXBlNjJpbTlNWmFSdzFORURQalRyRVRvOGdZYkV2cy9BbVEzNTFrS1NVakI2RzAwajB1WU9EUDBnbUh1ODFJOEUzQ3ducUlpcnU2ejFrWjFxK1BzQWV3bmpIeGdzSEEzeTZtYld3WkRyWFlmaVlhUlFNOXNIbWtsQ2l0RDM4bTVhZ0kvcGJvUEdpVVUrNkRPb2dyRlpZSnN1QjZqQzUxMXB6cnAxWmtqNVpQYUs0OWw4S0VqOEM4UU1BTFhMMzJoN00xYkt3WVVIK0U0RXpOa3RNZzZUTzhVcG12TXJVcHN5VXF0RWo1Y3VIS1pQZm1naENONkozQ2lvajZPR2FLL0dQNUFmbDQvWHRjZC9wMmgvcnMzN0VPZVpWWHRMMG03OVlCMGVzV0NydU9DN1hGeFlwVnE5T3M2cEZMS2N3WnBESWxUaXJ4WlVUUUFzNnF6a20wNnA5OGc3QkFlK2REcTZkc280OTlpWUg2VEtYLzFZN0R6a3ZndGRpemprWFBkc0R0UUN2OVV3K3dwOVU3RGJHS29nUGVNYTNNZCtwdmV6N1czNUVpRXVhKyt0Z3kvQkJqRkZGeTNsM1dGcE85S1dnejd6cG03QWVLSnQ4VDExZGxlQ2ZlWGtrVUFLSUFmNXFvSWJhcHNaV3dwYmtORmhIYXgyeElQRURnZmcxYXpWWTgwWmNGdWN0TDdUbExuTVEvMGxVVGJpU3cxbkg2OU1HNnpPMGI5ZjZCUWRnQW1EMDZ5SzU2bURjWUJaVUNBd0VBQWFPQ0FUZ3dnZ0UwTUE0R0ExVWREd0VCL3dRRUF3SUJoakFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQjBHQTFVZERnUVdCQlRrcnlzbWNSb3JTQ2VGTDFKbUxPL3dpUk54UGpBZkJnTlZIU01FR0RBV2dCUmdlMllhUlEyWHlvbFFMMzBFelRTby8vejlTekJnQmdnckJnRUZCUWNCQVFSVU1GSXdKUVlJS3dZQkJRVUhNQUdHR1doMGRIQTZMeTl2WTNOd0xuQnJhUzVuYjI5bkwyZHpjakV3S1FZSUt3WUJCUVVITUFLR0hXaDBkSEE2THk5d2Eya3VaMjl2Wnk5bmMzSXhMMmR6Y2pFdVkzSjBNRElHQTFVZEh3UXJNQ2t3SjZBbG9DT0dJV2gwZEhBNkx5OWpjbXd1Y0d0cExtZHZiMmN2WjNOeU1TOW5jM0l4TG1OeWJEQTdCZ05WSFNBRU5EQXlNQWdHQm1lQkRBRUNBVEFJQmdabmdRd0JBZ0l3RFFZTEt3WUJCQUhXZVFJRkF3SXdEUVlMS3dZQkJBSFdlUUlGQXdNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFEU2tIckVvbzlDMGRoZW1NWG9oNmRGU1BzamJkQlpCaUxnOU5SM3Q1UCtUNFZ4ZnE3dnFmTS9iNUEzUmkxZnlKbTlidmhkR2FKUTNiMnQ2eU1BWU4vb2xVYXpzYUwreXlFbjlXcHJLQVNPc2hJQXJBb3labCt0SmFveDExOGZlc3NtWG4xaElWdzQxb2VRYTF2MXZnNEZ2NzR6UGw2L0FoU3J3OVU1cENaRXQ0V2k0d1N0ejZkVFovQ0xBTng4TFpoMUo3UUpWajJmaE10ZlRKcjl3NHozMFoyMDlmT1UwaU9NeStxZHVCbXB2dll1UjdoWkw2RHVwc3pmbncwU2tmdGhzMThkRzlaS2I1OVVodm1hU0daUlZiTlFwc2czQlpsdmlkMGxJS08yZDF4b3pjbE96Z2pYUFlvdkpKSXVsdHprTXUzNHFRYjlTei95aWxyYkNnajg9Ig==","RawIssuer":"Ik1GY3hDekFKQmdOVkJBWVRBa0pGTVJrd0Z3WURWUVFLRXhCSGJHOWlZV3hUYVdkdUlHNTJMWE5oTVJBd0RnWURWUVFMRXdkU2IyOTBJRU5CTVJzd0dRWURWUVFERXhKSGJHOWlZV3hUYVdkdUlGSnZiM1FnUTBFPSI=","RawSubject":"Ik1FY3hDekFKQmdOVkJBWVRBbFZUTVNJd0lBWURWUVFLRXhsSGIyOW5iR1VnVkhKMWMzUWdVMlZ5ZG1salpYTWdURXhETVJRd0VnWURWUVFERXd0SFZGTWdVbTl2ZENCU01RPT0i","RawSubjectPublicKeyInfo":"Ik1JSUNJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBZzhBTUlJQ0NnS0NBZ0VBdGhFQ2l4N2pvWGViTzl5L2xENjNsYWRBUEtIOWd2bDlNZ2FDY2ZiMmpILzc2TnU4YWk2WGw2T01TL2tyOXJINXpvUWRzZm5GbDk3dnVmS2o2YndTaVY2bnFsS3IrQ01ueTZTeG5HUGIxNWwrOEFwZTYyaW05TVphUncxTkVEUGpUckVUbzhnWWJFdnMvQW1RMzUxa0tTVWpCNkcwMGowdVlPRFAwZ21IdTgxSThFM0N3bnFJaXJ1Nnoxa1oxcStQc0Fld25qSHhnc0hBM3k2bWJXd1pEclhZZmlZYVJRTTlzSG1rbENpdEQzOG01YWdJL3Bib1BHaVVVKzZET29nckZaWUpzdUI2akM1MTFwenJwMVprajVaUGFLNDlsOEtFajhDOFFNQUxYTDMyaDdNMWJLd1lVSCtFNEV6Tmt0TWc2VE84VXBtdk1yVXBzeVVxdEVqNWN1SEtaUGZtZ2hDTjZKM0Npb2o2T0dhSy9HUDVBZmw0L1h0Y2QvcDJoL3JzMzdFT2VaVlh0TDBtNzlZQjBlc1dDcnVPQzdYRnhZcFZxOU9zNnBGTEtjd1pwRElsVGlyeFpVVFFBczZxemttMDZwOThnN0JBZStkRHE2ZHNvNDk5aVlINlRLWC8xWTdEemt2Z3RkaXpqa1hQZHNEdFFDdjlVdyt3cDlVN0RiR0tvZ1BlTWEzTWQrcHZlejdXMzVFaUV1YSsrdGd5L0JCakZGRnkzbDNXRnBPOUtXZ3o3enBtN0FlS0p0OFQxMWRsZUNmZVhra1VBS0lBZjVxb0liYXBzWld3cGJrTkZoSGF4MnhJUEVEZ2ZnMWF6Vlk4MFpjRnVjdEw3VGxMbk1RLzBsVVRiaVN3MW5INjlNRzZ6TzBiOWY2QlFkZ0FtRDA2eUs1Nm1EY1lCWlVDQXdFQUFRPT0i","RawTBSCertificate":"Ik1JSUVTcUFEQWdFQ0FoQjN2UTFzMnpiNUd1b2hEOFR3V05NTk1BMEdDU3FHU0liM0RRRUJDd1VBTUZjeEN6QUpCZ05WQkFZVEFrSkZNUmt3RndZRFZRUUtFeEJIYkc5aVlXeFRhV2R1SUc1MkxYTmhNUkF3RGdZRFZRUUxFd2RTYjI5MElFTkJNUnN3R1FZRFZRUURFeEpIYkc5aVlXeFRhV2R1SUZKdmIzUWdRMEV3SGhjTk1qQXdOakU1TURBd01EUXlXaGNOTWpnd01USTRNREF3TURReVdqQkhNUXN3Q1FZRFZRUUdFd0pWVXpFaU1DQUdBMVVFQ2hNWlIyOXZaMnhsSUZSeWRYTjBJRk5sY25acFkyVnpJRXhNUXpFVU1CSUdBMVVFQXhNTFIxUlRJRkp2YjNRZ1VqRXdnZ0lpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElDRHdBd2dnSUtBb0lDQVFDMkVRS0xIdU9oZDVzNzNMK1VQcmVWcDBBOG9mMkMrWDB5Qm9KeDl2YU1mL3ZvMjd4cUxwZVhvNHhMK1N2MnNmbk9oQjJ4K2NXWDN1KzU4cVBwdkJLSlhxZXFVcXY0SXlmTHBMR2NZOXZYbVg3d0NsN3JhS2IweGxwSERVMFFNK05Pc1JPanlCaHNTK3o4Q1pEZm5XUXBKU01Ib2JUU1BTNWc0TS9TQ1llN3pVandUY0xDZW9pS3U3clBXUm5XcjQrd0I3Q2VNZkdDd2NEZkxxWnRiQmtPdGRoK0pocEZBejJ3ZWFTVUtLMFBmeWJscUFqK2x1ZzhhSlJUN29NNmlDc1ZsZ215NEhxTUxuWFduT3VuVm1TUGxrOW9yajJYd29TUHdMeEF3QXRjdmZhSHN6VnNyQmhRZjRUZ1RNMlMweURwTTd4U21hOHl0U216SlNxMFNQbHk0Y3BrOSthQ0VJM29uY0tLaVBvNFpvcjhZL2tCK1hqOWUxeDMrbmFIK3V6ZnNRNTVsVmUwdlNidjFnSFI2eFlLdTQ0THRjWEZpbFdyMDZ6cWtVc3B6Qm1rTWlWT0t2RmxSTkFDenFyT1NiVHFuM3lEc0VCNzUwT3JwMnlqajMySmdmcE1wZi9WanNQT1MrQzEyTE9PUmM5MndPMUFLLzFURDdDbjFUc05zWXFpQTk0eHJjeDM2bTk3UHRiZmtTSVM1cjc2MkRMOEVHTVVVWExlWGRZV2s3MHBhRFB2T21ic0I0b20zeFBYVjJWNEo5NWVTUlFBb2dCL21xZ2h0cW14bGJDbHVRMFdFZHJIYkVnOFFPQitEVnJOVmp6Umx3VzV5MHZ0T1V1Y3hEL1NWUk51SkxEV2NmcjB3YnJNN1J2MS9vRkIyQUNZUFRySXJucVlOeGdGbFFJREFRQUJvNElCT0RDQ0FUUXdEZ1lEVlIwUEFRSC9CQVFEQWdHR01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZPU3ZLeVp4R2l0SUo0VXZVbVlzNy9DSkUzRStNQjhHQTFVZEl3UVlNQmFBRkdCN1pocEZEWmZLaVZBdmZRVE5OS2ovL1AxTE1HQUdDQ3NHQVFVRkJ3RUJCRlF3VWpBbEJnZ3JCZ0VGQlFjd0FZWVphSFIwY0RvdkwyOWpjM0F1Y0d0cExtZHZiMmN2WjNOeU1UQXBCZ2dyQmdFRkJRY3dBb1lkYUhSMGNEb3ZMM0JyYVM1bmIyOW5MMmR6Y2pFdlozTnlNUzVqY25Rd01nWURWUjBmQkNzd0tUQW5vQ1dnSTRZaGFIUjBjRG92TDJOeWJDNXdhMmt1WjI5dlp5OW5jM0l4TDJkemNqRXVZM0pzTURzR0ExVWRJQVEwTURJd0NBWUdaNEVNQVFJQk1BZ0dCbWVCREFFQ0FqQU5CZ3NyQmdFRUFkWjVBZ1VEQWpBTkJnc3JCZ0VFQWRaNUFnVURBdz09Ig==","RegisteredIDs":[],"SPKIFingerprint":"Imh4cVJsUFR1MWJNUy8wRElUQjFTU3UwdmQ0dS84bDhUalBnZmFBcDYzR2M9Ig==","SPKISubjectFingerprint":"IitpM216QUtWWGFzY0pZNk1kc2Nodm51L3JpdEhrbkQ0ZjBPcUpmRlBDcmc9Ig==","SelfSigned":false,"SerialNumber":{},"Signature":"Ik5LUWVzU2lqMExSMkY2WXhlaUhwMFZJK3lOdDBGa0dJdUQwMUhlM2svNVBoWEYrcnUrcDh6OXZrRGRHTFYvSW1iMXUrRjBab2xEZHZhM3JJd0JnMytpVlJyT3hvdjdMSVNmMWFtc29CSTZ5RWdDc0NqSm1YNjBscWpIWFh4OTZ5eVplZldFaFhEaldoNUJyVy9XK0RnVy92ak0rWHI4Q0ZLdkQxVG1rSmtTM2hhTGpCSzNQcDFObjhJc0EzSHd0bUhVbnRBbFdQWitFeTE5TW12M0RqUGZSbmJUMTg1VFNJNHpMNnAyNEdhbSs5aTVIdUZrdm9PNm16TitmRFJLUisyR3pYeDBiMWtwdm4xU0crWnBJWmxGVnMxQ215RGNGbVcrSjNTVWdvN1ozWEdqTnlVN09DTmM5aWk4a2tpNlczT1F5N2ZpcEJ2MUxQL0tLV3RzS0NQdz09Ig==","SignatureAlgorithm":4,"SignatureAlgorithmOID":[1,2,840,113549,1,1,11],"SignedCertificateTimestampList":[],"Subject":{"Country":["US"],"Organization":["Google Trust Services LLC"],"OrganizationalUnit":null,"Locality":null,"Province":null,"StreetAddress":null,"PostalCode":null,"DomainComponent":null,"EmailAddress":null,"SerialNumber":"","CommonName":"GTS Root R1","SerialNumbers":null,"CommonNames":["GTS Root R1"],"GivenName":null,"Surname":null,"OrganizationIDs":null,"JurisdictionLocality":null,"JurisdictionProvince":null,"JurisdictionCountry":null,"Names":[{"type":"2.5.4.6","value":"US"},{"type":"2.5.4.10","value":"Google Trust Services LLC"},{"type":"2.5.4.3","value":"GTS Root R1"}],"ExtraNames":null,"OriginalRDNS":[[{"type":"2.5.4.6","value":"US"}],[{"type":"2.5.4.10","value":"Google Trust Services LLC"}],[{"type":"2.5.4.3","value":"GTS Root R1"}]]},"SubjectKeyId":"IjVLOHJKbkVhSzBnbmhTOVNaaXp2OElrVGNUND0i","SubjectUniqueId":{"BitLength":0,"Bytes":[]},"TBSCertificateFingerprint":"ImFsQmlzTkY0MVZieFk3RTdHdzhaUTEwQ1dJS1J6SFZZbmY3bTZ4SEkxY009Ig==","TorServiceDescriptors":[],"URIs":[],"UnhandledCriticalExtensions":[],"UnknownExtKeyUsage":[],"ValidationLevel":2,"ValidityPeriod":240105600,"Version":3},"raw":"Ik1JSUZZakNDQkVxZ0F3SUJBZ0lRZDcwTmJOczIrUnJxSVEvRThGalREVEFOQmdrcWhraUc5dzBCQVFzRkFEQlhNUXN3Q1FZRFZRUUdFd0pDUlRFWk1CY0dBMVVFQ2hNUVIyeHZZbUZzVTJsbmJpQnVkaTF6WVRFUU1BNEdBMVVFQ3hNSFVtOXZkQ0JEUVRFYk1Ca0dBMVVFQXhNU1IyeHZZbUZzVTJsbmJpQlNiMjkwSUVOQk1CNFhEVEl3TURZeE9UQXdNREEwTWxvWERUSTRNREV5T0RBd01EQTBNbG93UnpFTE1Ba0dBMVVFQmhNQ1ZWTXhJakFnQmdOVkJBb1RHVWR2YjJkc1pTQlVjblZ6ZENCVFpYSjJhV05sY3lCTVRFTXhGREFTQmdOVkJBTVRDMGRVVXlCU2IyOTBJRkl4TUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUF0aEVDaXg3am9YZWJPOXkvbEQ2M2xhZEFQS0g5Z3ZsOU1nYUNjZmIyakgvNzZOdThhaTZYbDZPTVMva3I5ckg1em9RZHNmbkZsOTd2dWZLajZid1NpVjZucWxLcitDTW55NlN4bkdQYjE1bCs4QXBlNjJpbTlNWmFSdzFORURQalRyRVRvOGdZYkV2cy9BbVEzNTFrS1NVakI2RzAwajB1WU9EUDBnbUh1ODFJOEUzQ3ducUlpcnU2ejFrWjFxK1BzQWV3bmpIeGdzSEEzeTZtYld3WkRyWFlmaVlhUlFNOXNIbWtsQ2l0RDM4bTVhZ0kvcGJvUEdpVVUrNkRPb2dyRlpZSnN1QjZqQzUxMXB6cnAxWmtqNVpQYUs0OWw4S0VqOEM4UU1BTFhMMzJoN00xYkt3WVVIK0U0RXpOa3RNZzZUTzhVcG12TXJVcHN5VXF0RWo1Y3VIS1pQZm1naENONkozQ2lvajZPR2FLL0dQNUFmbDQvWHRjZC9wMmgvcnMzN0VPZVpWWHRMMG03OVlCMGVzV0NydU9DN1hGeFlwVnE5T3M2cEZMS2N3WnBESWxUaXJ4WlVUUUFzNnF6a20wNnA5OGc3QkFlK2REcTZkc280OTlpWUg2VEtYLzFZN0R6a3ZndGRpemprWFBkc0R0UUN2OVV3K3dwOVU3RGJHS29nUGVNYTNNZCtwdmV6N1czNUVpRXVhKyt0Z3kvQkJqRkZGeTNsM1dGcE85S1dnejd6cG03QWVLSnQ4VDExZGxlQ2ZlWGtrVUFLSUFmNXFvSWJhcHNaV3dwYmtORmhIYXgyeElQRURnZmcxYXpWWTgwWmNGdWN0TDdUbExuTVEvMGxVVGJpU3cxbkg2OU1HNnpPMGI5ZjZCUWRnQW1EMDZ5SzU2bURjWUJaVUNBd0VBQWFPQ0FUZ3dnZ0UwTUE0R0ExVWREd0VCL3dRRUF3SUJoakFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQjBHQTFVZERnUVdCQlRrcnlzbWNSb3JTQ2VGTDFKbUxPL3dpUk54UGpBZkJnTlZIU01FR0RBV2dCUmdlMllhUlEyWHlvbFFMMzBFelRTby8vejlTekJnQmdnckJnRUZCUWNCQVFSVU1GSXdKUVlJS3dZQkJRVUhNQUdHR1doMGRIQTZMeTl2WTNOd0xuQnJhUzVuYjI5bkwyZHpjakV3S1FZSUt3WUJCUVVITUFLR0hXaDBkSEE2THk5d2Eya3VaMjl2Wnk5bmMzSXhMMmR6Y2pFdVkzSjBNRElHQTFVZEh3UXJNQ2t3SjZBbG9DT0dJV2gwZEhBNkx5OWpjbXd1Y0d0cExtZHZiMmN2WjNOeU1TOW5jM0l4TG1OeWJEQTdCZ05WSFNBRU5EQXlNQWdHQm1lQkRBRUNBVEFJQmdabmdRd0JBZ0l3RFFZTEt3WUJCQUhXZVFJRkF3SXdEUVlMS3dZQkJBSFdlUUlGQXdNd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFEU2tIckVvbzlDMGRoZW1NWG9oNmRGU1BzamJkQlpCaUxnOU5SM3Q1UCtUNFZ4ZnE3dnFmTS9iNUEzUmkxZnlKbTlidmhkR2FKUTNiMnQ2eU1BWU4vb2xVYXpzYUwreXlFbjlXcHJLQVNPc2hJQXJBb3labCt0SmFveDExOGZlc3NtWG4xaElWdzQxb2VRYTF2MXZnNEZ2NzR6UGw2L0FoU3J3OVU1cENaRXQ0V2k0d1N0ejZkVFovQ0xBTng4TFpoMUo3UUpWajJmaE10ZlRKcjl3NHozMFoyMDlmT1UwaU9NeStxZHVCbXB2dll1UjdoWkw2RHVwc3pmbncwU2tmdGhzMThkRzlaS2I1OVVodm1hU0daUlZiTlFwc2czQlpsdmlkMGxJS08yZDF4b3pjbE96Z2pYUFlvdkpKSXVsdHprTXUzNHFRYjlTei95aWxyYkNnajg9Ig=="}],"validation":{"browser_trusted":true,"matches_domain":true}},"server_finished":{"verify_data":"IjR5c01WRlFJc0NrQjZqV0ci"},"server_hello":{"cipher_suite":49195,"compression_method":0,"extended_master_secret":false,"heartbeat":false,"next_protocol_negotiation":false,"ocsp_stapling":false,"random":"Ilp1aEROYjI4aVBtNGZEcXZBWGdPdTBrNUh0b2NzNnR6UkU5WFRrZFNSQUU9Ig==","secure_renegotiation":true,"session_id":"Imh2VnYvUlZRa3E0aTZYSENOdWpXRVFwLzdQbFB0MjBiL3QvM3ZpSVhVSEk9Ig==","ticket":false,"unknown_extensions":["IkFBc0FBZ0VBIg=="],"version":771},"server_key_exchange":{"digest":"InJ5MytkVncvTXhHczQ2MVNWOUV1WExhZ1ZyVURyT2twbEtLMWROL1dqQW89Ig==","ecdh_params":{"curve_id":23,"server_public":{"X":{},"Y":{}}},"signature":{"raw":"Ik1FWUNJUUROcGl5TXdNaTVmcTVYdllGN2VCaG9IUk5wTzl0bkhxNTNENWt0R3dmWTl3SWhBSXlsV2NiSjFrS3NuTzk0eDkzbVJLaVFvaWdsWU1YSjNpc3hhVyt0NnJPdiI=","signature_and_hash_type":{"Hash":4,"Signature":3},"tls_version":771,"type":"ecdsa","valid":true}}},"heartbleed_log":{"heartbeat_enabled":false,"heartbleed_vulnerable":false}}},"duration":0.155033333,"status":"NOERROR","timestamp":"2024-09-16T10:39:49-04:00"}}}
```

### Using `--result-verbosity=short`
Filters out the quite long `TLS Handshake`
```
$ echo "cloudflare.com" | ./zdns A --threads=2 --https --verify-server-cert --root-cas-file="/Users/phillip/Desktop/macos-root-certs.pem" --result-verbosity=short
{"name":"cloudflare.com","results":{"A":{"data":{"additionals":[{"flags":"","type":"EDNS0","udpsize":1232,"version":0}],"answers":[{"answer":"104.16.132.229","class":"IN","name":"cloudflare.com","type":"A"},{"answer":"104.16.133.229","class":"IN","name":"cloudflare.com","type":"A"}]},"duration":0.083580417,"status":"NOERROR","timestamp":"2024-09-16T10:41:21-04:00"}}}
```

### Not providing Root CAs
```
$ echo "cloudflare.com" | ./zdns A --threads=2 --https --verify-server-cert                                                                                       
FATA[0000] resolver config did not pass validation: cannot verify server certificates without root CAs 
```

## Performance
### TCP
Ran `make benchmark` over 7k domains with `zdns A--verbosity=3 --threads=100 --tcp-only--name-servers=1.1.1.1,1.0.0.1,8.8.8.8,8.8.4.4` while also running `tcpdump`:
`sudo tcpdump -i any -n  -s 1 'tcp port 53 and tcp[tcpflags] & (tcp-syn|tcp-ack) == tcp-syn and outbound' | wc -l`

`main` - 10.37 s. - 7001 Unique Handshakes
`Phillip/336-preserve-conns` - 8 s - 202 unique handshakes

Note - It seems like Google will close the TCP connection after a certain period of time/number of lookups. If I hit an `EOF` error, I'll close and re-attempt the connection. So that's why the branch doesn't have handshakes perfectly equalling threads (100 threads != 202 unique handshakes).

### TLS

`main` - Not Applicable
`branch` - 12.40 s

### HTTPS

`main` - Not Applicable
`branch` - 15.38 s