### PR TITLE
patch: only exclude the zdns binary in workspace root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 !.golangci.yml
 *.iml
 *.code-workspace
-zdns
+/zdns


### PR DESCRIPTION
currently src/zdns is also excluded
