### PR TITLE
Prevent NONEEDEDGLUE errors and add cache statistics

### DIFF
--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -530,6 +530,8 @@ func Run(gc CLIConf) {
 	close(outChan)
 	close(metaChan)
 	routineWG.Wait()
+	// print cache stats
+	//printCacheStats(resolverConfig.Cache)
 	if gc.MetadataFilePath != "" {
 		// we're done processing data. aggregate all the data from individual routines
 		metaData := aggregateMetadata(metaChan)
@@ -570,6 +572,14 @@ func Run(gc CLIConf) {
 	}
 }
 
+//	func printCacheStats(cache *zdns.Cache) {
+//		if cache != nil {
+//			log.Warnf("Cache Hits: %d", cache.Hits.Load())
+//			log.Warnf("Cache Misses: %d", cache.Misses.Load())
+//			log.Warnf("Cache Adds: %d", cache.Adds.Load())
+//		}
+//	}
+//
 // doLookupWorker is a single worker thread that processes lookups from the input channel. It calls wg.Done when it is finished.
 func doLookupWorker(gc *CLIConf, rc *zdns.ResolverConfig, inputChan <-chan string, output chan<- string, metaChan chan<- routineMetadata, wg *sync.WaitGroup) error {
 	defer wg.Done()

--- a/src/internal/cachehash/shardedcachehash.go
+++ b/src/internal/cachehash/shardedcachehash.go
@@ -42,7 +42,7 @@ func (c *ShardedCacheHash) getShard(k interface{}) *CacheHash {
 	return &c.shards[c.getShardID(k)]
 }
 
-func (c *ShardedCacheHash) Add(k interface{}, v interface{}) bool {
+func (c *ShardedCacheHash) Add(k interface{}, v interface{}) (didExist, didEject bool) {
 	return c.getShard(k).Upsert(k, v)
 }
 

--- a/src/zdns/cache.go
+++ b/src/zdns/cache.go
@@ -46,7 +46,7 @@ type TimedAnswer struct {
 
 type Cache struct {
 	IterativeCache cachehash.ShardedCacheHash
-	stats          CacheStatistics
+	Stats          CacheStatistics
 }
 
 // Init initializes the cache with a maximum cacheSize.
@@ -74,9 +74,9 @@ func (s *Cache) addCachedAnswer(q Question, nameServer string, isAuthority bool,
 		s.VerboseLog(depth+1, "inserted new cache entry for ", q, " ", nameServer, " is authority: ", isAuthority)
 	}
 	if didEject {
-		s.stats.IncrementEjects()
+		s.Stats.IncrementEjects()
 	}
-	s.stats.IncrementAdds()
+	s.Stats.IncrementAdds()
 }
 
 func (s *Cache) GetCachedAuthority(authorityName string, ns *NameServer, depth int) (retv *SingleQueryResult, isFound bool) {
@@ -119,10 +119,10 @@ func (s *Cache) getCachedResult(q Question, ns *NameServer, isAuthority bool, de
 	unres, ok := s.IterativeCache.Get(cacheKey)
 	if !ok { // nothing found
 		s.VerboseLog(depth+2, "-> no entry found in cache for ", q.Name)
-		s.stats.IncrementMisses()
+		s.Stats.IncrementMisses()
 		return retv, false, false
 	}
-	s.stats.IncrementHits()
+	s.Stats.IncrementHits()
 	cachedRes, ok := unres.(CachedResult)
 	if !ok {
 		log.Panic("unable to cast cached result for ", q.Name)

--- a/src/zdns/cache.go
+++ b/src/zdns/cache.go
@@ -271,13 +271,17 @@ func (s *Cache) SafeAddCachedAnswer(q Question, res *SingleQueryResult, ns *Name
 	s.addCachedAnswer(q, nsString, false, cachedRes, depth)
 }
 
+// TODO maybe to reduce cache thrashing we don't keep over-writing the cache entry, only if it's a new entry
+
 // SafeAddCachedAuthority adds an authority to the cache. This is a special case where the result should only have
 // authorities and additionals records. What layer this authority is for is gathered from the Authority.Name field.
 // This Authority.Name must be below the current layer.
 // Will be cached under an NS record for the authority.
 func (s *Cache) SafeAddCachedAuthority(res *SingleQueryResult, ns *NameServer, depth int, layer string) {
 	if len(res.Answers) > 0 {
+		// TODO decide if this log should be removed
 		s.VerboseLog(depth+1, "SafeAddCachedAuthority: aborting since authority record shouldn't have answers: ", layer, ": ", res.Answers)
+		res.Answers = make([]interface{}, 0)
 	}
 	authName := ""
 	for _, auth := range res.Authorities {

--- a/src/zdns/cache.go
+++ b/src/zdns/cache.go
@@ -274,7 +274,7 @@ func (s *Cache) SafeAddCachedAnswer(q Question, res *SingleQueryResult, ns *Name
 	s.addCachedAnswer(q, nsString, false, cachedRes, depth)
 }
 
-// SafeAddCachedAuthority adds an authority to the cache. This is a special case where the result should only have
+// SafeAddCachedAuthority Writes an authority to the cache. This is a special case where the result should only have
 // authorities and additionals records. What layer this authority is for is gathered from the Authority.Name field.
 // This Authority.Name must be below the current layer.
 // Will be cached under an NS record for the authority.

--- a/src/zdns/cache.go
+++ b/src/zdns/cache.go
@@ -55,7 +55,9 @@ func (s *Cache) Init(cacheSize int) {
 }
 
 func (s *Cache) VerboseLog(depth int, args ...interface{}) {
-	log.Debug(makeVerbosePrefix(depth), fmt.Sprint("Cache: ", args))
+	if log.GetLevel() >= log.DebugLevel {
+		log.Debug(makeVerbosePrefix(depth), fmt.Sprint("Cache: ", args))
+	}
 }
 
 func (s *Cache) addCachedAnswer(q Question, nameServer string, isAuthority bool, result *CachedResult, depth int) {

--- a/src/zdns/cache.go
+++ b/src/zdns/cache.go
@@ -14,6 +14,7 @@
 package zdns
 
 import (
+	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -21,15 +22,9 @@ import (
 	"github.com/zmap/dns"
 
 	"github.com/zmap/zdns/src/internal/cachehash"
-	"github.com/zmap/zdns/src/internal/util"
 )
 
 type IsCached bool
-
-type TimedAnswer struct {
-	Answer    interface{}
-	ExpiresAt time.Time
-}
 
 type CachedKey struct {
 	Question    Question
@@ -38,217 +33,247 @@ type CachedKey struct {
 }
 
 type CachedResult struct {
-	Answers map[interface{}]TimedAnswer
+	Answers     []TimedAnswer
+	Authorities []TimedAnswer
+	Additionals []TimedAnswer
+}
+
+type TimedAnswer struct {
+	Answer    Answer
+	ExpiresAt time.Time
 }
 
 type Cache struct {
 	IterativeCache cachehash.ShardedCacheHash
-	//Hits           atomic.Uint64
-	//Misses         atomic.Uint64
-	//Adds           atomic.Uint64
+	stats          CacheStatistics
 }
 
+// Init initializes the cache with a maximum cacheSize.
 func (s *Cache) Init(cacheSize int) {
 	s.IterativeCache.Init(cacheSize, 4096)
 }
 
 func (s *Cache) VerboseLog(depth int, args ...interface{}) {
-	log.Debug(makeVerbosePrefix(depth), args)
+	log.Debug(makeVerbosePrefix(depth), fmt.Sprint("Cache: ", args))
 }
 
-func (s *Cache) AddCachedAnswer(answer interface{}, ns *NameServer, depth int) {
-	//s.Adds.Add(1)
-	a, ok := answer.(Answer)
-	if !ok {
-		// we can't cache this entry because we have no idea what to name it
-		return
-	}
-	q := questionFromAnswer(a)
-
-	// only cache records that can help prevent future iteration: A(AAA), NS, (C|D)NAME.
-	// This will prevent some entries that will never help future iteration (e.g., PTR)
-	// from causing unnecessary cache evictions.
-	// TODO: this is overly broad right now and will unnecessarily cache some leaf A/AAAA records. However,
-	// it's a lot of work to understand _why_ we're doing a specific lookup and this will still help
-	// in other cases, e.g., PTR lookups
-	if !(q.Type == dns.TypeA || q.Type == dns.TypeAAAA || q.Type == dns.TypeNS || q.Type == dns.TypeDNAME || q.Type == dns.TypeCNAME) {
-		return
-	}
-	expiresAt := time.Now().Add(time.Duration(a.TTL) * time.Second)
-	ca := CachedResult{}
-	ca.Answers = make(map[interface{}]TimedAnswer)
-	cacheKey := CachedKey{q, "", false}
-	if ns != nil {
-		cacheKey.NameServer = ns.String()
-	}
+func (s *Cache) AddCachedAnswer(q Question, nameServer string, isAuthority bool, result *CachedResult, depth int) {
+	cacheKey := CachedKey{q, nameServer, false}
 	s.IterativeCache.Lock(cacheKey)
-	defer s.IterativeCache.Unlock(cacheKey)
-	// don't bother to move this to the top of the linked list. we're going
-	// to add this record back in momentarily and that will take care of this
-	i, ok := s.IterativeCache.GetNoMove(cacheKey)
-	if ok {
-		// record found, check type on interface
-		ca, ok = i.(CachedResult)
-		if !ok {
-			log.Panic("unable to cast cached result")
-		}
+	// this record will replace any existing record with the exact same cache key
+	didExist, didEject := s.IterativeCache.Add(cacheKey, *result)
+	s.IterativeCache.Unlock(cacheKey)
+	if didExist && didEject {
+		log.Panic("cache entry shouldn't be both replaced and evicted: ", q, " ", nameServer, " ", isAuthority)
+	} else if didExist {
+		s.VerboseLog(depth+1, "replaced existing cache entry for ", q, " ", nameServer, " is authority: ", isAuthority)
+	} else if didEject {
+		s.VerboseLog(depth+1, "inserting cache entry caused eviction, entry: ", q, " ", nameServer, " is authority: ", isAuthority)
+	} else {
+		s.VerboseLog(depth+1, "inserted new cache entry for ", q, " ", nameServer, " is authority: ", isAuthority)
 	}
-	// we have an existing record. Let's add this answer to it.
-	ta := TimedAnswer{
-		Answer:    answer,
-		ExpiresAt: expiresAt}
-	ca.Answers[a] = ta
-	s.IterativeCache.Add(cacheKey, ca)
-	s.VerboseLog(depth+1, "Upsert cached answer ", q, " ", ca)
+	if didEject {
+		s.stats.IncrementEjects()
+	}
+	s.stats.IncrementAdds()
 }
 
-func (s *Cache) GetCachedResult(q Question, ns *NameServer, depth int) (SingleQueryResult, bool) {
-	var retv SingleQueryResult
-	cacheKey := CachedKey{q, "", false}
+func (s *Cache) GetCachedResult(q Question, ns *NameServer, isAuthority bool, depth int) (retv SingleQueryResult, isFound, partiallyExpired bool) {
+	isFound = false
+	partiallyExpired = false
+	cacheKey := CachedKey{q, "", isAuthority}
 	if ns != nil {
 		cacheKey.NameServer = ns.String()
-		s.VerboseLog(depth+1, "Cache request for: ", q.Name, " (", q.Type, ") @", cacheKey.NameServer)
+		retv.Resolver = ns.String()
+		if isAuthority {
+			s.VerboseLog(depth+1, "Cache authority request for: ", q.Name, " (", q.Type, ") @", cacheKey.NameServer)
+		} else {
+			s.VerboseLog(depth+1, "Cache request for: ", q.Name, " (", q.Type, ") @", cacheKey.NameServer)
+		}
+	} else if isAuthority {
+		s.VerboseLog(depth+1, "Cache authority request for: ", q.Name, " (", q.Type, ")")
 	} else {
 		s.VerboseLog(depth+1, "Cache request for: ", q.Name, " (", q.Type, ")")
 	}
 	s.IterativeCache.Lock(cacheKey)
+	defer s.IterativeCache.Unlock(cacheKey)
 	unres, ok := s.IterativeCache.Get(cacheKey)
 	if !ok { // nothing found
-		//s.Misses.Add(1)
 		s.VerboseLog(depth+2, "-> no entry found in cache for ", q.Name)
-		s.IterativeCache.Unlock(cacheKey)
-		return retv, false
+		s.stats.IncrementMisses()
+		return retv, false, false
 	}
-	//s.Hits.Add(1)
-	retv.Authorities = make([]interface{}, 0)
-	retv.Answers = make([]interface{}, 0)
-	retv.Additional = make([]interface{}, 0)
+	s.stats.IncrementHits()
 	cachedRes, ok := unres.(CachedResult)
 	if !ok {
 		log.Panic("unable to cast cached result for ", q.Name)
 	}
+	retv.Answers = make([]interface{}, 0, len(cachedRes.Answers))
+	retv.Authorities = make([]interface{}, 0, len(cachedRes.Authorities))
+	retv.Additional = make([]interface{}, 0, len(cachedRes.Additionals))
 	// great we have a result. let's go through the entries and build a result. In the process, throw away anything
 	// that's expired
 	now := time.Now()
-	for k, cachedAnswer := range cachedRes.Answers {
+	for _, cachedAnswer := range cachedRes.Answers {
 		if cachedAnswer.ExpiresAt.Before(now) {
-			// if we have a write lock, we can perform the necessary actions
-			// and then write this back to the cache. However, if we don't,
-			// we need to start this process over with a write lock
-			s.VerboseLog(depth+2, "Expiring cache entry ", k)
-			delete(cachedRes.Answers, k)
+			partiallyExpired = true
+			s.VerboseLog(depth+2, "expiring cache answer ", cachedAnswer.Answer.Name)
 		} else {
-			// this result is valid. append it to the SingleQueryResult we're going to hand to the user
 			retv.Answers = append(retv.Answers, cachedAnswer.Answer)
 		}
 	}
-	s.IterativeCache.Unlock(cacheKey)
+	for _, cachedAuthority := range cachedRes.Authorities {
+		if cachedAuthority.ExpiresAt.Before(now) {
+			partiallyExpired = true
+			s.VerboseLog(depth+2, "expiring cache authority ", cachedAuthority.Answer.Name)
+		} else {
+			retv.Authorities = append(retv.Authorities, cachedAuthority.Answer)
+		}
+	}
+	for _, cachedAdditional := range cachedRes.Additionals {
+		if cachedAdditional.ExpiresAt.Before(now) {
+			partiallyExpired = true
+			s.VerboseLog(depth+2, "expiring cache additional ", cachedAdditional.Answer.Name)
+		} else {
+			retv.Additional = append(retv.Additional, cachedAdditional.Answer)
+		}
+	}
 	// Don't return an empty response.
 	if len(retv.Answers) == 0 && len(retv.Authorities) == 0 && len(retv.Additional) == 0 {
-		s.VerboseLog(depth+2, "-> no entry found in cache, after expiration for ", q.Name)
+		// remove from cache since it's completely expired
+		s.IterativeCache.Delete(cacheKey)
+		s.VerboseLog(depth+2, "-> no entry found in cache, after expiration for ", cacheKey, ", removing from cache")
 		var emptyRetv SingleQueryResult
-		return emptyRetv, false
-	}
-	if ns != nil {
-		retv.Resolver = ns.String()
+		return emptyRetv, false, false
 	}
 
 	s.VerboseLog(depth+2, "Cache hit for ", q.Name, ": ", retv)
-	return retv, true
+	return retv, true, partiallyExpired
 }
 
-func (s *Cache) SafeAddCachedAnswer(a interface{}, ns *NameServer, layer, debugType string, depth int) {
-	ans, ok := a.(Answer)
-	if !ok {
-		s.VerboseLog(depth+1, "unable to cast ", debugType, ": ", layer, ": ", a)
-		return
-	}
-	if ok, _ := nameIsBeneath(ans.Name, layer); !ok {
-		log.Info("detected poison ", debugType, ": ", ans.Name, "(", ans.Type, "): ", layer, ": ", a)
-		return
-	}
-	s.AddCachedAnswer(a, ns, depth)
+func isCacheableType(ans *Answer) bool {
+	// only cache records that can help prevent future iteration: A(AAA), NS, (C|D)NAME.
+	// This will prevent some entries that will never help future iteration (e.g., PTR)
+	// from causing unnecessary cache evictions.
+	//// TODO: this is overly broad right now and will unnecessarily cache some leaf A/AAAA records. However,
+	return ans.RrType == dns.TypeA || ans.RrType == dns.TypeAAAA || ans.RrType == dns.TypeNS || ans.RrType == dns.TypeDNAME || ans.RrType == dns.TypeCNAME
 }
 
-func (s *Cache) SafeAddLayerNameServers(layer string, result SingleQueryResult, ns *NameServer, depth int, cacheNonAuthoritativeAns bool) {
-	authsAndAdditionals := util.Concat(result.Authorities, result.Additional)
-	// build a map of TimedAnswers to add to cache
-	timedAns := make(map[interface{}]TimedAnswer, len(authsAndAdditionals))
-	for _, a := range authsAndAdditionals {
+func (s *Cache) buildCachedResult(res *SingleQueryResult, depth int, layer string) *CachedResult {
+	now := time.Now()
+	cachedRes := CachedResult{}
+	cachedRes.Answers = make([]TimedAnswer, 0, len(res.Answers))
+	for _, a := range res.Answers {
 		castAns, ok := a.(Answer)
 		if !ok {
-			log.Info("unable to cast authority in layer name servers: ", layer, ": ", a)
+			s.VerboseLog(depth+1, "SafeAddCachedAnswer: unable to cast to Answer: ", layer, ": ", a)
 			continue
 		}
-		//if ok, _ = nameIsBeneath(castAns.Name, layer); !ok {
-		//	log.Info("detected poison in adding nameserver authorities: ", castAns.Name, "(", castAns.Type, "): ", layer, ": ", castAns)
-		//	return
-		//}
-		if castAns.RrType != dns.TypeNS && castAns.RrType != dns.TypeA && castAns.RrType != dns.TypeAAAA {
-			log.Info("ignoring unexpected RRType in layer name servers: ", layer, ": ", castAns)
+		if !isCacheableType(&castAns) {
+			s.VerboseLog(depth+1, "SafeAddCachedAnswer: ignoring non-cacheable type: ", layer, ": ", castAns)
 			continue
 		}
-		timedAns[a] = TimedAnswer{
-			Answer:    a,
-			ExpiresAt: time.Now().Add(time.Duration(a.(Answer).TTL) * time.Second),
-		}
+		cachedRes.Answers = append(cachedRes.Answers, TimedAnswer{
+			Answer:    castAns,
+			ExpiresAt: now.Add(time.Duration(castAns.TTL) * time.Second),
+		})
 	}
-	cacheKey := CachedKey{Question: Question{Name: layer, Type: dns.TypeNS}, IsAuthority: true}
-	s.IterativeCache.Lock(cacheKey)
-	defer s.IterativeCache.Unlock(cacheKey)
-	//s.Adds.Add(1)
-	s.IterativeCache.Add(cacheKey, CachedResult{Answers: timedAns})
-}
-
-func (s *Cache) GetLayerNameServers(name string) (SingleQueryResult, bool) {
-	res := SingleQueryResult{}
-	res.Answers = make([]interface{}, 0)
-	res.Authorities = make([]interface{}, 0)
-	res.Additional = make([]interface{}, 0)
-	cacheKey := CachedKey{Question: Question{Name: name, Type: dns.TypeNS}, IsAuthority: true}
-	s.IterativeCache.Lock(cacheKey)
-	defer s.IterativeCache.Unlock(cacheKey)
-	unres, ok := s.IterativeCache.Get(cacheKey)
-	if !ok {
-		//s.Misses.Add(1)
-		return SingleQueryResult{}, false
-	}
-	//s.Hits.Add(1)
-	cachedRes, ok := unres.(CachedResult)
-	if !ok {
-		log.Panic("unable to cast cached result for ", name)
-	}
-	for _, cachedAnswer := range cachedRes.Answers {
-		// check expiration
-		if cachedAnswer.ExpiresAt.Before(time.Now()) {
-			delete(cachedRes.Answers, cachedAnswer.Answer)
-			continue
-		}
-		castAns, ok := cachedAnswer.Answer.(Answer)
+	cachedRes.Authorities = make([]TimedAnswer, 0, len(res.Authorities))
+	for _, a := range res.Authorities {
+		castAns, ok := a.(Answer)
 		if !ok {
-			log.Panic("unable to cast cached answer for ", name)
+			s.VerboseLog(depth+1, "SafeAddCachedAnswer: unable to cast to Answer: ", layer, ": ", a)
+			continue
 		}
-		if castAns.RrType == dns.TypeNS {
-			res.Authorities = append(res.Authorities, castAns)
-		} else if castAns.RrType == dns.TypeA || castAns.RrType == dns.TypeAAAA {
-			res.Additional = append(res.Additional, castAns)
-		} else {
-			log.Info("ignoring unexpected RRType in layer name servers: ", name, ": ", castAns)
+		if !isCacheableType(&castAns) {
+			s.VerboseLog(depth+1, "SafeAddCachedAnswer: ignoring non-cacheable type: ", layer, ": ", castAns)
+			continue
 		}
+		cachedRes.Authorities = append(cachedRes.Authorities, TimedAnswer{
+			Answer:    castAns,
+			ExpiresAt: now.Add(time.Duration(castAns.TTL) * time.Second),
+		})
 	}
-	return res, true
+	cachedRes.Additionals = make([]TimedAnswer, 0, len(res.Additional))
+	for _, a := range res.Additional {
+		castAns, ok := a.(Answer)
+		if !ok {
+			s.VerboseLog(depth+1, "SafeAddCachedAnswer: unable to cast to Answer: ", layer, ": ", a)
+			continue
+		}
+		if !isCacheableType(&castAns) {
+			s.VerboseLog(depth+1, "SafeAddCachedAnswer: ignoring non-cacheable type: ", layer, ": ", castAns)
+			continue
+		}
+		cachedRes.Additionals = append(cachedRes.Additionals, TimedAnswer{
+			Answer:    castAns,
+			ExpiresAt: now.Add(time.Duration(castAns.TTL) * time.Second),
+		})
+	}
+	return &cachedRes
 }
 
-func (s *Cache) CacheUpdate(layer string, result SingleQueryResult, ns *NameServer, depth int, cacheNonAuthoritativeAns bool) {
-	for _, a := range result.Additional {
-		s.SafeAddCachedAnswer(a, ns, layer, "additional", depth)
+func (s *Cache) SafeAddCachedAnswer(q Question, res *SingleQueryResult, ns *NameServer, layer string, depth int) {
+	//for _, a := range res.Answers {
+	//	ans, ok := a.(Answer)
+	//	if !ok {
+	//		s.VerboseLog(depth+1, "SafeAddCachedAnswer: unable to cast to Answer: ", layer, ": ", a)
+	//		return
+	//	}
+	//	if ok, _ = nameIsBeneath(ans.Name, layer); !ok {
+	//		log.Info("detected poison: ", ans.Name, "(", ans.Type, "): ", layer, ": ", a)
+	//		return
+	//	}
+	//}
+	// TODO - not sure how/in what way to check for poison here that won't cause issues
+	nsString := ""
+	if ns != nil {
+		nsString = ns.String()
 	}
-	for _, a := range result.Authorities {
-		s.SafeAddCachedAnswer(a, ns, layer, "authority", depth)
+	cachedRes := s.buildCachedResult(res, depth, layer)
+	if len(cachedRes.Answers) == 0 && len(cachedRes.Authorities) == 0 && len(cachedRes.Additionals) == 0 {
+		s.VerboseLog(depth+1, "SafeAddCachedAnswer: no cacheable records found, aborting")
+		return
 	}
-	if result.Flags.Authoritative || cacheNonAuthoritativeAns {
-		for _, a := range result.Answers {
-			s.SafeAddCachedAnswer(a, ns, layer, "answer", depth)
+	s.AddCachedAnswer(q, nsString, false, cachedRes, depth)
+}
+
+// SafeAddCachedAuthority adds an authority to the cache. This is a special case where the result should only have
+// authorities and additionals records. What layer this authority is for is gathered from the Authority.Name field.
+// This Authority.Name must be below the current layer.
+// Will be cached under an NS record for the authority.
+func (s *Cache) SafeAddCachedAuthority(res *SingleQueryResult, ns *NameServer, depth int, layer string) {
+	if len(res.Answers) > 0 {
+		s.VerboseLog(depth+1, "SafeAddCachedAuthority: aborting since authority record shouldn't have answers: ", layer, ": ", res.Answers)
+	}
+	authName := ""
+	for _, auth := range res.Authorities {
+		castAuth, ok := auth.(Answer)
+		if !ok {
+			s.VerboseLog(depth+1, "SafeAddCachedAuthority: unable to cast to Answer: ", layer, ": ", auth)
+			return
+		}
+		if len(authName) == 0 {
+			authName = castAuth.Name
+		} else if authName != castAuth.Name {
+			s.VerboseLog(depth+1, "SafeAddCachedAuthority: multiple authority names: ", layer, ": ", authName, " ", castAuth.Name, " , aborting")
+			return
 		}
 	}
+	// check for poison
+	if ok, _ := nameIsBeneath(authName, layer); !ok {
+		s.VerboseLog(depth+1, "SafeAddCachedAuthority: detected poison: ", authName, "(", dns.TypeNS, "): ", layer, " , aborting")
+		return
+	}
+	nsString := ""
+	if ns != nil {
+		nsString = ns.String()
+	}
+
+	cachedRes := s.buildCachedResult(res, depth, layer)
+	if len(cachedRes.Answers) == 0 && len(cachedRes.Authorities) == 0 && len(cachedRes.Additionals) == 0 {
+		s.VerboseLog(depth+1, "SafeAddCachedAnswer: no cacheable records found, aborting")
+		return
+	}
+	s.AddCachedAnswer(Question{Name: authName, Type: dns.TypeNS, Class: dns.ClassINET}, nsString, true, cachedRes, depth)
 }

--- a/src/zdns/cache.go
+++ b/src/zdns/cache.go
@@ -100,6 +100,7 @@ func (s *Cache) GetCachedResults(q Question, ns *NameServer, depth int) (retv *S
 }
 
 func (s *Cache) getCachedResult(q Question, ns *NameServer, isAuthority bool, depth int) (retv *SingleQueryResult, isFound, partiallyExpired bool) {
+	retv = &SingleQueryResult{}
 	isFound = false
 	partiallyExpired = false
 	cacheKey := CachedKey{q, "", isAuthority}

--- a/src/zdns/cache.go
+++ b/src/zdns/cache.go
@@ -108,7 +108,7 @@ func (s *Cache) GetCachedResult(q Question, ns *NameServer, depth int) (SingleQu
 	s.IterativeCache.Lock(cacheKey)
 	unres, ok := s.IterativeCache.Get(cacheKey)
 	if !ok { // nothing found
-		s.VerboseLog(depth+2, "-> no entry found in cache")
+		s.VerboseLog(depth+2, "-> no entry found in cache for ", q.Name)
 		s.IterativeCache.Unlock(cacheKey)
 		return retv, false
 	}
@@ -117,7 +117,7 @@ func (s *Cache) GetCachedResult(q Question, ns *NameServer, depth int) (SingleQu
 	retv.Additional = make([]interface{}, 0)
 	cachedRes, ok := unres.(CachedResult)
 	if !ok {
-		log.Panic("unable to cast cached result")
+		log.Panic("unable to cast cached result for ", q.Name)
 	}
 	// great we have a result. let's go through the entries and build
 	// and build a result. In the process, throw away anything that's expired
@@ -137,7 +137,7 @@ func (s *Cache) GetCachedResult(q Question, ns *NameServer, depth int) (SingleQu
 	s.IterativeCache.Unlock(cacheKey)
 	// Don't return an empty response.
 	if len(retv.Answers) == 0 && len(retv.Authorities) == 0 && len(retv.Additional) == 0 {
-		s.VerboseLog(depth+2, "-> no entry found in cache, after expiration")
+		s.VerboseLog(depth+2, "-> no entry found in cache, after expiration for ", q.Name)
 		var emptyRetv SingleQueryResult
 		return emptyRetv, false
 	}
@@ -145,7 +145,7 @@ func (s *Cache) GetCachedResult(q Question, ns *NameServer, depth int) (SingleQu
 		retv.Resolver = ns.String()
 	}
 
-	s.VerboseLog(depth+2, "Cache hit: ", retv)
+	s.VerboseLog(depth+2, "Cache hit for ", q.Name, ": ", retv)
 	return retv, true
 }
 

--- a/src/zdns/cache.go
+++ b/src/zdns/cache.go
@@ -273,16 +273,13 @@ func (s *Cache) SafeAddCachedAnswer(q Question, res *SingleQueryResult, ns *Name
 	s.addCachedAnswer(q, nsString, false, cachedRes, depth)
 }
 
-// TODO maybe to reduce cache thrashing we don't keep over-writing the cache entry, only if it's a new entry
-
 // SafeAddCachedAuthority adds an authority to the cache. This is a special case where the result should only have
 // authorities and additionals records. What layer this authority is for is gathered from the Authority.Name field.
 // This Authority.Name must be below the current layer.
 // Will be cached under an NS record for the authority.
 func (s *Cache) SafeAddCachedAuthority(res *SingleQueryResult, ns *NameServer, depth int, layer string) {
 	if len(res.Answers) > 0 {
-		// TODO decide if this log should be removed
-		s.VerboseLog(depth+1, "SafeAddCachedAuthority: aborting since authority record shouldn't have answers: ", layer, ": ", res.Answers)
+		// authorities should not have answers
 		res.Answers = make([]interface{}, 0)
 	}
 	authName := ""

--- a/src/zdns/cache_stats.go
+++ b/src/zdns/cache_stats.go
@@ -1,0 +1,63 @@
+/*
+ * ZDNS Copyright 2024 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package zdns
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+type CacheStatistics struct {
+	ShouldCaptureStatistics bool
+	Hits                    atomic.Uint64 // number of reads to the cache that result in a hit
+	Misses                  atomic.Uint64 // number of reads to the cache that result in a miss
+	Adds                    atomic.Uint64 // number of writes to the cache
+	Ejects                  atomic.Uint64 // number of cache entries that are ejected due to insertions
+}
+
+func (s *Cache) incrementHits() {
+	if s.stats.ShouldCaptureStatistics {
+		s.stats.Hits.Add(1)
+	}
+}
+
+func (s *Cache) incrementMisses() {
+	if s.stats.ShouldCaptureStatistics {
+		s.stats.Misses.Add(1)
+	}
+}
+
+func (s *Cache) incrementAdds() {
+	if s.stats.ShouldCaptureStatistics {
+		s.stats.Adds.Add(1)
+	}
+}
+
+func (s *Cache) incrementEjects() {
+	if s.stats.ShouldCaptureStatistics {
+		s.stats.Ejects.Add(1)
+	}
+}
+
+func (s *Cache) PrintStatistics() {
+	hits := s.stats.Hits.Load()
+	misses := s.stats.Misses.Load()
+	adds := s.stats.Adds.Load()
+	ejects := s.stats.Ejects.Load()
+	total := hits + misses
+	hitRate := float64(hits) / float64(total)
+	missRate := float64(misses) / float64(total)
+	fmt.Printf("Cache statistics: hits=%d misses=%d adds=%d ejects=%d hitRate=%f missRate=%f\n", hits, misses, adds, ejects, hitRate, missRate)
+}

--- a/src/zdns/cache_stats.go
+++ b/src/zdns/cache_stats.go
@@ -15,8 +15,9 @@
 package zdns
 
 import (
-	"fmt"
 	"sync/atomic"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type CacheStatistics struct {
@@ -63,5 +64,5 @@ func (s *CacheStatistics) PrintStatistics() {
 	total := hits + misses
 	hitRate := float64(hits) / float64(total)
 	missRate := float64(misses) / float64(total)
-	fmt.Printf("Cache statistics: hits=%d misses=%d adds=%d ejects=%d hitRate=%f%% missRate=%f%%\n", hits, misses, adds, ejects, hitRate*100, missRate*100)
+	log.Debugf("Cache statistics: hits=%d misses=%d adds=%d ejects=%d hitRate=%f%% missRate=%f%%\n", hits, misses, adds, ejects, hitRate*100, missRate*100)
 }

--- a/src/zdns/cache_stats.go
+++ b/src/zdns/cache_stats.go
@@ -64,5 +64,5 @@ func (s *CacheStatistics) PrintStatistics() {
 	total := hits + misses
 	hitRate := float64(hits) / float64(total)
 	missRate := float64(misses) / float64(total)
-	log.Debugf("Cache statistics: hits=%d misses=%d adds=%d ejects=%d hitRate=%f%% missRate=%f%%\n", hits, misses, adds, ejects, hitRate*100, missRate*100)
+	log.Debugf("Cache statistics: hits=%d misses=%d adds=%d ejects=%d hitRate=%f%% missRate=%f%%", hits, misses, adds, ejects, hitRate*100, missRate*100)
 }

--- a/src/zdns/cache_stats.go
+++ b/src/zdns/cache_stats.go
@@ -20,44 +20,48 @@ import (
 )
 
 type CacheStatistics struct {
-	ShouldCaptureStatistics bool
-	Hits                    atomic.Uint64 // number of reads to the cache that result in a hit
-	Misses                  atomic.Uint64 // number of reads to the cache that result in a miss
-	Adds                    atomic.Uint64 // number of writes to the cache
-	Ejects                  atomic.Uint64 // number of cache entries that are ejected due to insertions
+	shouldCaptureStatistics bool
+	hits                    atomic.Uint64 // number of reads to the cache that result in a hit
+	misses                  atomic.Uint64 // number of reads to the cache that result in a miss
+	adds                    atomic.Uint64 // number of writes to the cache
+	ejects                  atomic.Uint64 // number of cache entries that are ejected due to insertions
 }
 
 func (s *CacheStatistics) IncrementHits() {
-	if s.ShouldCaptureStatistics {
-		s.Hits.Add(1)
+	if s.shouldCaptureStatistics {
+		s.hits.Add(1)
 	}
 }
 
+func (s *CacheStatistics) CaptureStatistics() {
+	s.shouldCaptureStatistics = true
+}
+
 func (s *CacheStatistics) IncrementMisses() {
-	if s.ShouldCaptureStatistics {
-		s.Misses.Add(1)
+	if s.shouldCaptureStatistics {
+		s.misses.Add(1)
 	}
 }
 
 func (s *CacheStatistics) IncrementAdds() {
-	if s.ShouldCaptureStatistics {
-		s.Adds.Add(1)
+	if s.shouldCaptureStatistics {
+		s.adds.Add(1)
 	}
 }
 
 func (s *CacheStatistics) IncrementEjects() {
-	if s.ShouldCaptureStatistics {
-		s.Ejects.Add(1)
+	if s.shouldCaptureStatistics {
+		s.ejects.Add(1)
 	}
 }
 
 func (s *CacheStatistics) PrintStatistics() {
-	hits := s.Hits.Load()
-	misses := s.Misses.Load()
-	adds := s.Adds.Load()
-	ejects := s.Ejects.Load()
+	hits := s.hits.Load()
+	misses := s.misses.Load()
+	adds := s.adds.Load()
+	ejects := s.ejects.Load()
 	total := hits + misses
 	hitRate := float64(hits) / float64(total)
 	missRate := float64(misses) / float64(total)
-	fmt.Printf("Cache statistics: hits=%d misses=%d adds=%d ejects=%d hitRate=%f missRate=%f\n", hits, misses, adds, ejects, hitRate, missRate)
+	fmt.Printf("Cache statistics: hits=%d misses=%d adds=%d ejects=%d hitRate=%f%% missRate=%f%%\n", hits, misses, adds, ejects, hitRate*100, missRate*100)
 }

--- a/src/zdns/cache_stats.go
+++ b/src/zdns/cache_stats.go
@@ -27,25 +27,25 @@ type CacheStatistics struct {
 	Ejects                  atomic.Uint64 // number of cache entries that are ejected due to insertions
 }
 
-func (s *CacheStatistics) incrementHits() {
+func (s *CacheStatistics) IncrementHits() {
 	if s.ShouldCaptureStatistics {
 		s.Hits.Add(1)
 	}
 }
 
-func (s *CacheStatistics) incrementMisses() {
+func (s *CacheStatistics) IncrementMisses() {
 	if s.ShouldCaptureStatistics {
 		s.Misses.Add(1)
 	}
 }
 
-func (s *CacheStatistics) incrementAdds() {
+func (s *CacheStatistics) IncrementAdds() {
 	if s.ShouldCaptureStatistics {
 		s.Adds.Add(1)
 	}
 }
 
-func (s *CacheStatistics) incrementEjects() {
+func (s *CacheStatistics) IncrementEjects() {
 	if s.ShouldCaptureStatistics {
 		s.Ejects.Add(1)
 	}

--- a/src/zdns/cache_stats.go
+++ b/src/zdns/cache_stats.go
@@ -27,35 +27,35 @@ type CacheStatistics struct {
 	Ejects                  atomic.Uint64 // number of cache entries that are ejected due to insertions
 }
 
-func (s *Cache) incrementHits() {
-	if s.stats.ShouldCaptureStatistics {
-		s.stats.Hits.Add(1)
+func (s *CacheStatistics) incrementHits() {
+	if s.ShouldCaptureStatistics {
+		s.Hits.Add(1)
 	}
 }
 
-func (s *Cache) incrementMisses() {
-	if s.stats.ShouldCaptureStatistics {
-		s.stats.Misses.Add(1)
+func (s *CacheStatistics) incrementMisses() {
+	if s.ShouldCaptureStatistics {
+		s.Misses.Add(1)
 	}
 }
 
-func (s *Cache) incrementAdds() {
-	if s.stats.ShouldCaptureStatistics {
-		s.stats.Adds.Add(1)
+func (s *CacheStatistics) incrementAdds() {
+	if s.ShouldCaptureStatistics {
+		s.Adds.Add(1)
 	}
 }
 
-func (s *Cache) incrementEjects() {
-	if s.stats.ShouldCaptureStatistics {
-		s.stats.Ejects.Add(1)
+func (s *CacheStatistics) incrementEjects() {
+	if s.ShouldCaptureStatistics {
+		s.Ejects.Add(1)
 	}
 }
 
-func (s *Cache) PrintStatistics() {
-	hits := s.stats.Hits.Load()
-	misses := s.stats.Misses.Load()
-	adds := s.stats.Adds.Load()
-	ejects := s.stats.Ejects.Load()
+func (s *CacheStatistics) PrintStatistics() {
+	hits := s.Hits.Load()
+	misses := s.Misses.Load()
+	adds := s.Adds.Load()
+	ejects := s.Ejects.Load()
 	total := hits + misses
 	hitRate := float64(hits) / float64(total)
 	missRate := float64(misses) / float64(total)

--- a/src/zdns/cache_test.go
+++ b/src/zdns/cache_test.go
@@ -14,9 +14,10 @@
 package zdns
 
 import (
-	"github.com/zmap/dns"
 	"net"
 	"testing"
+
+	"github.com/zmap/dns"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -476,7 +476,7 @@ func (r *Resolver) cachedRetryingLookup(ctx context.Context, q Question, nameSer
 	result, status, try, err := r.retryingLookup(ctx, q, nameServer, requestIteration)
 	r.verboseLog(depth+2, "Results from wire for name: ", q, ", Layer: ", layer, ", Nameserver: ", nameServer, " status: ", status, " , err: ", err, " result: ", result)
 
-	if !requestIteration && strings.ToLower(q.Name) != layer && authName != layer {
+	if !requestIteration && strings.ToLower(q.Name) != layer && authName != layer && q.Name != authName { // TODO - how to detect if we've retrieved an authority record or a answer record? maybe add q.Name != authName
 		r.verboseLog(depth+2, "Cache auth upsert for ", authName)
 		r.cache.SafeAddCachedAuthority(&result, cacheNameServer, depth+2, layer)
 

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -476,7 +476,7 @@ func (r *Resolver) cachedRetryingLookup(ctx context.Context, q Question, nameSer
 	result, status, try, err := r.retryingLookup(ctx, q, nameServer, requestIteration)
 	r.verboseLog(depth+2, "Results from wire for name: ", q, ", Layer: ", layer, ", Nameserver: ", nameServer, " status: ", status, " , err: ", err, " result: ", result)
 
-	if !requestIteration && strings.ToLower(q.Name) != layer && authName != layer && q.Name != authName { // TODO - how to detect if we've retrieved an authority record or a answer record? maybe add q.Name != authName
+	if !requestIteration && strings.ToLower(q.Name) != layer && authName != layer && !result.Flags.Authoritative { // TODO - how to detect if we've retrieved an authority record or a answer record? maybe add q.Name != authName
 		r.verboseLog(depth+2, "Cache auth upsert for ", authName)
 		r.cache.SafeAddCachedAuthority(&result, cacheNameServer, depth+2, layer)
 

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -478,7 +478,7 @@ func (r *Resolver) cachedRetryingLookup(ctx context.Context, q Question, nameSer
 
 	if !requestIteration && strings.ToLower(q.Name) != layer && authName != layer {
 		r.verboseLog(depth+2, "Cache auth upsert for ", authName)
-		r.cache.SafeAddCachedAuthority(&result, nameServer, depth+2, layer)
+		r.cache.SafeAddCachedAuthority(&result, cacheNameServer, depth+2, layer)
 
 	} else {
 		r.cache.SafeAddCachedAnswer(q, &result, cacheNameServer, layer, depth+2, cacheNonAuthoritative)

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -21,12 +21,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/zmap/zcrypto/x509"
-
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/dns"
 	"github.com/zmap/zcrypto/tls"
+	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zgrab2/lib/http"
 	"github.com/zmap/zgrab2/lib/output"
 

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -437,75 +437,34 @@ func (r *Resolver) cachedRetryingLookup(ctx context.Context, q Question, nameSer
 			return r, isCached, StatusBlacklist, 0, nil
 		}
 	}
+	var authName string
 	if !requestIteration {
 		// We're performing our own iteration, let's try checking the cache for the next authority
 		// For example, if we query yahoo.com and google.com, we don't need to go to the root servers for the gTLD
 		// servers twice, they'll be identical
 		name := strings.ToLower(q.Name)
 		layer = strings.ToLower(layer)
+		var err error
 		// get the next authority to query
-		authName, err := nextAuthority(name, layer)
+		authName, err = nextAuthority(name, layer)
 		if err != nil {
 			r.verboseLog(depth+2, err)
 			return SingleQueryResult{}, isCached, StatusAuthFail, 0, errors.Wrap(err, "could not get next authority with name: "+name+" and layer: "+layer)
 		}
-		if name != layer && authName != layer {
+		// Only cache the root -> gTLD authoritative lookups
+		if layer == "." && name != layer && authName != layer {
 			// we have a valid authority to check the cache for
-			var result SingleQueryResult
-			result.Answers = make([]interface{}, 0)
-			result.Additional = make([]interface{}, 0)
-			result.Authorities = make([]interface{}, 0)
 			if authName == "" {
 				r.verboseLog(depth+2, "Can't parse name to authority properly. name: ", name, ", layer: ", layer)
 				return SingleQueryResult{}, isCached, StatusAuthFail, 0, nil
 			}
 			r.verboseLog(depth+2, "Cache auth check for ", authName)
-			var qAuth Question
-			qAuth.Name = authName
-			qAuth.Type = dns.TypeNS
-			qAuth.Class = dns.ClassINET
-			cachedResult, ok = r.cache.GetCachedResult(qAuth, nil, depth+2)
+			cachedResult, ok = r.cache.GetLayerNameServers(authName)
 			if ok {
-				isCached = true
-				// we have a cache hit on the NS record for the authorities. Let's construct a response with the NS
-				// record. However, the caller is going to expect an answer as if they'd queried the root server, so we
-				// need to populate the authority and additionals, and remove the NS answers since the caller didn't
-				// perform an NS lookup.
-				for _, ans := range cachedResult.Answers {
-					ns, ansOk := ans.(Answer)
-					if !ansOk {
-						continue
-					}
-					if ns.Type == "NS" {
-						result.Authorities = append(result.Authorities, ns)
-					}
-				}
-				// populate the additionals from the cache
-				// starting with A records
-				for _, ans := range cachedResult.Answers {
-					var qAdd Question
-					qAdd.Name = strings.TrimSuffix(ans.(Answer).Answer, ".")
-					qAdd.Type = dns.TypeA
-					qAdd.Class = dns.ClassINET
-					cachedResult, ok = r.cache.GetCachedResult(qAdd, nil, depth+2)
-					if ok {
-						result.Additional = append(result.Additional, cachedResult.Answers...)
-					}
-				}
-				// now AAAA records
-				for _, ans := range cachedResult.Answers {
-					var qAdd Question
-					qAdd.Name = strings.TrimSuffix(ans.(Answer).Answer, ".")
-					qAdd.Type = dns.TypeAAAA
-					qAdd.Class = dns.ClassINET
-					cachedResult, ok = r.cache.GetCachedResult(qAdd, nil, depth+2)
-					if ok {
-						result.Additional = append(result.Additional, cachedResult.Answers...)
-					}
-				}
+				r.verboseLog(depth+2, "Cache auth hit for ", authName)
 				// only want to return if we actually have additionals and authorities from the cache for the caller
-				if len(result.Additional) > 0 && len(result.Authorities) > 0 {
-					return result, isCached, StatusNoError, 0, nil
+				if len(cachedResult.Additional) > 0 && len(cachedResult.Authorities) > 0 {
+					return cachedResult, true, StatusNoError, 0, nil
 				}
 				// unsuccessful in retrieving from the cache, we'll continue to the wire
 			}
@@ -517,7 +476,14 @@ func (r *Resolver) cachedRetryingLookup(ctx context.Context, q Question, nameSer
 	result, status, try, err := r.retryingLookup(ctx, q, nameServer, requestIteration)
 	r.verboseLog(depth+2, "Results from wire for name: ", q, ", Layer: ", layer, ", Nameserver: ", nameServer, " status: ", status, " , err: ", err, " result: ", result)
 
-	r.cache.CacheUpdate(layer, result, cacheNameServer, depth+2, cacheNonAuthoritative)
+	// TODO need to update the cache if this is an auth lookup
+	if !requestIteration && layer == "." && strings.ToLower(q.Name) != layer && authName != layer {
+		r.verboseLog(depth+2, "Cache auth upsert for ", authName)
+		r.cache.SafeAddLayerNameServers(authName, result, nameServer, depth+2, cacheNonAuthoritative)
+
+	} else {
+		r.cache.CacheUpdate(layer, result, cacheNameServer, depth+2, cacheNonAuthoritative)
+	}
 	return result, isCached, status, try, err
 }
 

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -513,7 +513,9 @@ func (r *Resolver) cachedRetryingLookup(ctx context.Context, q Question, nameSer
 	}
 
 	// Alright, we're not sure what to do, go to the wire.
+	r.verboseLog(depth+2, "Cache miss for ", q, ", Layer: ", layer, ", Nameserver: ", nameServer, " going to the wire in retryingLookup")
 	result, status, try, err := r.retryingLookup(ctx, q, nameServer, requestIteration)
+	r.verboseLog(depth+2, "Results from wire for name: ", q, ", Layer: ", layer, ", Nameserver: ", nameServer, " status: ", status, " , err: ", err, " result: ", result)
 
 	r.cache.CacheUpdate(layer, result, cacheNameServer, depth+2, cacheNonAuthoritative)
 	return result, isCached, status, try, err
@@ -937,11 +939,11 @@ func (r *Resolver) extractAuthority(ctx context.Context, authority interface{}, 
 	// that would normally be cache poison. Because it's "ok" and quite common
 	res, status := checkGlue(server, *result, r.ipVersionMode, r.iterationIPPreference)
 	if status != StatusNoError {
-		if ok, _ = nameIsBeneath(server, layer); ok {
-			// The domain we're searching for is beneath us but no glue was returned. We cannot proceed without this Glue.
-			// Terminating
-			return nil, StatusNoNeededGlue, "", trace
-		}
+		//if ok, _ = nameIsBeneath(server, layer); ok {
+		//	// Glue is optional, so if we don't have it try to lookup the server directly
+		//	// Terminating
+		//	return nil, StatusNoNeededGlue, "", trace
+		//}
 		// Fall through to normal query
 		var q Question
 		q.Name = server

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -691,5 +691,7 @@ func (r *Resolver) randomRootNameServer() *NameServer {
 }
 
 func (r *Resolver) verboseLog(depth int, args ...interface{}) {
-	log.Debug(makeVerbosePrefix(depth), args)
+	if log.GetLevel() >= log.DebugLevel {
+		log.Debug(makeVerbosePrefix(depth), args)
+	}
 }

--- a/src/zdns/util.go
+++ b/src/zdns/util.go
@@ -43,10 +43,6 @@ func isStatusAnswer(s Status) bool {
 	return false
 }
 
-func questionFromAnswer(a Answer) Question {
-	return Question{Name: a.Name, Type: a.RrType, Class: a.RrClass}
-}
-
 func nameIsBeneath(name, layer string) (bool, string) {
 	name = strings.ToLower(name)
 	layer = strings.ToLower(layer)

--- a/src/zdns/util.go
+++ b/src/zdns/util.go
@@ -61,7 +61,7 @@ func nameIsBeneath(name, layer string) (bool, string) {
 	return false, ""
 }
 
-func checkGlue(server string, result SingleQueryResult, ipMode IPVersionMode, ipPreference IterationIPPreference) (SingleQueryResult, Status) {
+func checkGlue(server string, result *SingleQueryResult, ipMode IPVersionMode, ipPreference IterationIPPreference) (*SingleQueryResult, Status) {
 	var ansType string
 	if ipMode == IPv4Only {
 		ansType = "A"
@@ -90,7 +90,7 @@ func checkGlue(server string, result SingleQueryResult, ipMode IPVersionMode, ip
 	return checkGlueHelper(server, ansType, result)
 }
 
-func checkGlueHelper(server, ansType string, result SingleQueryResult) (SingleQueryResult, Status) {
+func checkGlueHelper(server, ansType string, result *SingleQueryResult) (*SingleQueryResult, Status) {
 	for _, additional := range result.Additional {
 		ans, ok := additional.(Answer)
 		if !ok {
@@ -104,10 +104,10 @@ func checkGlueHelper(server, ansType string, result SingleQueryResult) (SingleQu
 			retv.Answers = make([]interface{}, 0, 1)
 			retv.Additional = make([]interface{}, 0)
 			retv.Answers = append(retv.Answers, ans)
-			return retv, StatusNoError
+			return &retv, StatusNoError
 		}
 	}
-	return SingleQueryResult{}, StatusError
+	return nil, StatusError
 }
 
 // nextAuthority returns the next authority to query based on the current name and layer


### PR DESCRIPTION
## Description
Prior to this change, we were adding `Authorities` and `Additionals` as separate records in the cache. This meant that the `Authorities` was inserted as an NS record, but the Additionals were inserted as separate A/AAAA records. Separately, our cache is an LRU cache with 4096 shards, 2 entries per shard by default. What this means is that we have no guarantees that all of a domain's Authorities + Additionals are in the cache, since a partial set can be evicted.

This loss of accuracy was what caused the `NONEEDEDGLUE` records to pop up, especially as more domains in the same run.

## Changes
- Add CacheStats that capture cache hits, misses, evictions with `--verbosity=5`. No performance impact if `--verbosity < 5`
   - Ex: `time="2024-09-27T20:28:52Z" level=debug msg="Cache statistics: hits=29870 misses=85581 adds=30790 ejects=21604 hitRate=25.872448% missRate=74.127552%"`
- Switched to using a single `SingleQueryResult` pointer vs. returning the struct since each function would have to create a new structure and copy the internals. The pointer avoids this.
- Re-wrote cache so that an entire `Authority` record or `Answer record are stored atomically
    - `Authority` records store the authority's for a certain domain - `.com`
    - `Answer` records store the authoritative answers for a certain query - `A google.com`

## Performance
Tested with 10000 top domains, `A --iterative --threads=100 --verbosity=5`
### main
Runtime - 37.2 s
Allocs - 2199 MB total allocations (this is not peak memory use since the Garbage Collector cleans up un-used memory, this is just total allocated objects)
NOERROR - 9919
TIMEOUT/ITERATIVE_TIMEOUT - 5
NXDOMAIN - 54

### Branch
Runtime - 33.9 s
Allocs - 1216 MB
NOERROR - 9916
TIMEOUT/ITERATIVE_TIMEOUT - 9
NXDOMAIN - 55

Main takeaway is there was a sharp reduction in allocations, however the runtime reduction wasn't that large (and likely within the margin of error, other A/B tests didn't show such a large delta), so it seems garbage collection is not our bottleneck.

Either way, I think this is a needed change for cache use.