### PR TITLE
Only `makeVerbosePrefix` if we're in at least `Debug` log level

### DIFF
--- a/src/zdns/cache.go
+++ b/src/zdns/cache.go
@@ -48,7 +48,10 @@ func (s *Cache) Init(cacheSize int) {
 }
 
 func (s *Cache) VerboseLog(depth int, args ...interface{}) {
-	log.Debug(makeVerbosePrefix(depth), args)
+	// the makeVerbosePrefix is expensive, so only do it if we're going to log
+	if log.GetLevel() >= log.DebugLevel {
+		log.Debug(makeVerbosePrefix(depth), args)
+	}
 }
 
 func (s *Cache) AddCachedAnswer(answer interface{}, ns *NameServer, depth int) {

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -691,5 +691,8 @@ func (r *Resolver) randomRootNameServer() *NameServer {
 }
 
 func (r *Resolver) verboseLog(depth int, args ...interface{}) {
-	log.Debug(makeVerbosePrefix(depth), args)
+	// the makeVerbosePrefix function is expensive, only call it if we're going to log
+	if log.GetLevel() >= log.DebugLevel {
+		log.Debug(makeVerbosePrefix(depth), args)
+	}
 }


### PR DESCRIPTION
Was looking at the `make benchmark` `allocs_objects` trace and noticed a non-insignificant number were caused by `makeVerbosePrefix`

<img width="670" alt="image" src="https://github.com/user-attachments/assets/f2201a22-bbef-472f-ae7f-ca58089d31b0">

## Description
We'll check if we're at least at `Debug` level before calling `makeVerbosePrefix`

## Allocations Reduction
`main`.   - 14,880,272
`branch` - 10,100,534