### PR TITLE
feat: DNSSEC Validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.20"
       - name: Build
         run: |
           go version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: Build
         run: |
           go version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: "1.21"
       - name: Build
         run: |
           go version
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: "1.23"
       - name: Other lint
         run: |
           go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/large_scan_integration_test.yml
+++ b/.github/workflows/large_scan_integration_test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Build
         run: |
           go version

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.iml
 *.code-workspace
 /zdns
+*.log

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ result verbosity levels: `short`, `normal` (default), `long`, and `trace`:
 
 Users can also include specific additional fields using the `--include-fields`
 flag and specifying a list of fields, e.g., `--include-fields=flags,resolver`.
-Additional fields are: class, protocol, ttl, resolver, flags.
+Additional fields are: class, protocol, ttl, resolver, flags, dnssec.
 
 Name Server Mode
 ----------------

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.15.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
-	github.com/zmap/go-dns-root-anchors v0.0.0-20241013070941-7d9393cc3f64
+	github.com/zmap/go-dns-root-anchors v0.0.0-20241116225636-aa592d6ee59f
 	github.com/zmap/go-iptree v0.0.0-20210731043055-d4e632617837
 	github.com/zmap/zcrypto v0.0.0-20240803002437-3a861682ac77
 	github.com/zmap/zflags v1.4.0-beta.1.0.20200204220219-9d95409821b6

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/zmap/zdns
 
 go 1.21.1
 
+toolchain go1.23.3
+
 require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/liip/sheriff v0.12.0
@@ -9,8 +11,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/schollz/progressbar/v3 v3.15.0
 	github.com/sirupsen/logrus v1.9.3
-	github.com/zmap/go-dns-root-anchors v0.0.0-20241116225636-aa592d6ee59f
 	github.com/stretchr/testify v1.10.0
+	github.com/zmap/go-dns-root-anchors v0.0.0-20241116225636-aa592d6ee59f
 	github.com/zmap/go-iptree v0.0.0-20210731043055-d4e632617837
 	github.com/zmap/zcrypto v0.0.0-20240803002437-3a861682ac77
 	github.com/zmap/zflags v1.4.0-beta.1.0.20200204220219-9d95409821b6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zmap/zdns
 
-go 1.20
+go 1.21.1
 
 require (
 	github.com/hashicorp/go-version v1.7.0
@@ -10,6 +10,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.15.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
+	github.com/zmap/go-dns-root-anchors v0.0.0-20241013070941-7d9393cc3f64
 	github.com/zmap/go-iptree v0.0.0-20210731043055-d4e632617837
 	github.com/zmap/zcrypto v0.0.0-20240803002437-3a861682ac77
 	github.com/zmap/zflags v1.4.0-beta.1.0.20200204220219-9d95409821b6

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/zmap/zdns
 
 go 1.20
 
-toolchain go1.23.3
-
 require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/liip/sheriff v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zmap/zdns
 
-go 1.21.1
+go 1.20
 
 toolchain go1.23.3
 
@@ -12,7 +12,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.15.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
-	github.com/zmap/go-dns-root-anchors v0.0.0-20241116225636-aa592d6ee59f
+	github.com/zmap/go-dns-root-anchors v0.0.0-20241218192521-63aee68224b6
 	github.com/zmap/go-iptree v0.0.0-20210731043055-d4e632617837
 	github.com/zmap/zcrypto v0.0.0-20240803002437-3a861682ac77
 	github.com/zmap/zflags v1.4.0-beta.1.0.20200204220219-9d95409821b6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zmap/zdns
 
-go 1.20
+go 1.21
 
 require (
 	github.com/hashicorp/go-version v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zmap/dns v1.1.63-zdns1 h1:vaZIXXLZqjmZTGcpu9qPDcunqWfxeRMh0OwLiCxcjsI=
 github.com/zmap/dns v1.1.63-zdns1/go.mod h1:L50pXblXGxDFLaon9W4vGSfC1rGIcBL29sS7sNvNKuI=
-github.com/zmap/go-dns-root-anchors v0.0.0-20241013070941-7d9393cc3f64 h1:nimnL754tetLIX/BtOp7lXk5H2/Jqo472MYBNhWTgAo=
-github.com/zmap/go-dns-root-anchors v0.0.0-20241013070941-7d9393cc3f64/go.mod h1:AkYq/HWOOEFPx6YgVn2oYjaZjLw2R/HV5WUWfJrFQ6s=
+github.com/zmap/go-dns-root-anchors v0.0.0-20241116225636-aa592d6ee59f h1:XffIjsyncaK1BH7GpceohPRnesxBaO7lduwbXG05ICo=
+github.com/zmap/go-dns-root-anchors v0.0.0-20241116225636-aa592d6ee59f/go.mod h1:AkYq/HWOOEFPx6YgVn2oYjaZjLw2R/HV5WUWfJrFQ6s=
 github.com/zmap/go-iptree v0.0.0-20210731043055-d4e632617837 h1:DjHnADS2r2zynZ3WkCFAQ+PNYngMSNceRROi0pO6c3M=
 github.com/zmap/go-iptree v0.0.0-20210731043055-d4e632617837/go.mod h1:9vp0bxqozzQwcjBwenEXfKVq8+mYbwHkQ1NF9Ap0DMw=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zmap/dns v1.1.63-zdns1 h1:vaZIXXLZqjmZTGcpu9qPDcunqWfxeRMh0OwLiCxcjsI=
 github.com/zmap/dns v1.1.63-zdns1/go.mod h1:L50pXblXGxDFLaon9W4vGSfC1rGIcBL29sS7sNvNKuI=
-github.com/zmap/go-dns-root-anchors v0.0.0-20241116225636-aa592d6ee59f h1:XffIjsyncaK1BH7GpceohPRnesxBaO7lduwbXG05ICo=
-github.com/zmap/go-dns-root-anchors v0.0.0-20241116225636-aa592d6ee59f/go.mod h1:AkYq/HWOOEFPx6YgVn2oYjaZjLw2R/HV5WUWfJrFQ6s=
+github.com/zmap/go-dns-root-anchors v0.0.0-20241218192521-63aee68224b6 h1:vJV1O3ZIH9ywqPKaiYCHkyZOZmSZvdRHjlqmBk3JIIs=
+github.com/zmap/go-dns-root-anchors v0.0.0-20241218192521-63aee68224b6/go.mod h1:cmGnqnZjrvWCBaJclyvXNP6yHEDjwoSV06GmM1zmdXU=
 github.com/zmap/go-iptree v0.0.0-20210731043055-d4e632617837 h1:DjHnADS2r2zynZ3WkCFAQ+PNYngMSNceRROi0pO6c3M=
 github.com/zmap/go-iptree v0.0.0-20210731043055-d4e632617837/go.mod h1:9vp0bxqozzQwcjBwenEXfKVq8+mYbwHkQ1NF9Ap0DMw=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zmap/dns v1.1.63-zdns1 h1:vaZIXXLZqjmZTGcpu9qPDcunqWfxeRMh0OwLiCxcjsI=
 github.com/zmap/dns v1.1.63-zdns1/go.mod h1:L50pXblXGxDFLaon9W4vGSfC1rGIcBL29sS7sNvNKuI=
+github.com/zmap/go-dns-root-anchors v0.0.0-20241013070941-7d9393cc3f64 h1:nimnL754tetLIX/BtOp7lXk5H2/Jqo472MYBNhWTgAo=
+github.com/zmap/go-dns-root-anchors v0.0.0-20241013070941-7d9393cc3f64/go.mod h1:AkYq/HWOOEFPx6YgVn2oYjaZjLw2R/HV5WUWfJrFQ6s=
 github.com/zmap/go-iptree v0.0.0-20210731043055-d4e632617837 h1:DjHnADS2r2zynZ3WkCFAQ+PNYngMSNceRROi0pO6c3M=
 github.com/zmap/go-iptree v0.0.0-20210731043055-d4e632617837/go.mod h1:9vp0bxqozzQwcjBwenEXfKVq8+mYbwHkQ1NF9Ap0DMw=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -91,7 +91,7 @@ type InputOutputOptions struct {
 	BlacklistFilePath            string `long:"blacklist-file" description:"blacklist file for servers to exclude from lookups"`
 	DNSConfigFilePath            string `long:"conf-file" default:"/etc/resolv.conf" description:"config file for DNS servers"`
 	MultipleModuleConfigFilePath string `short:"c" long:"multi-config-file" description:"config file path for multiple module"`
-	IncludeInOutput              string `long:"include-fields" description:"Comma separated list of fields to additionally output beyond result verbosity. Options: class, protocol, ttl, resolver, flags"`
+	IncludeInOutput              string `long:"include-fields" description:"Comma separated list of fields to additionally output beyond result verbosity. Options: class, protocol, ttl, resolver, flags, dnssec"`
 	InputFilePath                string `short:"f" long:"input-file" default:"-" description:"names to read, defaults to stdin"`
 	LogFilePath                  string `long:"log-file" default:"-" description:"where should JSON logs be saved, defaults to stderr"`
 	MetadataFilePath             string `long:"metadata-file" description:"where should JSON metadata be saved, defaults to no metadata output. Use '-' for stderr."`

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -64,6 +64,7 @@ type QueryOptions struct {
 	ClassString        string `long:"class" default:"INET" description:"DNS class to query. Options: INET, CSNET, CHAOS, HESIOD, NONE, ANY."`
 	ClientSubnetString string `long:"client-subnet" description:"Client subnet in CIDR format for EDNS0."`
 	Dnssec             bool   `long:"dnssec" description:"Requests DNSSEC records by setting the DNSSEC OK (DO) bit"`
+	ValidateDNSSEC     bool   `long:"validate-dnssec" description:"Validate DNSSEC records, only applicable with --iterative"`
 	UseNSID            bool   `long:"nsid" description:"Request NSID."`
 }
 

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -211,7 +211,17 @@ func populateResolverConfig(gc *CLIConf) *zdns.ResolverConfig {
 	config.MaxDepth = gc.MaxDepth
 	config.CheckingDisabledBit = gc.CheckingDisabled
 	config.ShouldRecycleSockets = !gc.DisableRecycleSockets
-	config.DNSSecEnabled = gc.Dnssec
+
+	config.ShouldValidateDNSSEC = gc.ValidateDNSSEC
+	if config.ShouldValidateDNSSEC {
+		config.DNSSecEnabled = true
+		if !gc.IterativeResolution {
+			log.Fatal("DNSSEC validation is only supported with iterative resolution")
+		}
+	} else {
+		config.DNSSecEnabled = gc.Dnssec
+	}
+
 	config.DNSConfigFilePath = gc.DNSConfigFilePath
 
 	config.LogLevel = log.Level(gc.Verbosity)

--- a/src/zdns/answers.go
+++ b/src/zdns/answers.go
@@ -220,12 +220,12 @@ type RRSIGAnswer struct {
 func (r *RRSIGAnswer) ToVanillaType() *dns.RRSIG {
 	expiration, err := dns.StringToTime(r.Expiration)
 	if err != nil {
-		panic(fmt.Sprintf("failed to parse expiration time: %s", r.Expiration))
+		panic("failed to parse expiration time: " + r.Expiration)
 	}
 
 	inception, err := dns.StringToTime(r.Inception)
 	if err != nil {
-		panic(fmt.Sprintf("failed to parse inception time: %s", r.Inception))
+		panic("failed to parse inception time: " + r.Inception)
 	}
 
 	return &dns.RRSIG{

--- a/src/zdns/answers.go
+++ b/src/zdns/answers.go
@@ -78,12 +78,43 @@ type DNSKEYAnswer struct {
 	PublicKey string `json:"public_key" groups:"short,normal,long,trace"`
 }
 
+func (r *DNSKEYAnswer) ToVanillaType() *dns.DNSKEY {
+	return &dns.DNSKEY{
+		Hdr: dns.RR_Header{
+			Name:   dns.CanonicalName(r.Name),
+			Rrtype: r.RrType,
+			Class:  dns.StringToClass[r.Class],
+			Ttl:    r.TTL,
+		},
+		Flags:     r.Flags,
+		Protocol:  r.Protocol,
+		Algorithm: r.Algorithm,
+		PublicKey: r.PublicKey,
+	}
+}
+
 type DSAnswer struct {
 	Answer
 	KeyTag     uint16 `json:"key_tag" groups:"short,normal,long,trace"`
 	Algorithm  uint8  `json:"algorithm" groups:"short,normal,long,trace"`
 	DigestType uint8  `json:"digest_type" groups:"short,normal,long,trace"`
 	Digest     string `json:"digest" groups:"short,normal,long,trace"`
+}
+
+func (r *DSAnswer) ToVanillaType() *dns.DS {
+	return &dns.DS{
+		Hdr: dns.RR_Header{
+
+			Name:   dns.CanonicalName(r.Name),
+			Rrtype: r.RrType,
+			Class:  dns.StringToClass[r.Class],
+			Ttl:    r.TTL,
+		},
+		KeyTag:     r.KeyTag,
+		Algorithm:  r.Algorithm,
+		DigestType: r.DigestType,
+		Digest:     r.Digest,
+	}
 }
 
 type GPOSAnswer struct {
@@ -184,6 +215,36 @@ type RRSIGAnswer struct {
 	KeyTag      uint16 `json:"keytag" groups:"short,normal,long,trace"`
 	SignerName  string `json:"signer_name" groups:"short,normal,long,trace"`
 	Signature   string `json:"signature" groups:"short,normal,long,trace"`
+}
+
+func (r *RRSIGAnswer) ToVanillaType() *dns.RRSIG {
+	expiration, err := dns.StringToTime(r.Expiration)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse expiration time: %s", r.Expiration))
+	}
+
+	inception, err := dns.StringToTime(r.Inception)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse inception time: %s", r.Inception))
+	}
+
+	return &dns.RRSIG{
+		Hdr: dns.RR_Header{
+			Name:   dns.CanonicalName(r.Name),
+			Rrtype: r.RrType,
+			Class:  dns.StringToClass[r.Class],
+			Ttl:    r.TTL,
+		},
+		TypeCovered: r.TypeCovered,
+		Algorithm:   r.Algorithm,
+		Labels:      r.Labels,
+		OrigTtl:     r.OriginalTTL,
+		Expiration:  expiration,
+		Inception:   inception,
+		KeyTag:      r.KeyTag,
+		SignerName:  r.SignerName,
+		Signature:   r.Signature,
+	}
 }
 
 type RPAnswer struct {

--- a/src/zdns/answers.go
+++ b/src/zdns/answers.go
@@ -420,8 +420,9 @@ func makeBitString(bm []uint16) string {
 }
 
 func makeBitArray(s string) []uint16 {
-	var retv []uint16
-	for _, t := range strings.Fields(s) {
+	fields := strings.Fields(s)
+	retv := make([]uint16, 0, len(fields))
+	for _, t := range fields {
 		retv = append(retv, dns.StringToType[t])
 	}
 	return retv

--- a/src/zdns/cache.go
+++ b/src/zdns/cache.go
@@ -14,6 +14,7 @@
 package zdns
 
 import (
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -251,7 +252,7 @@ func (s *Cache) SafeAddCachedAnswer(q Question, res *SingleQueryResult, ns *Name
 			continue
 		}
 		baseAns := castAns.BaseAns()
-		if ok, _ = nameIsBeneath(baseAns.Name, layer); !ok {
+		if ok, _ = nameIsBeneath(baseAns.Name, layer); !ok && baseAns.Type != dns.TypeToString[dns.TypeNSEC3] {
 			if len(nsString) > 0 {
 				s.VerboseLog(depth+1, "SafeAddCachedAnswer: detected poison: ", baseAns.Name, "(", baseAns.Type, "): @", nsString, ", ", layer, " , aborting")
 			} else {
@@ -296,11 +297,11 @@ func (s *Cache) SafeAddCachedAuthority(res *SingleQueryResult, ns *NameServer, d
 			// We'll log in buildCachedResult
 			continue
 		}
-		baseAns := castAuth.BaseAns()
+		currName := strings.ToLower(castAuth.BaseAns().Name)
 		if len(authName) == 0 {
-			authName = baseAns.Name
-		} else if authName != baseAns.Name {
-			s.VerboseLog(depth+1, "SafeAddCachedAuthority: multiple authority names: ", layer, ": ", authName, " ", baseAns.Name, " , aborting")
+			authName = currName
+		} else if authName != currName {
+			s.VerboseLog(depth+1, "SafeAddCachedAuthority: multiple authority names: ", layer, ": ", authName, " ", currName, " , aborting")
 			return
 		}
 	}

--- a/src/zdns/cache.go
+++ b/src/zdns/cache.go
@@ -338,7 +338,13 @@ func (s *Cache) SafeAddCachedAuthority(res *SingleQueryResult, ns *NameServer, d
 		}
 	}
 
-	res.Authorities = otherRRs
+	res = &SingleQueryResult{
+		Answers:            otherRRs,
+		Protocol:           res.Protocol,
+		Resolver:           res.Resolver,
+		Flags:              res.Flags,
+		TLSServerHandshake: res.TLSServerHandshake,
+	}
 	cachedRes := s.buildCachedResult(res, depth, layer)
 	if len(cachedRes.Answers) == 0 && len(cachedRes.Authorities) == 0 && len(cachedRes.Additionals) == 0 {
 		s.VerboseLog(depth+1, "SafeAddCachedAnswer: no cacheable records found, aborting")

--- a/src/zdns/cache.go
+++ b/src/zdns/cache.go
@@ -338,14 +338,9 @@ func (s *Cache) SafeAddCachedAuthority(res *SingleQueryResult, ns *NameServer, d
 		}
 	}
 
-	res = &SingleQueryResult{
-		Answers:            otherRRs,
-		Protocol:           res.Protocol,
-		Resolver:           res.Resolver,
-		Flags:              res.Flags,
-		TLSServerHandshake: res.TLSServerHandshake,
-	}
-	cachedRes := s.buildCachedResult(res, depth, layer)
+	copiedRes := *res
+	copiedRes.Authorities = otherRRs
+	cachedRes := s.buildCachedResult(&copiedRes, depth, layer)
 	if len(cachedRes.Answers) == 0 && len(cachedRes.Authorities) == 0 && len(cachedRes.Additionals) == 0 {
 		s.VerboseLog(depth+1, "SafeAddCachedAnswer: no cacheable records found, aborting")
 		return

--- a/src/zdns/conf.go
+++ b/src/zdns/conf.go
@@ -49,7 +49,16 @@ const (
 	StatusIterTimeout  Status = "ITERATIVE_TIMEOUT"
 	StatusNoAuth       Status = "NOAUTH"
 	StatusNoNeededGlue Status = "NONEEDEDGLUE" // When a nameserver is authoritative for itself and the parent nameserver doesn't provide the glue to look it up
+	StatusCircular     Status = "CIRCULAR"     // When circular query dependencies are detected
 )
+
+func isStatusRetryable(status Status) bool {
+	switch status {
+	case StatusServFail, StatusNXDomain, StatusRefused, StatusTruncated, StatusError, StatusTimeout, StatusIterTimeout:
+		return true
+	}
+	return false
+}
 
 var RootServersV4 = []NameServer{
 	{IP: net.ParseIP("198.41.0.4"), Port: 53},     // A

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -422,6 +422,14 @@ func (v *dNSSECValidator) fetchDSRecords(signerDomain string, trace Trace, depth
 				v.r.verboseLog(depth, "DNSSEC: Found matching NSEC3 proving DS non-existence for", signerDomain)
 				return nil, true, trace, nil
 			}
+		} else if zTypedNSEC, ok := rr.(NSECAnswer); ok {
+			nsec := zTypedNSEC.ToVanillaType()
+			if dns.CanonicalName(nsec.Header().Name) == signerDomain && !slices.Contains(nsec.TypeBitMap, dns.TypeDS) {
+				// NSEC record directly matching the signer domain and proving DS non-existence
+				v.r.verboseLog(depth, "DNSSEC: Found matching NSEC proving DS non-existence for", signerDomain)
+				return nil, true, trace, nil
+			}
+			// NSEC doesn't have the opt-out flag
 		}
 	}
 

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -59,7 +59,7 @@ const (
 //   - Status: Overall DNSSEC validation status (Secure/Insecure/Bogus/Indeterminate)
 //   - DS: Collection of DS records actually used during validation
 //   - DNSKEY: Collection of DNSKEY records actually used during validation
-//   - Answer/Additionals/Authoritative: Per-RRset validation results
+//   - Answer/Additional/Authoritative: Per-RRset validation results
 //
 // - Trace: Updated trace context containing validation path
 func (v *dNSSECValidator) validate(depth int, trace Trace) (*DNSSECResult, Trace) {
@@ -81,7 +81,7 @@ func (v *dNSSECValidator) validate(depth int, trace Trace) (*DNSSECResult, Trace
 	if !v.msg.Authoritative {
 		// Validate the additional section
 		sectionRes, trace = v.validateSection(v.msg.Extra, depth, trace)
-		result.Additionals = sectionRes
+		result.Additional = sectionRes
 
 		// Validate the authoritative section
 		sectionRes, trace = v.validateSection(v.msg.Ns, depth, trace)

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -354,7 +354,7 @@ func (r *Resolver) validateRRSIGs(ctx context.Context, typeToRRSets map[uint16][
 			return false, trace, fmt.Errorf("no RRSIG found for type %s", dns.TypeToString[rrType])
 		}
 
-		r.verboseLog(depth, fmt.Sprintf("DNSSEC: Verifying RRSIGs for type %s", dns.TypeToString[rrType]))
+		r.verboseLog(depth, "DNSSEC: Verifying RRSIGs for type", dns.TypeToString[rrType])
 
 		// Validate the RRSIGs for the RRset using validateRRSIG
 		passed, updatedTrace, err := r.validateRRSIG(ctx, rrType, rrSet, rrsigs, nameServer, isIterative, trace, depth+1)

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -18,6 +18,7 @@
  * - https://datatracker.ietf.org/doc/html/rfc4033
  * - https://datatracker.ietf.org/doc/html/rfc4034
  * - https://datatracker.ietf.org/doc/html/rfc4035 (probably the most relevant one)
+ * - https://datatracker.ietf.org/doc/html/rfc6840
  * - https://datatracker.ietf.org/doc/html/rfc8914
  * - https://datatracker.ietf.org/doc/html/rfc7958
  *

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -33,9 +33,8 @@ func (r *Resolver) validateChainOfDNSSECTrust(ctx context.Context, msg *dns.Msg,
 	typeToRRSets := make(map[uint16][]dns.RR)
 	typeToRRSigs := make(map[uint16][]*dns.RRSIG)
 
-	if msg.Authoritative {
-		updateTypeMapWithRRs(typeToRRSets, typeToRRSigs, msg.Answer)
-	} else {
+	updateTypeMapWithRRs(typeToRRSets, typeToRRSigs, msg.Answer)
+	if !msg.Authoritative && isIterative {
 		updateTypeMapWithRRs(typeToRRSets, typeToRRSigs, msg.Ns)
 	}
 

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -137,7 +137,7 @@ func (r *Resolver) getDNSKEYs(ctx context.Context, signerDomain string, nameServ
 		RetriesRemaining: &retries,
 	}
 
-	res, trace, status, err := r.lookup(ctx, &dnskeyQuestion, []NameServer{*nameServer}, isIterative, trace, depth)
+	res, trace, status, err := r.lookup(ctx, &dnskeyQuestion, []NameServer{*nameServer}, isIterative, trace)
 	if status != StatusNoError || err != nil {
 		return nil, nil, trace, fmt.Errorf("cannot get DNSKEYs for signer domain %s, status: %s, err: %v", signerDomain, status, err)
 	}

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -180,14 +180,6 @@ func (v *dNSSECValidator) validateSection(section []dns.RR, depth int, trace Tra
 				setResult.Signature = &sigParsed
 			} else {
 				v.r.verboseLog(depth+1, "could not verify any RRSIG for RRset", rrsKey.String(), "err:", err)
-				// TODO: This check for bogus is not comprehensive or entirely accurate.
-				// If the error is due to the inability to retrieve DNSKEY or DS records, the status should be indeterminate.
-				// If a DS record exists at the SOA, but no RRSIG is found here, the status should be bogus (this case is not handled here).
-				// If no DS record is found at the SOA, the status should be insecure because a chain of trust cannot be established.
-				// However, this is unlikely in this context because an RRSIG should not exist without a corresponding DS record,
-				// unless the domain starts a different trust anchor (which most resolvers would not trust anyway).
-				// Distinguishing between these cases requires additional context, which would involve storing or querying more information
-				// about the domain. These operations can be costly, so we need to decide if the additional complexity is worth it.
 				setResult.Status = DNSSECBogus
 				setResult.Error = err.Error()
 			}

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -59,13 +59,18 @@ func (v *dNSSECValidator) validate(depth int, trace Trace) (*DNSSECResult, Trace
 	sectionRes, trace := v.validateSection(v.msg.Answer, depth, trace)
 	result.Answer = sectionRes
 
-	// Validate the additional section
-	sectionRes, trace = v.validateSection(v.msg.Extra, depth, trace)
-	result.Additionals = sectionRes
+	// If the message is authoritative, we drop the additional and authoritative sections
+	// in Resolver.iterativeLookup, hence no need to validate them here. Validating them
+	// causes circular lookups in some cases and can confuse the user.
+	if !v.msg.Authoritative {
+		// Validate the additional section
+		sectionRes, trace = v.validateSection(v.msg.Extra, depth, trace)
+		result.Additionals = sectionRes
 
-	// Validate the authoritative section
-	sectionRes, trace = v.validateSection(v.msg.Ns, depth, trace)
-	result.Authoritative = sectionRes
+		// Validate the authoritative section
+		sectionRes, trace = v.validateSection(v.msg.Ns, depth, trace)
+		result.Authoritative = sectionRes
+	}
 
 	for ds := range v.ds {
 		parsed := ParseAnswer(&ds).(DSAnswer) //nolint:golint,errcheck
@@ -265,10 +270,20 @@ func (v *dNSSECValidator) getDNSKEYs(signerDomain string, trace Trace, depth int
 	}
 
 	res, trace, status, err := v.r.lookup(v.ctx, &dnskeyQuestion, v.r.rootNameServers, v.isIterative, trace)
-	// DNSSECResult may be nil if the response is from the cache.
-	if status != StatusNoError || err != nil || (res.DNSSECResult != nil && res.DNSSECResult.Status != DNSSECSecure) {
-		v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: Failed to get DNSKEYs for signer domain %s, query status: %s, err: %v", signerDomain, status, err))
-		return nil, nil, trace, fmt.Errorf("cannot get DNSKEYs for signer domain %s", signerDomain)
+	if status != StatusNoError {
+		v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: Failed to get DNSKEYs for signer domain %s, query status: %s", signerDomain, status))
+		return nil, nil, trace, fmt.Errorf("DNSKEY fetch failed, query status: %s", status)
+	} else if err != nil {
+		v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: Failed to get DNSKEYs for signer domain %s, err: %v", signerDomain, err))
+		return nil, nil, trace, fmt.Errorf("DNSKEY fetch failed, err: %v", err)
+	} else if res.DNSSECResult != nil && res.DNSSECResult.Status != DNSSECSecure { // 	// DNSSECResult may be nil if the response is from the cache.
+		v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: Failed to get DNSKEYs for signer domain %s, DNSSEC status: %s", signerDomain, res.DNSSECResult.Status))
+
+		if prevResult := getResultForRRset(RRsetKey(dnskeyQuestion.Q), res.DNSSECResult.Answer); prevResult != nil && prevResult.Error != "" {
+			return nil, nil, trace, fmt.Errorf("DNSKEY fetch failed: %s", prevResult.Error)
+		} else {
+			return nil, nil, trace, fmt.Errorf("DNSKEY fetch failed, DNSSEC status: %s", res.DNSSECResult.Status)
+		}
 	}
 
 	// RRSIGs of res should have been verified before returning to here.
@@ -340,9 +355,20 @@ func (v *dNSSECValidator) findSEPs(signerDomain string, dnskeyMap map[uint16]*dn
 		// DNSSECResult may be nil if the response is from the cache.
 		res, newTrace, status, err := v.r.lookup(v.ctx, &dsQuestion, v.r.rootNameServers, v.isIterative, trace)
 		trace = newTrace
-		if status != StatusNoError || err != nil || (res.DNSSECResult != nil && res.DNSSECResult.Status != DNSSECSecure) {
-			v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: Failed to get DS records for signer domain %s, query status: %s,  err: %v", signerDomain, status, err))
-			return nil, trace, fmt.Errorf("failed to get DS records for signer domain %s", signerDomain)
+		if status != StatusNoError {
+			v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: Failed to get DS records for signer domain %s, query status: %s", signerDomain, status))
+			return nil, trace, fmt.Errorf("DS fetch failed, query status: %s", status)
+		} else if err != nil {
+			v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: Failed to get DS records for signer domain %s, err: %v", signerDomain, err))
+			return nil, trace, fmt.Errorf("DS fetch failed, err: %v", err)
+		} else if res.DNSSECResult != nil && res.DNSSECResult.Status != DNSSECSecure {
+			v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: Failed to get DS records for signer domain %s, DNSSEC status: %s", signerDomain, res.DNSSECResult.Status))
+
+			if prevResult := getResultForRRset(RRsetKey(dsQuestion.Q), res.DNSSECResult.Answer); prevResult != nil && prevResult.Error != "" {
+				return nil, trace, fmt.Errorf("DS fetch failed: %s", prevResult.Error)
+			} else {
+				return nil, trace, fmt.Errorf("DS fetch failed, DNSSEC status: %s", res.DNSSECResult.Status)
+			}
 		}
 
 		// RRSIGs of res should have been verified before returning to here.
@@ -453,11 +479,12 @@ func (v *dNSSECValidator) validateRRSIG(rrSetType uint16, rrSet []dns.RR, rrsigs
 		if err := rrsig.Verify(matchingKey, rrSet); err == nil {
 			v.dNSKEY[*matchingKey] = true
 			return rrsig, trace, nil
+		} else {
+			lastErr = fmt.Errorf("RRSIG with keytag=%d failed to verify: %v", keyTag, err)
+			v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: RRSIG with keytag=%d failed to verify: %v", keyTag, err))
+			continue
 		}
-
-		lastErr = fmt.Errorf("RRSIG with keytag=%d failed to verify", keyTag)
-		v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: RRSIG with keytag=%d failed to verify", keyTag))
 	}
 
-	return nil, trace, errors.Wrap(lastErr, "could not verify any RRSIG for RRset")
+	return nil, trace, lastErr
 }

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -129,7 +129,7 @@ func (r *Resolver) getDNSKEYs(ctx context.Context, signerDomain string, nameServ
 	zsks := make(map[uint16]*dns.DNSKEY)
 
 	retries := r.retries
-	nameWithoutTrailingDot := strings.TrimSuffix(dns.CanonicalName(signerDomain), rootZone)
+	nameWithoutTrailingDot := removeTrailingDotIfNotRoot(signerDomain)
 	if signerDomain == rootZone {
 		nameWithoutTrailingDot = rootZone
 	}
@@ -199,7 +199,7 @@ func (r *Resolver) getDNSKEYs(ctx context.Context, signerDomain string, nameServ
 // - error: If validation fails for any DS record, returns an error with details.
 func (r *Resolver) validateDSRecords(ctx context.Context, signerDomain string, dnskeyMap map[uint16]*dns.DNSKEY, nameServer *NameServer, isIterative bool, trace Trace, depth int) (bool, Trace, error) {
 	retries := r.retries
-	nameWithoutTrailingDot := strings.TrimSuffix(dns.CanonicalName(signerDomain), rootZone)
+	nameWithoutTrailingDot := removeTrailingDotIfNotRoot(signerDomain)
 
 	dsQuestion := QuestionWithMetadata{
 		Q: Question{

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -381,6 +381,7 @@ func (v *dNSSECValidator) findSEPs(signerDomain string, dnskeyMap map[uint16]*dn
 	}
 
 	if len(sepKeys) == 0 {
+		v.r.verboseLog(depth, "DNSSEC: No SEP found for signer domain", signerDomain)
 		return nil, trace, errors.New("no SEP matching DS found")
 	}
 
@@ -422,7 +423,7 @@ func (v *dNSSECValidator) validateRRSIG(rrSetType uint16, rrSet []dns.RR, rrsigs
 			_, zskMap, updatedTrace, err := v.getDNSKEYs(rrsig.SignerName, trace, depth+1)
 			dnskeyMap = zskMap
 			if err != nil {
-				lastErr = fmt.Errorf("failed to retrieve DNSKEYs for signer domain %s: %v", rrsig.SignerName, err)
+				lastErr = err
 				continue
 			}
 			trace = updatedTrace

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -51,6 +51,7 @@ const (
 // DNSSEC status.
 //
 // Parameters:
+// - msg: DNS message to validate
 // - depth: Current recursion depth for logging purposes
 // - trace: Trace context for tracking validation path
 //
@@ -62,42 +63,54 @@ const (
 //   - Answer/Additional/Authoritative: Per-RRset validation results
 //
 // - Trace: Updated trace context containing validation path
-func (v *dNSSECValidator) validate(depth int, trace Trace) (*DNSSECResult, Trace) {
+func (v *dNSSECValidator) validate(layer string, msg *dns.Msg, nameServer *NameServer, depth int, trace Trace) (*DNSSECResult, Trace) {
 	result := makeDNSSECResult()
+	if v.status != DNSSECSecure {
+		result.Status = v.status
+		result.Reason = v.reason
+		return result, trace
+	}
+
+	v.resetDNSSECValidator(msg, nameServer)
 
 	if !hasRRSIG(v.msg) {
 		v.r.verboseLog(depth, "DNSSEC: No RRSIG records found in message")
 		result.Status = DNSSECInsecure // This can't be secure, but it could be bogus instead
-		return result, trace
+		result.Reason = "No RRSIG records found in message"
+	} else {
+		// Validate the answer section
+		var sectionRes []DNSSECPerSetResult
+		sectionRes, trace = v.validateSection(v.msg.Answer, depth, trace)
+		result.Answer = sectionRes
+
+		// If the message is authoritative, we drop the additional and authoritative sections
+		// in Resolver.iterativeLookup, hence no need to validate them here. Validating them
+		// causes circular lookups in some cases and can confuse the user.
+		if !v.msg.Authoritative {
+			// Validate the additional section
+			sectionRes, trace = v.validateSection(v.msg.Extra, depth, trace)
+			result.Additional = sectionRes
+
+			// Validate the authoritative section
+			sectionRes, trace = v.validateSection(v.msg.Ns, depth, trace)
+			result.Authoritative = sectionRes
+		}
+
+		for ds := range v.ds {
+			parsed := ParseAnswer(&ds).(DSAnswer) //nolint:golint,errcheck
+			result.DS = append(result.DS, &parsed)
+		}
+		for dnskey := range v.dNSKEY {
+			parsed := ParseAnswer(&dnskey).(DNSKEYAnswer) //nolint:golint,errcheck
+			result.DNSKEY = append(result.DNSKEY, &parsed)
+		}
+
+		result.populateStatus()
 	}
 
-	// Validate the answer section
-	sectionRes, trace := v.validateSection(v.msg.Answer, depth, trace)
-	result.Answer = sectionRes
-
-	// If the message is authoritative, we drop the additional and authoritative sections
-	// in Resolver.iterativeLookup, hence no need to validate them here. Validating them
-	// causes circular lookups in some cases and can confuse the user.
-	if !v.msg.Authoritative {
-		// Validate the additional section
-		sectionRes, trace = v.validateSection(v.msg.Extra, depth, trace)
-		result.Additional = sectionRes
-
-		// Validate the authoritative section
-		sectionRes, trace = v.validateSection(v.msg.Ns, depth, trace)
-		result.Authoritative = sectionRes
-	}
-
-	for ds := range v.ds {
-		parsed := ParseAnswer(&ds).(DSAnswer) //nolint:golint,errcheck
-		result.DS = append(result.DS, &parsed)
-	}
-	for dnskey := range v.dNSKEY {
-		parsed := ParseAnswer(&dnskey).(DNSKEYAnswer) //nolint:golint,errcheck
-		result.DNSKEY = append(result.DNSKEY, &parsed)
-	}
-
-	result.populateStatus()
+	v.r.verboseLog(depth, "DNSSEC: Validation result for layer", layer, ":", result.Status)
+	v.status = result.Status
+	v.reason = fmt.Sprintf("zone %s: %s", layer, result.Reason)
 
 	return result, trace
 }
@@ -421,7 +434,7 @@ func (v *dNSSECValidator) findSEPs(signerDomain string, dnskeyMap map[uint16]*dn
 		} else {
 			v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: Delegation verified for DNSKEY with KeyTag %d, SEP established", key.KeyTag()))
 
-			v.ds[*actualDS] = true
+			v.ds[*actualDS] = struct{}{}
 			sepKeys[key.KeyTag()] = key
 		}
 	}
@@ -493,7 +506,7 @@ func (v *dNSSECValidator) validateRRSIG(rrSetType uint16, rrSet []dns.RR, rrsigs
 
 		// Verify the RRSIG with the matching DNSKEY
 		if err := rrsig.Verify(matchingKey, rrSet); err == nil {
-			v.dNSKEY[*matchingKey] = true
+			v.dNSKEY[*matchingKey] = struct{}{}
 			return rrsig, trace, nil
 		} else {
 			lastErr = fmt.Errorf("RRSIG with keytag=%d failed to verify: %v", keyTag, err)

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -11,6 +11,21 @@
  * implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+/*
+ * DNSSEC validator of ZDNS.
+ * RFC reference:
+ * - https://datatracker.ietf.org/doc/html/rfc4033
+ * - https://datatracker.ietf.org/doc/html/rfc4034
+ * - https://datatracker.ietf.org/doc/html/rfc4035 (probably the most relevant one)
+ * - https://datatracker.ietf.org/doc/html/rfc8914
+ * - https://datatracker.ietf.org/doc/html/rfc7958
+ *
+ * Other references:
+ * - https://www.cloudflare.com/learning/dns/dnssec/how-dnssec-works/
+ * - https://dnsviz.net/
+ */
+
 package zdns
 
 import (

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -1,0 +1,270 @@
+/*
+ * ZDNS Copyright 2024 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package zdns
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/zmap/dns"
+)
+
+const (
+	zoneSigningKeyFlag = 256
+	keySigningKeyFlag  = 257
+)
+
+func (r *Resolver) validateChainOfDNSSECTrust(ctx context.Context, msg *dns.Msg, q Question, nameServer *NameServer, isIterative bool, depth int, trace Trace) (bool, Trace, error) {
+	typeToRRSets := make(map[uint16][]dns.RR)
+	typeToRRSigs := make(map[uint16][]*dns.RRSIG)
+
+	// Extract all the RRSets from the message
+	for _, rr := range msg.Answer {
+		rrType := rr.Header().Rrtype
+		if rrType == dns.TypeRRSIG {
+			rrSig := rr.(*dns.RRSIG)
+			typeToRRSigs[rrSig.TypeCovered] = append(typeToRRSigs[rrSig.TypeCovered], rrSig)
+		} else {
+			typeToRRSets[rrType] = append(typeToRRSets[rrType], rr)
+		}
+	}
+
+	// Shortcut checks on RRSIG cardinality
+	if len(typeToRRSigs) == 0 {
+		// No RRSIGs, possibly because DNSSEC is not enabled... or we are hijacked
+		r.verboseLog(depth+1, "DNSSEC: No RRSIGs found")
+		return false, trace, nil
+	}
+
+	if len(typeToRRSets) != len(typeToRRSigs) {
+		return false, trace, errors.New("mismatched number of RRsets and RRSIGs")
+	}
+
+	// Verify if for each RRset there is a corresponding RRSIG
+	for rrType := range typeToRRSets {
+		if _, ok := typeToRRSigs[rrType]; !ok {
+			return false, trace, fmt.Errorf("found RRset for type %s but no RRSIG", dns.TypeToString[rrType])
+		}
+	}
+
+	r.verboseLog(depth+1, fmt.Sprintf("DNSSEC: Found %d RRsets and %d RRSIGs", len(typeToRRSets), len(typeToRRSigs)))
+
+	passed, trace, err := r.validateRRSIGs(ctx, typeToRRSets, typeToRRSigs, nameServer, isIterative, trace, depth)
+	if err != nil {
+		return false, trace, errors.Wrap(err, "could not validate RRSIGs")
+	}
+
+	return passed, trace, nil
+}
+
+// parseKSKsFromAnswer extracts only KSKs (Key Signing Keys) from a DNSKEY RRset answer,
+// populating a map where the KeyTag is the key and the DNSKEY is the value.
+// This function skips ZSKs and returns an error if any unexpected flags or types are encountered.
+//
+// Parameters:
+// - rrSet: The DNSKEY RRset answer to parse.
+//
+// Returns:
+// - map[uint16]*dns.DNSKEY: A map of KeyTag to KSKs.
+// - error: An error if an unexpected flag or type is encountered.
+func parseKSKsFromAnswer(rrSet []dns.RR) (map[uint16]*dns.DNSKEY, error) {
+	ksks := make(map[uint16]*dns.DNSKEY)
+
+	for _, rr := range rrSet {
+		dnskey, ok := rr.(*dns.DNSKEY)
+		if !ok {
+			return nil, fmt.Errorf("invalid RR type in DNSKEY RRset: %v", rr)
+		}
+		switch dnskey.Flags {
+		case keySigningKeyFlag:
+			ksks[dnskey.KeyTag()] = dnskey
+		case zoneSigningKeyFlag:
+			// Skip ZSKs
+			continue
+		default:
+			return nil, fmt.Errorf("unexpected DNSKEY flag: %d", dnskey.Flags)
+		}
+	}
+
+	if len(ksks) == 0 {
+		return nil, errors.New("could not find any KSK in DNSKEY RRset")
+	}
+
+	return ksks, nil
+}
+
+// getDNSKEYs retrieves and separates KSKs and ZSKs from the signer domain's DNSKEYs,
+// returning maps of KeyTags to DNSKEYs for both KSKs and ZSKs.
+//
+// Parameters:
+// - ctx: Context for cancellation and timeout control.
+// - signerDomain: The signer domain extracted from the RRSIG's SignerName field.
+// - nameServer: The nameserver to use for the DNS query.
+// - isIterative: Boolean indicating if the query should be iterative.
+// - trace: The trace context for tracking the request path.
+// - depth: The recursion or verification depth for logging purposes.
+//
+// Returns:
+// - ksks: Map of KeyTag to KSKs (Key Signing Keys) retrieved from the signer domain.
+// - zsks: Map of KeyTag to ZSKs (Zone Signing Keys) retrieved from the signer domain.
+// - Trace: Updated trace context with the DNSKEY query included.
+// - error: If the DNSKEY query fails or returns an unexpected status.
+func (r *Resolver) getDNSKEYs(ctx context.Context, signerDomain string, nameServer *NameServer, isIterative bool, trace Trace, depth int) (map[uint16]*dns.DNSKEY, map[uint16]*dns.DNSKEY, Trace, error) {
+	ksks := make(map[uint16]*dns.DNSKEY)
+	zsks := make(map[uint16]*dns.DNSKEY)
+
+	retries := r.retries
+	nameWithoutTrailingDot := strings.TrimSuffix(dns.CanonicalName(signerDomain), ".")
+	dnskeyQuestion := QuestionWithMetadata{
+		Q: Question{
+			Name:  nameWithoutTrailingDot,
+			Type:  dns.TypeDNSKEY,
+			Class: dns.ClassINET,
+		},
+		RetriesRemaining: &retries,
+	}
+
+	res, trace, status, err := r.lookup(ctx, &dnskeyQuestion, []NameServer{*nameServer}, isIterative, trace, depth)
+	if status != StatusNoError || err != nil {
+		return nil, nil, trace, fmt.Errorf("cannot get DNSKEYs for signer domain %s, status: %s, err: %v", signerDomain, status, err)
+	}
+
+	// RRSIGs of res should have been verified before returning to here.
+
+	// Separate DNSKEYs into KSKs and ZSKs maps based on flags
+	for _, rr := range res.Answers {
+		zTypedKey, ok := rr.(DNSKEYAnswer)
+		if !ok {
+			r.verboseLog(depth, fmt.Sprintf("DNSSEC: Non-DNSKEY RR type in DNSKEY answer: %v", rr))
+			continue
+		}
+		dnskey := zTypedKey.ToVanillaType()
+
+		switch dnskey.Flags {
+		case keySigningKeyFlag:
+			ksks[dnskey.KeyTag()] = dnskey
+		case zoneSigningKeyFlag:
+			zsks[dnskey.KeyTag()] = dnskey
+		default:
+			r.verboseLog(depth, fmt.Sprintf("DNSSEC: Unexpected DNSKEY flag %d in DNSKEY answer", dnskey.Flags))
+		}
+	}
+
+	// Error if no KSK/ZSK is found
+	if len(ksks) == 0 || len(zsks) == 0 {
+		return nil, nil, trace, errors.New("missing at least one KSK or ZSK in DNSKEY answer")
+	}
+
+	// TODO: Validate KSKs with DS records
+
+	return ksks, zsks, trace, nil
+}
+
+// validateRRSIG verifies multiple RRSIGs for a given RRset. For each RRSIG, it retrieves the necessary
+// DNSKEYs (KSKs for DNSKEY RRsets, ZSKs for others) from either the answer directly (for DNSKEY types) or
+// by querying the signer domain. Each RRSIG is validated only with the DNSKEY matching its KeyTag.
+//
+// Parameters:
+// - ctx: Context for cancellation and timeout control.
+// - rrSetType: The type of the RRset (e.g., dns.TypeA, dns.TypeDNSKEY).
+// - rrSet: The RRset that is being verified.
+// - rrsigs: A slice of RRSIGs associated with the RRset.
+// - nameServer: The nameserver to use for DNSKEY retrievals.
+// - isIterative: Boolean indicating if the DNSKEY queries should be iterative.
+// - trace: The trace context for tracking the request path.
+// - depth: The recursion or verification depth for logging purposes.
+//
+// Returns:
+// - bool: Returns true if at least one RRSIG is successfully verified for the RRset.
+// - Trace: Updated trace context including the DNSKEY retrievals and verifications.
+// - error: If no RRSIG is verified, returns an error describing the failure.
+func (r *Resolver) validateRRSIG(ctx context.Context, rrSetType uint16, rrSet []dns.RR, rrsigs []*dns.RRSIG, nameServer *NameServer, isIterative bool, trace Trace, depth int) (bool, Trace, error) {
+	var dnskeyMap map[uint16]*dns.DNSKEY
+	var err error
+
+	// If RRset type is DNSKEY, use pre-parsed KSKs from the answer directly
+	if rrSetType == dns.TypeDNSKEY {
+		dnskeyMap, err = parseKSKsFromAnswer(rrSet)
+		if err != nil {
+			return false, trace, fmt.Errorf("failed to parse KSKs from DNSKEY answer: %v", err)
+		}
+	} else {
+		// For other RRset types, fetch DNSKEYs for each RRSIG's signer domain
+		for _, rrsig := range rrsigs {
+			r.verboseLog(depth, fmt.Sprintf("DNSSEC: Verifying RRSIG with signer %s", rrsig.SignerName))
+
+			_, zskMap, updatedTrace, err := r.getDNSKEYs(ctx, rrsig.SignerName, nameServer, isIterative, trace, depth+1)
+			dnskeyMap = zskMap
+			if err != nil {
+				return false, updatedTrace, fmt.Errorf("failed to retrieve DNSKEYs for signer domain %s: %v", rrsig.SignerName, err)
+			}
+			trace = updatedTrace
+		}
+	}
+
+	// Attempt to verify each RRSIG using only the DNSKEY matching its KeyTag
+	for _, rrsig := range rrsigs {
+		keyTag := rrsig.KeyTag
+		matchingKey, found := dnskeyMap[keyTag]
+		if !found {
+			return false, trace, fmt.Errorf("no matching DNSKEY found for RRSIG with key tag %d", keyTag)
+		}
+
+		// Verify the RRSIG with the matching DNSKEY
+		if err := rrsig.Verify(matchingKey, rrSet); err == nil {
+			return true, trace, nil
+		}
+		r.verboseLog(depth, fmt.Sprintf("DNSSEC: RRSIG with keytag=%d failed to verify", keyTag))
+	}
+
+	return false, trace, fmt.Errorf("could not verify any RRSIG for RRset")
+}
+
+// validateRRSIGs verifies multiple RRsets and their corresponding RRSIGs. It iterates over each RRset, retrieves
+// the RRSIGs, and attempts to verify each RRSIG using validateRRSIG, using KSKs for DNSKEY RRset type and ZSKs
+// for other types.
+//
+// Parameters:
+// - ctx: Context for cancellation and timeout control.
+// - typeToRRSets: A map of RR types to slices of DNS Resource Records (RRsets) of that type.
+// - typeToRRSigs: A map of RR types to slices of RRSIGs associated with each RRset.
+// - nameServer: The nameserver to use for DNSKEY retrievals.
+// - isIterative: Boolean indicating if the DNSKEY queries should be iterative.
+// - depth: The recursion or verification depth for logging purposes.
+//
+// Returns:
+// - bool: Returns true if all RRSIGs for all RRsets are verified; otherwise, false if any RRSIG fails verification.
+// - Trace: Updated trace context with all verification attempts included.
+// - error: If verification fails for any RRSIG, returns an error with details.
+func (r *Resolver) validateRRSIGs(ctx context.Context, typeToRRSets map[uint16][]dns.RR, typeToRRSigs map[uint16][]*dns.RRSIG, nameServer *NameServer, isIterative bool, trace Trace, depth int) (bool, Trace, error) {
+	for rrType, rrSet := range typeToRRSets {
+		rrsigs, ok := typeToRRSigs[rrType]
+		if !ok || len(rrsigs) == 0 {
+			return false, trace, fmt.Errorf("no RRSIG found for type %s", dns.TypeToString[rrType])
+		}
+
+		r.verboseLog(depth, fmt.Sprintf("DNSSEC: Verifying RRSIGs for type %s", dns.TypeToString[rrType]))
+
+		// Validate the RRSIGs for the RRset using validateRRSIG
+		passed, updatedTrace, err := r.validateRRSIG(ctx, rrType, rrSet, rrsigs, nameServer, isIterative, trace, depth+1)
+		trace = updatedTrace
+		if !passed {
+			return false, trace, fmt.Errorf("could not verify any RRSIG for type %s: %v", dns.TypeToString[rrType], err)
+		}
+	}
+
+	return true, trace, nil
+}

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -45,11 +45,11 @@ func (v *dNSSECValidator) validate(depth int, trace Trace) (*DNSSECResult, Trace
 	result.Authoritative = sectionRes
 
 	for _, ds := range v.ds {
-		parsed := ParseAnswer(ds).(DSAnswer)
+		parsed := ParseAnswer(ds).(DSAnswer) //nolint:golint,errcheck
 		result.DS = append(result.DS, &parsed)
 	}
 	for _, dnskey := range v.dNSKEY {
-		parsed := ParseAnswer(dnskey).(DNSKEYAnswer)
+		parsed := ParseAnswer(dnskey).(DNSKEYAnswer) //nolint:golint,errcheck
 		result.DNSKEY = append(result.DNSKEY, &parsed)
 	}
 
@@ -80,7 +80,7 @@ func (v *dNSSECValidator) validateSection(section []dns.RR, depth int, trace Tra
 			if sigUsed != nil {
 				setResult.Status = DNSSECSecure
 
-				sigParsed := ParseAnswer(sigUsed).(RRSIGAnswer)
+				sigParsed := ParseAnswer(sigUsed).(RRSIGAnswer) //nolint:golint,errcheck
 				setResult.Signature = &sigParsed
 			} else {
 				v.r.verboseLog(depth+1, "could not verify any RRSIG for type", dns.TypeToString[rrType], ":", err)

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -44,12 +44,12 @@ func (v *dNSSECValidator) validate(depth int, trace Trace) (*DNSSECResult, Trace
 	sectionRes, trace = v.validateSection(v.msg.Ns, depth, trace)
 	result.Authoritative = sectionRes
 
-	for _, ds := range v.ds {
-		parsed := ParseAnswer(ds).(DSAnswer) //nolint:golint,errcheck
+	for ds := range v.ds {
+		parsed := ParseAnswer(&ds).(DSAnswer) //nolint:golint,errcheck
 		result.DS = append(result.DS, &parsed)
 	}
-	for _, dnskey := range v.dNSKEY {
-		parsed := ParseAnswer(dnskey).(DNSKEYAnswer) //nolint:golint,errcheck
+	for dnskey := range v.dNSKEY {
+		parsed := ParseAnswer(&dnskey).(DNSKEYAnswer) //nolint:golint,errcheck
 		result.DNSKEY = append(result.DNSKEY, &parsed)
 	}
 
@@ -307,7 +307,7 @@ func (v *dNSSECValidator) validateDSRecords(signerDomain string, dnskeyMap map[u
 		} else {
 			v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: DS record for KSK with KeyTag %d is valid", ksk.KeyTag()))
 
-			v.ds = append(v.ds, actualDS)
+			v.ds[*actualDS] = true
 			validatedKSKs[ksk.KeyTag()] = ksk
 		}
 	}
@@ -378,7 +378,7 @@ func (v *dNSSECValidator) validateRRSIG(rrSetType uint16, rrSet []dns.RR, rrsigs
 
 		// Verify the RRSIG with the matching DNSKEY
 		if err := rrsig.Verify(matchingKey, rrSet); err == nil {
-			v.dNSKEY = append(v.dNSKEY, matchingKey)
+			v.dNSKEY[*matchingKey] = true
 			return rrsig, trace, nil
 		}
 

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -423,11 +423,11 @@ func (v *dNSSECValidator) fetchDSRecords(signerDomain string, trace Trace, depth
 			nsec3 := zTypedNSEC3.ToVanillaType()
 			if nsec3.Flags&NSEC3OptOutFlag == 1 && nsec3.Cover(signerDomain) {
 				// Opt-out NSEC3 record covering the signer domain
-				v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: Found covering NSEC3 proving DS non-existence for %s", signerDomain))
+				v.r.verboseLog(depth, "DNSSEC: Found covering NSEC3 proving DS non-existence for", signerDomain)
 				return nil, true, trace, nil
 			} else if nsec3.Match(signerDomain) && !slices.Contains(nsec3.TypeBitMap, dns.TypeDS) {
 				// NSEC3 record directly matching the signer domain and proving DS non-existence
-				v.r.verboseLog(depth, fmt.Sprintf("DNSSEC: Found matching NSEC3 proving DS non-existence for %s", signerDomain))
+				v.r.verboseLog(depth, "DNSSEC: Found matching NSEC3 proving DS non-existence for", signerDomain)
 				return nil, true, trace, nil
 			}
 		}

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -416,6 +416,12 @@ func (v *dNSSECValidator) fetchDSRecords(signerDomain string, trace Trace, depth
 	for _, rr := range res.Authorities {
 		if zTypedNSEC3, ok := rr.(NSEC3Answer); ok {
 			nsec3 := zTypedNSEC3.ToVanillaType()
+
+			if nsec3.Iterations != 0 {
+				// An iterations count of 0 must be used in NSEC3 records to alleviate computational burdens. See RFC 9276, Sec. 3.1.
+				v.r.verboseLog(depth, "DNSSEC: Found non-compliant NSEC3 record with iterations count > 0", nsec3)
+			}
+
 			if nsec3.Flags&NSEC3OptOutFlag == 1 && nsec3.Cover(signerDomain) {
 				// Opt-out NSEC3 record covering the signer domain
 				v.r.verboseLog(depth, "DNSSEC: Found covering NSEC3 proving DS non-existence for", signerDomain)

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -197,9 +197,13 @@ func splitRRsetsAndSigs(rrs []dns.RR) (map[RRsetKey][]dns.RR, map[RRsetKey][]*dn
 //
 // Parameters:
 // - rrSet: The DNSKEY RRset to parse
+// - signerDomain: The domain for which SEP keys are being found
+// - depth: Current recursion depth for logging
+// - trace: Trace context for tracking validation path
 //
 // Returns:
 // - map[uint16]*dns.DNSKEY: Map of KeyTag to SEP key records
+// - Trace: Updated trace context
 // - error: Error if invalid records are found or no SEP present
 func (v *dNSSECValidator) findSEPsFromAnswer(rrSet []dns.RR, signerDomain string, depth int, trace Trace) (map[uint16]*dns.DNSKEY, Trace, error) {
 	dnskeys := make(map[uint16]*dns.DNSKEY)

--- a/src/zdns/dnssec.go
+++ b/src/zdns/dnssec.go
@@ -145,7 +145,6 @@ func (r *Resolver) getDNSKEYs(ctx context.Context, signerDomain string, nameServ
 	ksks := make(map[uint16]*dns.DNSKEY)
 	zsks := make(map[uint16]*dns.DNSKEY)
 
-	retries := r.retries
 	nameWithoutTrailingDot := removeTrailingDotIfNotRoot(signerDomain)
 	if signerDomain == rootZone {
 		nameWithoutTrailingDot = rootZone
@@ -157,7 +156,7 @@ func (r *Resolver) getDNSKEYs(ctx context.Context, signerDomain string, nameServ
 			Type:  dns.TypeDNSKEY,
 			Class: dns.ClassINET,
 		},
-		RetriesRemaining: &retries,
+		RetriesRemaining: &r.retriesRemaining,
 	}
 
 	res, trace, status, err := r.lookup(ctx, &dnskeyQuestion, r.rootNameServers, isIterative, trace)
@@ -217,7 +216,6 @@ func (r *Resolver) getDNSKEYs(ctx context.Context, signerDomain string, nameServ
 // - Trace: Updated trace context with the DS query included.
 // - error: If validation fails for any DS record, returns an error with details.
 func (r *Resolver) validateDSRecords(ctx context.Context, signerDomain string, dnskeyMap map[uint16]*dns.DNSKEY, nameServer *NameServer, isIterative bool, trace Trace, depth int) (bool, Trace, error) {
-	retries := r.retries
 	nameWithoutTrailingDot := removeTrailingDotIfNotRoot(signerDomain)
 
 	dsQuestion := QuestionWithMetadata{
@@ -226,7 +224,7 @@ func (r *Resolver) validateDSRecords(ctx context.Context, signerDomain string, d
 			Type:  dns.TypeDS,
 			Class: dns.ClassINET,
 		},
-		RetriesRemaining: &retries,
+		RetriesRemaining: &r.retriesRemaining,
 	}
 
 	dsRecords := make(map[uint16]dns.DS)

--- a/src/zdns/dnssec_types.go
+++ b/src/zdns/dnssec_types.go
@@ -142,8 +142,10 @@ func (r *DNSSECResult) populateStatus() {
 
 	for _, result := range r.Answer {
 		if result.Status == DNSSECInsecure {
-			r.Status = DNSSECInsecure
-			r.Reason = result.Error
+			// This is considered bogus. If we are at this point, we know a DS exists for
+			// the zone, so the answer section (authoritative data) should be signed.
+			r.Status = DNSSECBogus
+			r.Reason = "answer section is not signed when expected to be"
 			return
 		}
 
@@ -158,8 +160,8 @@ func (r *DNSSECResult) populateStatus() {
 		for _, result := range section {
 			if isDNSSECType(result.RRset.Type) {
 				if result.Status == DNSSECInsecure {
-					r.Status = DNSSECInsecure
-					r.Reason = result.Error
+					r.Status = DNSSECBogus
+					r.Reason = "DNSSEC-related RRset is not signed when expected to be"
 					return
 				}
 

--- a/src/zdns/dnssec_types.go
+++ b/src/zdns/dnssec_types.go
@@ -64,8 +64,8 @@ type dNSSECValidator struct {
 	nameServer  *NameServer
 	isIterative bool
 
-	ds     []*dns.DS
-	dNSKEY []*dns.DNSKEY
+	ds     map[dns.DS]bool
+	dNSKEY map[dns.DNSKEY]bool
 }
 
 // makeDNSSECValidator creates a new DNSSECValidator instance
@@ -77,8 +77,8 @@ func makeDNSSECValidator(r *Resolver, ctx context.Context, msg *dns.Msg, nameSer
 		nameServer:  nameServer,
 		isIterative: isIterative,
 
-		ds:     make([]*dns.DS, 0),
-		dNSKEY: make([]*dns.DNSKEY, 0),
+		ds:     make(map[dns.DS]bool),
+		dNSKEY: make(map[dns.DNSKEY]bool),
 	}
 }
 

--- a/src/zdns/dnssec_types.go
+++ b/src/zdns/dnssec_types.go
@@ -1,0 +1,62 @@
+/*
+ * ZDNS Copyright 2024 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package zdns
+
+// DNSSECStatus represents the overall validation status according to RFC 4035
+type DNSSECStatus string
+
+const (
+	DNSSECSecure        DNSSECStatus = "Secure"
+	DNSSECInsecure      DNSSECStatus = "Insecure"
+	DNSSECBogus         DNSSECStatus = "Bogus"
+	DNSSECIndeterminate DNSSECStatus = "Indeterminate"
+)
+
+// DNSSECPerSetResult represents the validation result for an RRSet
+type DNSSECPerSetResult struct {
+	Status       DNSSECStatus
+	ValidatedSig *RRSIGAnswer
+}
+
+// DNSSECResult captures all information generated during a DNSSEC validation
+type DNSSECResult struct {
+	Status        DNSSECStatus
+	DS            []*DSAnswer
+	DNSKEY        []*DNSKEYAnswer
+	Answer        map[string]DNSSECPerSetResult
+	Additionals   map[string]DNSSECPerSetResult
+	Authoritative map[string]DNSSECPerSetResult
+}
+
+// makeDNSSECResult creates and initializes a new DNSSECResult instance
+func makeDNSSECResult() *DNSSECResult {
+	return &DNSSECResult{
+		Status:        DNSSECIndeterminate,
+		DS:            make([]*DSAnswer, 0),
+		DNSKEY:        make([]*DNSKEYAnswer, 0),
+		Answer:        make(map[string]DNSSECPerSetResult),
+		Additionals:   make(map[string]DNSSECPerSetResult),
+		Authoritative: make(map[string]DNSSECPerSetResult),
+	}
+}
+
+// AreAnswersSecure checks if all RR sets in the answer section are secure
+func (r *DNSSECResult) AreAnswersSecure() bool {
+	for _, result := range r.Answer {
+		if result.Status != DNSSECSecure {
+			return false
+		}
+	}
+	return true
+}

--- a/src/zdns/dnssec_types.go
+++ b/src/zdns/dnssec_types.go
@@ -29,11 +29,7 @@ const (
 	DNSSECIndeterminate DNSSECStatus = "Indeterminate"
 )
 
-type RRsetKey struct {
-	Name  string `json:"name"`
-	Type  uint16 `json:"type"`
-	Class uint16 `json:"class"`
-}
+type RRsetKey Question
 
 func (r *RRsetKey) String() string {
 	return "name: " + r.Name + ", type: " + dns.TypeToString[r.Type] + ", class: " + dns.ClassToString[r.Class]
@@ -55,6 +51,15 @@ type DNSSECResult struct {
 	Answer        []DNSSECPerSetResult `json:"answer" groups:"dnssec,long,trace"`
 	Additionals   []DNSSECPerSetResult `json:"additionals" groups:"dnssec,long,trace"`
 	Authoritative []DNSSECPerSetResult `json:"authoritative" groups:"dnssec,long,trace"`
+}
+
+func getResultForRRset(rrsetKey RRsetKey, results []DNSSECPerSetResult) *DNSSECPerSetResult {
+	for _, result := range results {
+		if result.RRset == rrsetKey {
+			return &result
+		}
+	}
+	return nil
 }
 
 type dNSSECValidator struct {

--- a/src/zdns/dnssec_types.go
+++ b/src/zdns/dnssec_types.go
@@ -34,6 +34,7 @@ type DNSSECPerSetResult struct {
 	RrType    string       `json:"rr_type"`
 	Status    DNSSECStatus `json:"status"`
 	Signature *RRSIGAnswer `json:"sig"`
+	Error     string       `json:"error"`
 }
 
 // DNSSECResult captures all information generated during a DNSSEC validation
@@ -81,16 +82,6 @@ func makeDNSSECResult() *DNSSECResult {
 		Additionals:   make([]DNSSECPerSetResult, 0),
 		Authoritative: make([]DNSSECPerSetResult, 0),
 	}
-}
-
-// AreAnswersSecure checks if all RR sets in the answer section are secure.
-func (r *DNSSECResult) AreAnswersSecure() bool {
-	for _, result := range r.Answer {
-		if result.Status != DNSSECSecure {
-			return false
-		}
-	}
-	return true
 }
 
 // OverallStatus returns the overall validation status.

--- a/src/zdns/dnssec_types.go
+++ b/src/zdns/dnssec_types.go
@@ -49,12 +49,12 @@ type DNSSECPerSetResult struct {
 
 // DNSSECResult captures all information generated during a DNSSEC validation
 type DNSSECResult struct {
-	Status        DNSSECStatus         `json:"status" groups:"normal,long,trace"`
-	DS            []*DSAnswer          `json:"ds" groups:"long,trace"`
-	DNSKEY        []*DNSKEYAnswer      `json:"dnskey" groups:"long,trace"`
-	Answer        []DNSSECPerSetResult `json:"answer" groups:"long,trace"`
-	Additionals   []DNSSECPerSetResult `json:"additionals" groups:"long,trace"`
-	Authoritative []DNSSECPerSetResult `json:"authoritative" groups:"long,trace"`
+	Status        DNSSECStatus         `json:"status" groups:"dnssec,dnssec,normal,long,trace"`
+	DS            []*DSAnswer          `json:"ds" groups:"dnssec,long,trace"`
+	DNSKEY        []*DNSKEYAnswer      `json:"dnskey" groups:"dnssec,long,trace"`
+	Answer        []DNSSECPerSetResult `json:"answer" groups:"dnssec,long,trace"`
+	Additionals   []DNSSECPerSetResult `json:"additionals" groups:"dnssec,long,trace"`
+	Authoritative []DNSSECPerSetResult `json:"authoritative" groups:"dnssec,long,trace"`
 }
 
 type dNSSECValidator struct {

--- a/src/zdns/dnssec_types.go
+++ b/src/zdns/dnssec_types.go
@@ -31,19 +31,19 @@ const (
 
 // DNSSECPerSetResult represents the validation result for an RRSet
 type DNSSECPerSetResult struct {
-	RrType    string
-	Status    DNSSECStatus
-	Signature *RRSIGAnswer
+	RrType    string       `json:"rr_type"`
+	Status    DNSSECStatus `json:"status"`
+	Signature *RRSIGAnswer `json:"sig"`
 }
 
 // DNSSECResult captures all information generated during a DNSSEC validation
 type DNSSECResult struct {
-	Status        DNSSECStatus
-	DS            []*DSAnswer
-	DNSKEY        []*DNSKEYAnswer
-	Answer        []DNSSECPerSetResult
-	Additionals   []DNSSECPerSetResult
-	Authoritative []DNSSECPerSetResult
+	Status        DNSSECStatus         `json:"status" groups:"normal,long,trace"`
+	DS            []*DSAnswer          `json:"ds" groups:"long,trace"`
+	DNSKEY        []*DNSKEYAnswer      `json:"dnskey" groups:"long,trace"`
+	Answer        []DNSSECPerSetResult `json:"answer" groups:"long,trace"`
+	Additionals   []DNSSECPerSetResult `json:"additionals" groups:"long,trace"`
+	Authoritative []DNSSECPerSetResult `json:"authoritative" groups:"long,trace"`
 }
 
 type dNSSECValidator struct {

--- a/src/zdns/dnssec_types.go
+++ b/src/zdns/dnssec_types.go
@@ -13,6 +13,12 @@
  */
 package zdns
 
+import (
+	"context"
+
+	"github.com/miekg/dns"
+)
+
 // DNSSECStatus represents the overall validation status according to RFC 4035
 type DNSSECStatus string
 
@@ -38,6 +44,31 @@ type DNSSECResult struct {
 	Answer        []DNSSECPerSetResult
 	Additionals   []DNSSECPerSetResult
 	Authoritative []DNSSECPerSetResult
+}
+
+type dNSSECValidator struct {
+	r           *Resolver
+	ctx         context.Context
+	msg         *dns.Msg
+	nameServer  *NameServer
+	isIterative bool
+
+	ds     []*DSAnswer
+	dNSKEY []*DNSKEYAnswer
+}
+
+// makeDNSSECValidator creates a new DNSSECValidator instance
+func makeDNSSECValidator(r *Resolver, ctx context.Context, msg *dns.Msg, nameServer *NameServer, isIterative bool) *dNSSECValidator {
+	return &dNSSECValidator{
+		r:           r,
+		ctx:         ctx,
+		msg:         msg,
+		nameServer:  nameServer,
+		isIterative: isIterative,
+
+		ds:     make([]*DSAnswer, 0),
+		dNSKEY: make([]*DNSKEYAnswer, 0),
+	}
 }
 
 // makeDNSSECResult creates and initializes a new DNSSECResult instance

--- a/src/zdns/dnssec_types.go
+++ b/src/zdns/dnssec_types.go
@@ -49,7 +49,7 @@ type DNSSECResult struct {
 	DS            []*DSAnswer          `json:"ds" groups:"dnssec,long,trace"`
 	DNSKEY        []*DNSKEYAnswer      `json:"dnskey" groups:"dnssec,long,trace"`
 	Answer        []DNSSECPerSetResult `json:"answer" groups:"dnssec,long,trace"`
-	Additionals   []DNSSECPerSetResult `json:"additionals" groups:"dnssec,long,trace"`
+	Additional    []DNSSECPerSetResult `json:"additional" groups:"dnssec,long,trace"`
 	Authoritative []DNSSECPerSetResult `json:"authoritative" groups:"dnssec,long,trace"`
 }
 
@@ -94,7 +94,7 @@ func makeDNSSECResult() *DNSSECResult {
 		DS:            make([]*DSAnswer, 0),
 		DNSKEY:        make([]*DNSKEYAnswer, 0),
 		Answer:        make([]DNSSECPerSetResult, 0),
-		Additionals:   make([]DNSSECPerSetResult, 0),
+		Additional:    make([]DNSSECPerSetResult, 0),
 		Authoritative: make([]DNSSECPerSetResult, 0),
 	}
 }
@@ -118,7 +118,7 @@ func (r *DNSSECResult) populateStatus() {
 	r.Status = DNSSECSecure
 
 	// Check for bogus results first (highest priority)
-	checkSections := [][]DNSSECPerSetResult{r.Answer, r.Additionals, r.Authoritative}
+	checkSections := [][]DNSSECPerSetResult{r.Answer, r.Additional, r.Authoritative}
 	for _, section := range checkSections {
 		for _, result := range section {
 			if result.Status == DNSSECBogus {
@@ -140,7 +140,7 @@ func (r *DNSSECResult) populateStatus() {
 	}
 
 	// Check DNSSEC-related RRsets in other sections
-	for _, section := range [][]DNSSECPerSetResult{r.Additionals, r.Authoritative} {
+	for _, section := range [][]DNSSECPerSetResult{r.Additional, r.Authoritative} {
 		for _, result := range section {
 			if isDNSSECType(result.RRset.Type) {
 				if result.Status == DNSSECInsecure {

--- a/src/zdns/dnssec_types.go
+++ b/src/zdns/dnssec_types.go
@@ -31,9 +31,9 @@ const (
 
 // DNSSECPerSetResult represents the validation result for an RRSet
 type DNSSECPerSetResult struct {
-	RrType       string
-	Status       DNSSECStatus
-	ValidatedSig *RRSIGAnswer
+	RrType    string
+	Status    DNSSECStatus
+	Signature *RRSIGAnswer
 }
 
 // DNSSECResult captures all information generated during a DNSSEC validation
@@ -53,8 +53,8 @@ type dNSSECValidator struct {
 	nameServer  *NameServer
 	isIterative bool
 
-	ds     []*DSAnswer
-	dNSKEY []*DNSKEYAnswer
+	ds     []*dns.DS
+	dNSKEY []*dns.DNSKEY
 }
 
 // makeDNSSECValidator creates a new DNSSECValidator instance
@@ -66,8 +66,8 @@ func makeDNSSECValidator(r *Resolver, ctx context.Context, msg *dns.Msg, nameSer
 		nameServer:  nameServer,
 		isIterative: isIterative,
 
-		ds:     make([]*DSAnswer, 0),
-		dNSKEY: make([]*DNSKEYAnswer, 0),
+		ds:     make([]*dns.DS, 0),
+		dNSKEY: make([]*dns.DNSKEY, 0),
 	}
 }
 

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -33,11 +33,6 @@ import (
 	"github.com/zmap/zdns/src/internal/util"
 )
 
-const (
-	zoneSigningKeyFlag = 256
-	keySigningKeyFlag  = 257
-)
-
 // GetDNSServers returns a list of IPv4, IPv6 DNS servers from a file, or an error if one occurs
 func GetDNSServers(path string) (ipv4, ipv6 []string, err error) {
 	c, err := dns.ClientConfigFromFile(path)
@@ -424,7 +419,7 @@ func (r *Resolver) cyclingLookup(ctx context.Context, qWithMeta *QuestionWithMet
 			r.verboseLog(depth+1, "Cycling lookup failed - out of retries. Name: ", qWithMeta.Q.Name, ", Layer: ", layer, ", Nameserver: ", nameServer)
 			return result, isCached, status, trace, errors.New("cycling lookup failed - out of retries")
 		}
-		r.verboseLog(depth+1, "Cycling lookup failed, using a retry. Retries remaining: ", qWithMeta.RetriesRemaining, " , Name: ", qWithMeta.Q.Name, ", Layer: ", layer, ", Nameserver: ", nameServer)
+		r.verboseLog(depth+1, "Cycling lookup failed with status:", status, "err: ", err, ", using a retry. Retries remaining: ", *qWithMeta.RetriesRemaining, " , Name: ", qWithMeta.Q.Name, ", Layer: ", layer, ", Nameserver: ", nameServer)
 		*qWithMeta.RetriesRemaining--
 	}
 	return &SingleQueryResult{}, false, StatusError, trace, errors.New("cycling lookup function did not exit properly")
@@ -567,7 +562,7 @@ func (r *Resolver) cachedLookup(ctx context.Context, q Question, nameServer *Nam
 	if err != nil {
 		return &SingleQueryResult{}, isCached, status, trace, errors.Wrap(err, "could not perform lookup")
 	}
-	r.verboseLog(depth+2, "Results from wire for name: ", q, ", Layer: ", layer, ", Nameserver: ", nameServer, " status: ", status, " , err: ", err, " result: ", result)
+	r.verboseLog(depth+2, "Results from wire for name: ", q, ", Layer: ", layer, ", Nameserver: ", nameServer, " status: ", status, " , err: ", err, " result: ", *result)
 
 	if status == StatusNoError && result != nil {
 		if r.dnsSecEnabled {
@@ -1006,122 +1001,6 @@ func (r *Resolver) extractAuthority(ctx context.Context, authority interface{}, 
 		}
 	}
 	return nil, StatusServFail, layer, trace
-}
-
-func (r *Resolver) validateChainOfDNSSECTrust(ctx context.Context, msg *dns.Msg, q Question, nameServer *NameServer, isIterative bool, depth int, trace Trace) (bool, Trace, error) {
-	typeToRRSets := make(map[uint16][]dns.RR)
-	typeToRRSigs := make(map[uint16][]*dns.RRSIG)
-
-	// Extract all the RRSets from the message
-	for _, rr := range msg.Answer {
-		rrType := rr.Header().Rrtype
-		if rrType == dns.TypeRRSIG {
-			rrSig := rr.(*dns.RRSIG)
-			typeToRRSigs[rrSig.TypeCovered] = append(typeToRRSigs[rrSig.TypeCovered], rrSig)
-		} else {
-			typeToRRSets[rrType] = append(typeToRRSets[rrType], rr)
-		}
-	}
-
-	// Shortcut checks on RRSIG cardinality
-	if len(typeToRRSigs) == 0 {
-		// No RRSIGs, possibly because DNSSEC is not enabled... or we are hijacked
-		r.verboseLog(depth+1, "DNSSEC: No RRSIGs found")
-		return false, trace, nil
-	}
-
-	if len(typeToRRSets) != len(typeToRRSigs) {
-		return false, trace, errors.New("mismatched number of RRsets and RRSIGs")
-	}
-
-	// Verify if for each RRset there is a corresponding RRSIG
-	for rrType := range typeToRRSets {
-		if _, ok := typeToRRSigs[rrType]; !ok {
-			return false, trace, fmt.Errorf("found RRset for type %s but no RRSIG", dns.TypeToString[rrType])
-		}
-	}
-
-	r.verboseLog(depth+1, fmt.Sprintf("DNSSEC: Found %d RRsets and %d RRSIGs", len(typeToRRSets), len(typeToRRSigs)))
-
-	if q.Type == dns.TypeDNSKEY {
-		// Find Key Signing Key (KSK) and Zone Signing Key (ZSK)
-		var ksk *dns.DNSKEY
-		for _, rr := range typeToRRSets[dns.TypeDNSKEY] {
-			dnskey := rr.(*dns.DNSKEY)
-			if dnskey.Flags == keySigningKeyFlag {
-				ksk = dnskey
-			} else if dnskey.Flags == zoneSigningKeyFlag {
-				continue
-			} else {
-				return false, trace, fmt.Errorf("unknown DNSKEY flag: %d", dnskey.Flags)
-			}
-		}
-
-		if ksk == nil {
-			return false, trace, errors.New("could not find KSK")
-		}
-
-		// Verify the RRSIGs for the DNSKEY RRset
-		// TODO: key tag?
-		if err := typeToRRSigs[dns.TypeDNSKEY][0].Verify(ksk, typeToRRSets[dns.TypeDNSKEY]); err != nil {
-			return false, trace, errors.Wrap(err, "could not verify DNSKEY RRSIG")
-		}
-
-		// TODO: we'll just trust KSK for now (but we should find DS record and verify it)
-
-		return true, trace, nil
-	}
-
-	// Gather DNSKEYs
-	// TODO: > 1 ZSK?
-	var zsk *dns.DNSKEY
-	retries := r.retries
-	dnskeyQuestion := QuestionWithMetadata{
-		Q: Question{
-			Name:  q.Name,
-			Type:  dns.TypeDNSKEY,
-			Class: q.Class,
-		},
-		RetriesRemaining: &retries,
-	}
-	res, trace, status, err := r.lookup(ctx, &dnskeyQuestion, []NameServer{*nameServer}, isIterative, trace, depth+1)
-	if status != StatusNoError || err != nil {
-		return false, trace, fmt.Errorf("cannot get DNSKEYs, status: %s, err: %v", status, err)
-	}
-
-	// Type converting ZSK
-	for _, rr := range res.Answers {
-		switch rr := rr.(type) {
-		case DNSKEYAnswer:
-			// We don't care about KSK here. It must have been validated during DNSKEY lookup.
-			if rr.Flags == 256 { // TODO: magic number
-				zsk = &dns.DNSKEY{
-					Hdr:       dns.RR_Header{Name: dns.CanonicalName(rr.Name), Rrtype: rr.RrType, Class: dns.StringToClass[rr.Class], Ttl: rr.TTL},
-					Flags:     rr.Flags,
-					Protocol:  rr.Protocol,
-					Algorithm: rr.Algorithm,
-					PublicKey: rr.PublicKey,
-				}
-			}
-		case RRSIGAnswer:
-			continue // It's normal to have RRSIGs in any DNSSEC-enabled response.
-		default:
-			r.verboseLog(depth+1, fmt.Sprintf("DNSSEC: Found unexpected RRset in DNSKEY answer: %v", rr))
-			continue
-		}
-	}
-
-	// Verify the RRSIGs for each RRset
-	for rrType, rrSet := range typeToRRSets {
-		sig := typeToRRSigs[rrType][0]
-		// TODO should make use of sig.KeyTag.
-		r.verboseLog(depth+1, fmt.Sprintf("DNSSEC: Verifying RRSIG for type %s", dns.TypeToString[rrType]))
-		if err := sig.Verify(zsk, rrSet); err != nil {
-			return false, trace, errors.Wrapf(err, "could not verify RRSIG for type %s", dns.TypeToString[rrType])
-		}
-	}
-
-	return true, trace, nil
 }
 
 // CheckTxtRecords common function for all modules based on search in TXT record

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -569,7 +569,8 @@ func (r *Resolver) cachedLookup(ctx context.Context, q Question, nameServer *Nam
 	if status == StatusNoError && result != nil {
 		if r.dnsSecEnabled {
 			var dnssecResult *DNSSECResult
-			dnssecResult, trace, err = r.validateChainOfDNSSECTrust(ctx, rawResp, nameServer, !requestIteration, depth+2, trace)
+			validator := makeDNSSECValidator(r, ctx, rawResp, nameServer, !requestIteration)
+			dnssecResult, trace, err = validator.validate(depth+2, trace)
 			r.verboseLog(depth+2, "DNSSEC validation status: ", dnssecResult.Status, " err: ", err)
 			if err != nil {
 				return result, isCached, StatusError, trace, errors.Wrap(err, "error when validating DNSSEC")

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -915,9 +915,9 @@ func (r *Resolver) iterateOnAuthorities(ctx context.Context, qWithMeta *Question
 	})
 
 	for _, elem := range authorities {
-		// Skip DS and RRSIG records
+		// Skip DNSSEC records
 		switch elem.(type) {
-		case DSAnswer, RRSIGAnswer:
+		case DSAnswer, RRSIGAnswer, NSECAnswer, NSEC3Answer:
 			continue
 		}
 

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -505,7 +505,8 @@ func (r *Resolver) cachedLookup(ctx context.Context, q Question, nameServer *Nam
 			r.verboseLog(depth+2, err)
 			return &SingleQueryResult{}, isCached, StatusAuthFail, trace, errors.Wrap(err, "could not get next authority with name: "+name+" and layer: "+layer)
 		}
-		if name != layer && authName != layer {
+		// DS records are special, we need to query the parent zone and therefore cannot use the cache
+		if name != layer && authName != layer && q.Type != dns.TypeDS {
 			// we have a valid authority to check the cache for
 			if authName == "" {
 				r.verboseLog(depth+2, "Can't parse name to authority properly. name: ", name, ", layer: ", layer)

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -99,9 +99,6 @@ func (r *Resolver) doDstServersLookup(ctx context.Context, q Question, nameServe
 			q.Name = qname[:len(qname)-1]
 		}
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
-	defer cancel()
-
 	if r.shouldValidateDNSSEC {
 		r.validator = makeDNSSECValidator(r, ctx, isIterative)
 	}

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -582,7 +582,7 @@ func (r *Resolver) cachedLookup(ctx context.Context, q Question, nameServer *Nam
 		}
 
 		// only cache answers that don't have errors and pass DNSSEC validation
-		if !r.shouldValidateDNSSEC || result.DNSSECResult.Status == DNSSECSecure {
+		if !r.shouldValidateDNSSEC || result.DNSSECResult.Status != DNSSECBogus {
 			if !requestIteration && strings.ToLower(q.Name) != layer && authName != layer && !result.Flags.Authoritative { // TODO - how to detect if we've retrieved an authority record or a answer record? maybe add q.Name != authName
 				r.verboseLog(depth+2, "Cache auth upsert for ", authName)
 				r.cache.SafeAddCachedAuthority(result, cacheNameServer, depth+2, layer)
@@ -590,7 +590,7 @@ func (r *Resolver) cachedLookup(ctx context.Context, q Question, nameServer *Nam
 				r.cache.SafeAddCachedAnswer(q, result, cacheNameServer, layer, depth+2, cacheNonAuthoritative)
 			}
 		} else {
-			r.verboseLog(depth+2, "skipping cache for domain", q.Name, "and type", dns.TypeToString[q.Type], "due to DNSSEC insecure")
+			r.verboseLog(depth+2, "skipping cache for domain", q.Name, "and type", dns.TypeToString[q.Type], "due to DNSSEC bogus status")
 		}
 	} else if r.shouldValidateDNSSEC {
 		result.DNSSECResult = makeDNSSECResult()

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -363,7 +363,8 @@ func (r *Resolver) iterativeLookup(ctx context.Context, qWithMeta *QuestionWithM
 		r.verboseLog((depth + 1), "-> error occurred during lookup")
 		return result, trace, status, err
 	} else if len(result.Answers) != 0 || result.Flags.Authoritative {
-		if len(result.Answers) != 0 {
+		// DS records is authoritative from parent NS and will be in Authority section. Avoid dropping them.
+		if len(result.Answers) != 0 && qWithMeta.Q.Type != dns.TypeDS {
 			r.verboseLog((depth + 1), "-> answers found")
 			if len(result.Authorities) > 0 {
 				r.verboseLog((depth + 2), "Dropping ", len(result.Authorities), " authority answers from output")

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -571,10 +571,10 @@ func (r *Resolver) cachedLookup(ctx context.Context, q Question, nameServer *Nam
 			var dnssecResult *DNSSECResult
 			validator := makeDNSSECValidator(r, ctx, rawResp, nameServer, !requestIteration)
 			dnssecResult, trace, err = validator.validate(depth+2, trace)
-			r.verboseLog(depth+2, "DNSSEC validation status: ", dnssecResult.Status, " err: ", err)
-			if err != nil {
+			if err != nil || dnssecResult == nil {
 				return result, isCached, StatusError, trace, errors.Wrap(err, "error when validating DNSSEC")
 			}
+			r.verboseLog(depth+2, "DNSSEC validation status: ", dnssecResult.Status, " err: ", err)
 			result.DNSSECResult = dnssecResult
 		}
 

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -568,12 +568,13 @@ func (r *Resolver) cachedLookup(ctx context.Context, q Question, nameServer *Nam
 
 	if status == StatusNoError && result != nil {
 		if r.dnsSecEnabled {
-			var validated bool
-			validated, trace, err = r.validateChainOfDNSSECTrust(ctx, rawResp, nameServer, !requestIteration, depth+2, trace)
-			r.verboseLog(depth+2, "DNSSEC validation result: ", validated, " err: ", err)
+			var dnssecResult *DNSSECResult
+			dnssecResult, trace, err = r.validateChainOfDNSSECTrust(ctx, rawResp, nameServer, !requestIteration, depth+2, trace)
+			r.verboseLog(depth+2, "DNSSEC validation status: ", dnssecResult.Status, " err: ", err)
 			if err != nil {
-				return result, isCached, StatusError, trace, errors.Wrap(err, "could not validate chain of DNSSEC trust")
+				return result, isCached, StatusError, trace, errors.Wrap(err, "error when validating DNSSEC")
 			}
+			result.DNSSECResult = dnssecResult
 		}
 
 		// only cache answers that don't have errors

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -887,9 +887,10 @@ func (r *Resolver) iterateOnAuthorities(ctx context.Context, qWithMeta *Question
 	newTrace := trace
 	nameServers := make([]NameServer, 0, len(result.Authorities))
 	for i, elem := range result.Authorities {
-		if _, ok := elem.(DSAnswer); ok {
-			// DS records are not nameservers but may present in the section
-			// https://datatracker.ietf.org/doc/html/rfc4035#section-3.1.4
+		// Skip DS and RRSIG records as they are not nameservers but may present in the section
+		// https://datatracker.ietf.org/doc/html/rfc4035#section-3.1.4
+		switch elem.(type) {
+		case DSAnswer, RRSIGAnswer:
 			continue
 		}
 

--- a/src/zdns/qa.go
+++ b/src/zdns/qa.go
@@ -81,7 +81,7 @@ type SingleQueryResult struct {
 	Protocol           string        `json:"protocol" groups:"protocol,normal,long,trace"`
 	Resolver           string        `json:"resolver" groups:"resolver,normal,long,trace"`
 	Flags              DNSFlags      `json:"flags" groups:"flags,long,trace"`
-	DNSSECResult       *DNSSECResult `json:"dnssec" groups:"dnssec,normal,long,trace"`
+	DNSSECResult       *DNSSECResult `json:"dnssec,omitempty" groups:"dnssec,normal,long,trace"`
 	TLSServerHandshake interface{}   `json:"tls_handshake,omitempty" groups:"normal,long,trace"` // used for --tls and --https, JSON string of the TLS handshake
 }
 

--- a/src/zdns/qa.go
+++ b/src/zdns/qa.go
@@ -81,6 +81,7 @@ type SingleQueryResult struct {
 	Protocol           string        `json:"protocol" groups:"protocol,normal,long,trace"`
 	Resolver           string        `json:"resolver" groups:"resolver,normal,long,trace"`
 	Flags              DNSFlags      `json:"flags" groups:"flags,long,trace"`
+	DNSSECResult       *DNSSECResult `json:"dnssec,omitempty" groups:"normal,long,trace"`
 	TLSServerHandshake interface{}   `json:"tls_handshake,omitempty" groups:"normal,long,trace"` // used for --tls and --https, JSON string of the TLS handshake
 }
 

--- a/src/zdns/qa.go
+++ b/src/zdns/qa.go
@@ -81,7 +81,7 @@ type SingleQueryResult struct {
 	Protocol           string        `json:"protocol" groups:"protocol,normal,long,trace"`
 	Resolver           string        `json:"resolver" groups:"resolver,normal,long,trace"`
 	Flags              DNSFlags      `json:"flags" groups:"flags,long,trace"`
-	DNSSECResult       *DNSSECResult `json:"dnssec,omitempty" groups:"normal,long,trace"`
+	DNSSECResult       *DNSSECResult `json:"dnssec" groups:"normal,long,trace"`
 	TLSServerHandshake interface{}   `json:"tls_handshake,omitempty" groups:"normal,long,trace"` // used for --tls and --https, JSON string of the TLS handshake
 }
 

--- a/src/zdns/qa.go
+++ b/src/zdns/qa.go
@@ -81,7 +81,7 @@ type SingleQueryResult struct {
 	Protocol           string        `json:"protocol" groups:"protocol,normal,long,trace"`
 	Resolver           string        `json:"resolver" groups:"resolver,normal,long,trace"`
 	Flags              DNSFlags      `json:"flags" groups:"flags,long,trace"`
-	DNSSECResult       *DNSSECResult `json:"dnssec" groups:"normal,long,trace"`
+	DNSSECResult       *DNSSECResult `json:"dnssec" groups:"dnssec,normal,long,trace"`
 	TLSServerHandshake interface{}   `json:"tls_handshake,omitempty" groups:"normal,long,trace"` // used for --tls and --https, JSON string of the TLS handshake
 }
 

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -269,8 +269,8 @@ type Resolver struct {
 	connInfoIPv4Loopback        *ConnectionInfo // used for IPv4 lookups to loopback nameservers
 	connInfoIPv6Loopback        *ConnectionInfo // used for IPv6 lookups to loopback nameservers
 
-	retries          int
-	retriesRemaining int
+	retries          int // constant, configured max number of retries
+	retriesRemaining int // number of retries left in the current lookup
 	logLevel         log.Level
 
 	transportMode         transportMode

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -272,8 +272,9 @@ type Resolver struct {
 	connInfoIPv4Loopback        *ConnectionInfo // used for IPv4 lookups to loopback nameservers
 	connInfoIPv6Loopback        *ConnectionInfo // used for IPv6 lookups to loopback nameservers
 
-	retries          int // constant, configured max number of retries
-	retriesRemaining int // number of retries left in the current lookup
+	retries          int               // constant, configured max number of retries
+	retriesRemaining int               // number of retries left in the current lookup
+	pendingQueries   map[Question]bool // map of pending queries, to prevent cyclic queries
 	logLevel         log.Level
 
 	transportMode         transportMode
@@ -328,6 +329,7 @@ func InitResolver(config *ResolverConfig) (*Resolver, error) {
 
 		retries:              config.Retries,
 		logLevel:             config.LogLevel,
+		pendingQueries:       make(map[Question]bool),
 		lookupAllNameServers: config.LookupAllNameServers,
 
 		transportMode:         config.TransportMode,

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -269,8 +269,9 @@ type Resolver struct {
 	connInfoIPv4Loopback        *ConnectionInfo // used for IPv4 lookups to loopback nameservers
 	connInfoIPv6Loopback        *ConnectionInfo // used for IPv6 lookups to loopback nameservers
 
-	retries  int
-	logLevel log.Level
+	retries          int
+	retriesRemaining int
+	logLevel         log.Level
 
 	transportMode         transportMode
 	ipVersionMode         IPVersionMode

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -293,14 +293,16 @@ type Resolver struct {
 	followCNAMEs               bool // whether iterative lookups should follow CNAMEs/DNAMEs
 
 	dnsSecEnabled        bool
-	shouldValidateDNSSEC bool           // whether to validate DNSSEC
-	dnsOverHTTPSEnabled  bool           // whether to use DNS over HTTPS for External Lookups, n/a to Iterative Lookups
-	dnsOverTLSEnabled    bool           // whether to use DNS over TLS for External Lookups, n/a to Iterative Lookups
-	rootCAs              *x509.CertPool // Root CAs for DoT/DoH Server Verification
-	verifyServerCert     bool           // Verify server certificates for DoT/DoH
-	ednsOptions          []dns.EDNS0
-	checkingDisabledBit  bool
-	isClosed             bool // true if the resolver has been closed, lookup will panic if called after Close
+	shouldValidateDNSSEC bool             // whether to validate DNSSEC
+	validator            *dNSSECValidator // DNSSEC validator for the current lookup
+
+	dnsOverHTTPSEnabled bool           // whether to use DNS over HTTPS for External Lookups, n/a to Iterative Lookups
+	dnsOverTLSEnabled   bool           // whether to use DNS over TLS for External Lookups, n/a to Iterative Lookups
+	rootCAs             *x509.CertPool // Root CAs for DoT/DoH Server Verification
+	verifyServerCert    bool           // Verify server certificates for DoT/DoH
+	ednsOptions         []dns.EDNS0
+	checkingDisabledBit bool
+	isClosed            bool // true if the resolver has been closed, lookup will panic if called after Close
 }
 
 // InitResolver creates a new Resolver struct using the ResolverConfig. The Resolver is used to perform DNS lookups.

--- a/src/zdns/util.go
+++ b/src/zdns/util.go
@@ -40,6 +40,13 @@ func dotName(name string) string {
 	return strings.Join([]string{name, "."}, "")
 }
 
+func removeTrailingDotIfNotRoot(name string) string {
+	if name == "." {
+		return name
+	}
+	return strings.TrimSuffix(name, ".")
+}
+
 func TranslateMiekgErrorCode(err int) Status {
 	return Status(dns.RcodeToString[err])
 }

--- a/src/zdns/util.go
+++ b/src/zdns/util.go
@@ -29,9 +29,14 @@ import (
 const ZDNSVersion = "1.1.0"
 
 func dotName(name string) string {
+	if name == "." {
+		return name
+	}
+
 	if strings.HasSuffix(name, ".") {
 		log.Fatal("name already has trailing dot")
 	}
+
 	return strings.Join([]string{name, "."}, "")
 }
 
@@ -121,6 +126,10 @@ func nextAuthority(name, layer string) (string, error) {
 	// (This is dealt with elsewhere)
 	if strings.HasSuffix(name, "in-addr.arpa") && layer == "." {
 		return "in-addr.arpa", nil
+	}
+
+	if name == "." && layer == "." {
+		return ".", nil
 	}
 
 	idx := strings.LastIndex(name, ".")

--- a/src/zdns/util.go
+++ b/src/zdns/util.go
@@ -29,6 +29,9 @@ import (
 const ZDNSVersion = "1.1.0"
 
 func dotName(name string) string {
+	if strings.HasSuffix(name, ".") {
+		log.Fatal("name already has trailing dot")
+	}
 	return strings.Join([]string{name, "."}, "")
 }
 

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1328,7 +1328,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(dnssec["status"], "Insecure")
 
     def test_dnssec_validation_secure_cname(self):
-        # checks if dnssec validation reports insecure if a CNAME is not signed
+        # checks if dnssec validation reports secure if a CNAME is signed and the target is signed
         c = "A dining.umich.edu --iterative --validate-dnssec --result-verbosity=long"
         name = "."
         cmd, res = self.run_zdns(c, name)

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1364,19 +1364,14 @@ class Tests(unittest.TestCase):
             self.assertTrue(len(dnssec["ds"]) > 0)
             self.assertTrue(len(dnssec["dnskey"]) > 0)
 
-    def test_dnssec_validation_secure_circular_multiple_ksk(self):
-        # checks if dnssec validation can handle multiple KSKs and circular NS dependencies
+    def test_dnssec_validation_secure_circular(self):
+        # checks if dnssec validation can handle circular NS dependencies
         c = "A example.com --iterative --validate-dnssec --result-verbosity=long"
         name = "."
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd, "A")
         dnssec = res["results"]["A"]["data"]["dnssec"]
         self.assertEqual(dnssec["status"], "Secure")
-
-        # This may be flaky if IANA decides to change the KSKs for the zone
-        # Double check if this fails, or consider removing this test
-        self.assertTrue(len(dnssec["ds"]) >= 2)
-        self.assertTrue(len(dnssec["dnskey"]) >= 2)
 
     def test_dnssec_validation_insecure(self):
         # checks if dnssec validation reports insecure (not signed) zones correctly

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1318,6 +1318,24 @@ class Tests(unittest.TestCase):
         self.assertTrue(len(dnssec["ds"]) == 0)
         self.assertTrue(len(dnssec["dnskey"]) == 0)
 
+    def test_dnssec_validation_insecure_cname(self):
+        # checks if dnssec validation reports insecure if a CNAME is not signed
+        c = "A linkedin.com --iterative --validate-dnssec --result-verbosity=long"
+        name = "."
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd, "A")
+        dnssec = res["results"]["A"]["data"]["dnssec"]
+        self.assertEqual(dnssec["status"], "Insecure")
+
+    def test_dnssec_validation_secure_cname(self):
+        # checks if dnssec validation reports insecure if a CNAME is not signed
+        c = "A dining.umich.edu --iterative --validate-dnssec --result-verbosity=long"
+        name = "."
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd, "A")
+        dnssec = res["results"]["A"]["data"]["dnssec"]
+        self.assertEqual(dnssec["status"], "Secure")
+
     def test_dnssec_validation_bogus(self):
         # checks if dnssec validation reports bogus zones correctly
         DOMAINS = ["dnssec-failed.org", "rhybar.cz"]

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -12,7 +12,7 @@ from ipaddress import ip_address
 
 def recursiveSort(obj):
     def listSort(l):
-        assert (type(l) == type(list()))
+        assert type(l) == type(list())
         new_list = []
         for item in l:
             item = recursiveSort(item)
@@ -23,7 +23,7 @@ def recursiveSort(obj):
             return sorted(new_list)
 
     def dictSort(d):
-        assert (type(d) == type(dict()))
+        assert type(d) == type(dict())
         for key in d:
             d[key] = recursiveSort(d[key])
         return d
@@ -42,7 +42,9 @@ class Tests(unittest.TestCase):
     ZDNS_EXECUTABLE = "./zdns"
     ADDITIONAL_FLAGS = " --threads=10"  # flags used with every test
 
-    def run_zdns_check_failure(self, flags, name, expected_err, executable=ZDNS_EXECUTABLE):
+    def run_zdns_check_failure(
+        self, flags, name, expected_err, executable=ZDNS_EXECUTABLE
+    ):
         flags = flags + self.ADDITIONAL_FLAGS
         c = f"echo '{name}' | {executable} {flags}; exit 0"
         o = subprocess.check_output(c, shell=True, stderr=subprocess.STDOUT)
@@ -56,12 +58,14 @@ class Tests(unittest.TestCase):
 
     # Runs zdns with a given name(s) input and flags, returns the command and JSON objects from the piped JSON-Lines output
     # Used when running a ZDNS command that should return multiple lines of output, and you want those in a list
-    def run_zdns_multiline_output(self, flags, name, executable=ZDNS_EXECUTABLE, append_flags=True):
+    def run_zdns_multiline_output(
+        self, flags, name, executable=ZDNS_EXECUTABLE, append_flags=True
+    ):
         if append_flags:
             flags = flags + self.ADDITIONAL_FLAGS
         c = f"echo '{name}' | {executable} {flags}"
         o = subprocess.check_output(c, shell=True)
-        output_lines = o.decode('utf-8').strip().splitlines()
+        output_lines = o.decode("utf-8").strip().splitlines()
         json_objects = [json.loads(line.rstrip()) for line in output_lines]
         return c, json_objects
 
@@ -69,47 +73,91 @@ class Tests(unittest.TestCase):
 
     ROOT_A_A_ZDNS_TESTING_COM = {"21.9.87.65"}  # a.zdns-testing.com
 
-    ROOT_A_ANSWERS = [{"type": "A", "class": "IN", "answer": x,
-                       "name": "zdns-testing.com"} for x in ROOT_A_ZDNS_TESTING_COM]
+    ROOT_A_ANSWERS = [
+        {"type": "A", "class": "IN", "answer": x, "name": "zdns-testing.com"}
+        for x in ROOT_A_ZDNS_TESTING_COM
+    ]
 
-    ROOT_A_A_ZDNS_TESTING_COM_ANSWERS = [{"type": "A", "class": "IN", "answer": x,
-                                          "name": "a.zdns-testing.com"} for x in ROOT_A_A_ZDNS_TESTING_COM]
+    ROOT_A_A_ZDNS_TESTING_COM_ANSWERS = [
+        {"type": "A", "class": "IN", "answer": x, "name": "a.zdns-testing.com"}
+        for x in ROOT_A_A_ZDNS_TESTING_COM
+    ]
 
     ROOT_AAAA = {"fd5a:3bce:8713::1", "fde6:9bb3:dbd6::2", "fdb3:ac76:a577::3"}
 
-    ROOT_AAAA_ANSWERS = [{"type": "AAAA", "class": "IN", "answer": x,
-                          "name": "zdns-testing.com"} for x in ROOT_AAAA]
+    ROOT_AAAA_ANSWERS = [
+        {"type": "AAAA", "class": "IN", "answer": x, "name": "zdns-testing.com"}
+        for x in ROOT_AAAA
+    ]
 
     MX_SERVERS = [
-        {"answer": "mx1.zdns-testing.com.", "preference": 1, "type": "MX", "class": "IN", 'name': 'zdns-testing.com'},
-        {"answer": "mx2.zdns-testing.com.", "preference": 5, "type": "MX", "class": "IN", 'name': 'zdns-testing.com'},
-        {"answer": "mx1.censys.io.", "preference": 10, "type": "MX", "class": "IN", 'name': 'zdns-testing.com'},
+        {
+            "answer": "mx1.zdns-testing.com.",
+            "preference": 1,
+            "type": "MX",
+            "class": "IN",
+            "name": "zdns-testing.com",
+        },
+        {
+            "answer": "mx2.zdns-testing.com.",
+            "preference": 5,
+            "type": "MX",
+            "class": "IN",
+            "name": "zdns-testing.com",
+        },
+        {
+            "answer": "mx1.censys.io.",
+            "preference": 10,
+            "type": "MX",
+            "class": "IN",
+            "name": "zdns-testing.com",
+        },
     ]
 
     A_MX1_ZDNS_TESTING_COM = {"1.2.3.4", "2.3.4.5"}
 
     AAAA_MX1_ZDNS_TESTING_COM = {"fdb3:ac76:a577::4", "fdb3:ac76:a577::5"}
 
-    A_MX1_ZDNS_TESTING_COM_ANSWERS = [{"type": "A", "class": "IN", "answer": x, "name": "mx1.zdns-testing.com"}
-                                      for x in A_MX1_ZDNS_TESTING_COM]
-    AAAA_MX1_ZDNS_TESTING_COM_ANSWERS = [{"type": "AAAA", "class": "IN", "answer": x, "name": "mx1.zdns-testing.com"}
-                                         for x in AAAA_MX1_ZDNS_TESTING_COM]
+    A_MX1_ZDNS_TESTING_COM_ANSWERS = [
+        {"type": "A", "class": "IN", "answer": x, "name": "mx1.zdns-testing.com"}
+        for x in A_MX1_ZDNS_TESTING_COM
+    ]
+    AAAA_MX1_ZDNS_TESTING_COM_ANSWERS = [
+        {"type": "AAAA", "class": "IN", "answer": x, "name": "mx1.zdns-testing.com"}
+        for x in AAAA_MX1_ZDNS_TESTING_COM
+    ]
 
     NS_SERVERS = [
-        {"type": "NS", "class": "IN", "name": "zdns-testing.com",
-         "answer": "ns-cloud-c2.googledomains.com."},
-        {"type": "NS", "class": "IN", "name": "zdns-testing.com",
-         "answer": "ns-cloud-c3.googledomains.com."},
-        {"type": "NS", "class": "IN", "name": "zdns-testing.com",
-         "answer": "ns-cloud-c1.googledomains.com."},
-        {"type": "NS", "class": "IN", "name": "zdns-testing.com",
-         "answer": "ns-cloud-c4.googledomains.com."},
+        {
+            "type": "NS",
+            "class": "IN",
+            "name": "zdns-testing.com",
+            "answer": "ns-cloud-c2.googledomains.com.",
+        },
+        {
+            "type": "NS",
+            "class": "IN",
+            "name": "zdns-testing.com",
+            "answer": "ns-cloud-c3.googledomains.com.",
+        },
+        {
+            "type": "NS",
+            "class": "IN",
+            "name": "zdns-testing.com",
+            "answer": "ns-cloud-c1.googledomains.com.",
+        },
+        {
+            "type": "NS",
+            "class": "IN",
+            "name": "zdns-testing.com",
+            "answer": "ns-cloud-c4.googledomains.com.",
+        },
     ]
 
     NXDOMAIN_ANSWER = {
         "name": "zdns-testing-nxdomain.com",
         "class": "IN",
-        "status": "NXDOMAIN"
+        "status": "NXDOMAIN",
     }
 
     MX_LOOKUP_ANSWER = {
@@ -125,42 +173,42 @@ class Tests(unittest.TestCase):
                             "type": "MX",
                             "class": "IN",
                             "preference": 1,
-                            "ipv4_addresses": [
-                                "1.2.3.4",
-                                "2.3.4.5"
-                            ],
+                            "ipv4_addresses": ["1.2.3.4", "2.3.4.5"],
                             "ipv6_addresses": [
                                 "fdb3:ac76:a577::4",
-                                "fdb3:ac76:a577::5"
+                                "fdb3:ac76:a577::5",
                             ],
-
                         },
                         {
                             "name": "mx2.zdns-testing.com",
                             "type": "MX",
                             "class": "IN",
                             "preference": 5,
-                            "ipv4_addresses": [
-                                "5.6.7.8"
-                            ],
+                            "ipv4_addresses": ["5.6.7.8"],
                         },
                         {
                             "name": "mx1.censys.io",
                             "type": "MX",
                             "class": "IN",
                             "preference": 10,
-                        }
+                        },
                     ]
-                }
+                },
             }
-        }
+        },
     }
 
     MX_LOOKUP_ANSWER_IPV4 = copy.deepcopy(MX_LOOKUP_ANSWER)
-    del MX_LOOKUP_ANSWER_IPV4["results"]["MXLOOKUP"]["data"]["exchanges"][0]["ipv6_addresses"]
+    del MX_LOOKUP_ANSWER_IPV4["results"]["MXLOOKUP"]["data"]["exchanges"][0][
+        "ipv6_addresses"
+    ]
     MX_LOOKUP_ANSWER_IPV6 = copy.deepcopy(MX_LOOKUP_ANSWER)
-    del MX_LOOKUP_ANSWER_IPV6["results"]["MXLOOKUP"]["data"]["exchanges"][0]["ipv4_addresses"]
-    del MX_LOOKUP_ANSWER_IPV6["results"]["MXLOOKUP"]["data"]["exchanges"][1]["ipv4_addresses"]
+    del MX_LOOKUP_ANSWER_IPV6["results"]["MXLOOKUP"]["data"]["exchanges"][0][
+        "ipv4_addresses"
+    ]
+    del MX_LOOKUP_ANSWER_IPV6["results"]["MXLOOKUP"]["data"]["exchanges"][1][
+        "ipv4_addresses"
+    ]
 
     A_LOOKUP_WWW_ZDNS_TESTING = {
         "name": "www.zdns-testing.com",
@@ -169,19 +217,15 @@ class Tests(unittest.TestCase):
                 "class": "IN",
                 "status": "NOERROR",
                 "data": {
-                    "ipv4_addresses": [
-                        "1.2.3.4",
-                        "2.3.4.5",
-                        "3.4.5.6"
-                    ],
+                    "ipv4_addresses": ["1.2.3.4", "2.3.4.5", "3.4.5.6"],
                     "ipv6_addresses": [
                         "fde6:9bb3:dbd6::2",
                         "fd5a:3bce:8713::1",
-                        "fdb3:ac76:a577::3"
-                    ]
-                }
+                        "fdb3:ac76:a577::3",
+                    ],
+                },
             }
-        }
+        },
     }
 
     A_LOOKUP_WWW_ZDNS_TESTING_IPv6 = {
@@ -194,11 +238,11 @@ class Tests(unittest.TestCase):
                     "ipv6_addresses": [
                         "fde6:9bb3:dbd6::2",
                         "fd5a:3bce:8713::1",
-                        "fdb3:ac76:a577::3"
+                        "fdb3:ac76:a577::3",
                     ]
-                }
+                },
             }
-        }
+        },
     }
 
     A_LOOKUP_CNAME_CHAIN_03 = {
@@ -211,9 +255,9 @@ class Tests(unittest.TestCase):
                     "ipv4_addresses": [
                         "1.2.3.4",
                     ]
-                }
+                },
             }
-        }
+        },
     }
 
     A_LOOKUP_IPV4_WWW_ZDNS_TESTING = copy.deepcopy(A_LOOKUP_WWW_ZDNS_TESTING)
@@ -229,56 +273,44 @@ class Tests(unittest.TestCase):
                 "data": {
                     "servers": [
                         {
-                            "ipv4_addresses": [
-                                "216.239.34.108"
-                            ],
-                            "ipv6_addresses": [
-                                "2001:4860:4802:34::6c"
-                            ],
+                            "ipv4_addresses": ["216.239.34.108"],
+                            "ipv6_addresses": ["2001:4860:4802:34::6c"],
                             "name": "ns-cloud-c2.googledomains.com",
-                            "type": "NS"
+                            "type": "NS",
                         },
                         {
-                            "ipv4_addresses": [
-                                "216.239.32.108"
-                            ],
-                            "ipv6_addresses": [
-                                "2001:4860:4802:32::6c"
-                            ],
+                            "ipv4_addresses": ["216.239.32.108"],
+                            "ipv6_addresses": ["2001:4860:4802:32::6c"],
                             "name": "ns-cloud-c1.googledomains.com",
-                            "type": "NS"
+                            "type": "NS",
                         },
                         {
-                            "ipv4_addresses": [
-                                "216.239.38.108"
-                            ],
-                            "ipv6_addresses": [
-                                "2001:4860:4802:38::6c"
-                            ],
+                            "ipv4_addresses": ["216.239.38.108"],
+                            "ipv6_addresses": ["2001:4860:4802:38::6c"],
                             "name": "ns-cloud-c4.googledomains.com",
-                            "type": "NS"
+                            "type": "NS",
                         },
                         {
-                            "ipv4_addresses": [
-                                "216.239.36.108"
-                            ],
-                            "ipv6_addresses": [
-                                "2001:4860:4802:36::6c"
-                            ],
+                            "ipv4_addresses": ["216.239.36.108"],
+                            "ipv6_addresses": ["2001:4860:4802:36::6c"],
                             "name": "ns-cloud-c3.googledomains.com",
-                            "type": "NS"
-                        }
+                            "type": "NS",
+                        },
                     ]
-                }
+                },
             }
-        }
+        },
     }
 
     NS_LOOKUP_IPV4_WWW_ZDNS_TESTING = copy.deepcopy(NS_LOOKUP_WWW_ZDNS_TESTING)
-    for server in NS_LOOKUP_IPV4_WWW_ZDNS_TESTING["results"]["NSLOOKUP"]["data"]["servers"]:
+    for server in NS_LOOKUP_IPV4_WWW_ZDNS_TESTING["results"]["NSLOOKUP"]["data"][
+        "servers"
+    ]:
         del server["ipv6_addresses"]
     NS_LOOKUP_IPV6_WWW_ZDNS_TESTING = copy.deepcopy(NS_LOOKUP_WWW_ZDNS_TESTING)
-    for server in NS_LOOKUP_IPV6_WWW_ZDNS_TESTING["results"]["NSLOOKUP"]["data"]["servers"]:
+    for server in NS_LOOKUP_IPV6_WWW_ZDNS_TESTING["results"]["NSLOOKUP"]["data"][
+        "servers"
+    ]:
         del server["ipv4_addresses"]
 
     PTR_LOOKUP_GOOGLE_PUB = [
@@ -286,7 +318,7 @@ class Tests(unittest.TestCase):
             "type": "PTR",
             "class": "IN",
             "name": "8.8.8.8.in-addr.arpa",
-            "answer": "dns.google."
+            "answer": "dns.google.",
         }
     ]
 
@@ -297,7 +329,7 @@ class Tests(unittest.TestCase):
             "name": "zdns-testing.com",
             "tag": "issue",
             "value": "letsencrypt.org",
-            "flag": 0
+            "flag": 0,
         }
     ]
 
@@ -306,7 +338,7 @@ class Tests(unittest.TestCase):
             "type": "TXT",
             "class": "IN",
             "name": "test_txt.zdns-testing.com",
-            "answer": "Hello World!"
+            "answer": "Hello World!",
         }
     ]
 
@@ -329,9 +361,9 @@ class Tests(unittest.TestCase):
                 "recursion_available": False,
                 "authenticated": False,
                 "checking_disabled": False,
-                "error_code": 0
-            }
-        }
+                "error_code": 0,
+            },
+        },
     }
 
     TCP_LARGE_TXT_ANSWERS = [
@@ -339,85 +371,85 @@ class Tests(unittest.TestCase):
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "surveys, informed by our own experiences conducting a long-term research survey over the past year."
+            "answer": "surveys, informed by our own experiences conducting a long-term research survey over the past year.",
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "and explore the security implications of high speed Internet-scale network surveys, both offensive and defensive. "
+            "answer": "and explore the security implications of high speed Internet-scale network surveys, both offensive and defensive. ",
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "in under 45 minutes from user space on a single machine, approaching the theoretical maximum speed of gigabit Ethernet."
+            "answer": "in under 45 minutes from user space on a single machine, approaching the theoretical maximum speed of gigabit Ethernet.",
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "We introduce ZMap, a modular, open-source network scanner specifically architected to perform Internet-wide scans and capable of surveying the entire IPv4 address space"
+            "answer": "We introduce ZMap, a modular, open-source network scanner specifically architected to perform Internet-wide scans and capable of surveying the entire IPv4 address space",
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Internet-wide network scanning has numerous security applications, including exposing new vulnerabilities and tracking the adoption of defensive mechanisms, but probing the entire public address space with existing tools is both difficult and slow."
+            "answer": "Internet-wide network scanning has numerous security applications, including exposing new vulnerabilities and tracking the adoption of defensive mechanisms, but probing the entire public address space with existing tools is both difficult and slow.",
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "We also discuss best practices for good Internet citizenship when performing Internet-wide"
+            "answer": "We also discuss best practices for good Internet citizenship when performing Internet-wide",
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "We present the scanner architecture, experimentally characterize its performance and accuracy, "
+            "answer": "We present the scanner architecture, experimentally characterize its performance and accuracy, ",
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+            "answer": "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo."
+            "answer": "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.",
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+            "answer": "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt."
+            "answer": "Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.",
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+            "answer": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
+            "answer": "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem."
+            "answer": "Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.",
         },
     ]
 
@@ -426,7 +458,7 @@ class Tests(unittest.TestCase):
             "type": "CNAME",
             "class": "IN",
             "name": "www.zdns-testing.com",
-            "answer": "zdns-testing.com."
+            "answer": "zdns-testing.com.",
         }
     ]
 
@@ -435,23 +467,11 @@ class Tests(unittest.TestCase):
             "type": "CNAME",
             "class": "IN",
             "name": "www.zdns-testing.com",
-            "answer": "zdns-testing.com."
-        }, {
-            "type": "A",
-            "class": "IN",
-            "name": "zdns-testing.com",
-            "answer": "1.2.3.4"
-        }, {
-            "type": "A",
-            "class": "IN",
-            "name": "zdns-testing.com",
-            "answer": "2.3.4.5"
-        }, {
-            "type": "A",
-            "class": "IN",
-            "name": "zdns-testing.com",
-            "answer": "3.4.5.6"
-        }
+            "answer": "zdns-testing.com.",
+        },
+        {"type": "A", "class": "IN", "name": "zdns-testing.com", "answer": "1.2.3.4"},
+        {"type": "A", "class": "IN", "name": "zdns-testing.com", "answer": "2.3.4.5"},
+        {"type": "A", "class": "IN", "name": "zdns-testing.com", "answer": "3.4.5.6"},
     ]
 
     WWW_CNAME_AND_AAAA_ANSWERS = [
@@ -459,23 +479,26 @@ class Tests(unittest.TestCase):
             "type": "CNAME",
             "class": "IN",
             "name": "www.zdns-testing.com",
-            "answer": "zdns-testing.com."
-        }, {
+            "answer": "zdns-testing.com.",
+        },
+        {
             "type": "AAAA",
             "class": "IN",
             "name": "zdns-testing.com",
-            "answer": "fd5a:3bce:8713::1"
-        }, {
+            "answer": "fd5a:3bce:8713::1",
+        },
+        {
             "type": "AAAA",
             "class": "IN",
             "name": "zdns-testing.com",
-            "answer": "fde6:9bb3:dbd6::2"
-        }, {
+            "answer": "fde6:9bb3:dbd6::2",
+        },
+        {
             "type": "AAAA",
             "class": "IN",
             "name": "zdns-testing.com",
-            "answer": "fdb3:ac76:a577::3"
-        }
+            "answer": "fdb3:ac76:a577::3",
+        },
     ]
 
     CNAME_LOOP_ANSWERS = [
@@ -484,12 +507,13 @@ class Tests(unittest.TestCase):
             "class": "IN",
             "name": "cname-loop.zdns-testing.com",
             "answer": "cname-loop.esrg.stanford.edu.",
-        }, {
+        },
+        {
             "type": "CNAME",
             "class": "IN",
             "name": "cname-loop.esrg.stanford.edu",
             "answer": "cname-loop.zdns-testing.com.",
-        }
+        },
     ]
 
     # an A record behind a DNAME record
@@ -505,25 +529,20 @@ class Tests(unittest.TestCase):
             "class": "IN",
             "name": "a.zdns-dname.esrg.stanford.edu",
             "answer": "a.zdns-testing.com.",
-        }, {
+        },
+        {
             "type": "A",
             "class": "IN",
             "name": "a.zdns-testing.com",
             "answer": "21.9.87.65",
-        }
+        },
     ]
 
     DMARC_ANSWER = {
-        "data": {
-            "dmarc": "v=DMARC1; p=none; rua=mailto:postmaster@censys.io"
-        }
+        "data": {"dmarc": "v=DMARC1; p=none; rua=mailto:postmaster@censys.io"}
     }
 
-    SPF_ANSWER = {
-        "data": {
-            "spf": "v=spf1 mx include:_spf.google.com -all"
-        }
-    }
+    SPF_ANSWER = {"data": {"spf": "v=spf1 mx include:_spf.google.com -all"}}
 
     SOA_ANSWERS = [
         {
@@ -536,8 +555,7 @@ class Tests(unittest.TestCase):
             "refresh": 21600,
             "retry": 3600,
             "expire": 259200,
-            "min_ttl": 300
-
+            "min_ttl": 300,
         }
     ]
 
@@ -549,7 +567,7 @@ class Tests(unittest.TestCase):
             "port": 5060,
             "priority": 10,
             "target": "sip-anycast-1.voice.google.com.",
-            "weight": 1
+            "weight": 1,
         },
         {
             "type": "SRV",
@@ -558,8 +576,8 @@ class Tests(unittest.TestCase):
             "port": 5060,
             "priority": 20,
             "target": "sip-anycast-2.voice.google.com.",
-            "weight": 1
-        }
+            "weight": 1,
+        },
     ]
 
     TLSA_ANSWERS = [
@@ -570,22 +588,23 @@ class Tests(unittest.TestCase):
             "cert_usage": 3,
             "selector": 1,
             "matching_type": 1,
-            "certificate": "2a8f1dbc25611cd32da057c5dde9c4d55db6dd9b386b402ede4b7507d93ede8d"
-        }, {
+            "certificate": "2a8f1dbc25611cd32da057c5dde9c4d55db6dd9b386b402ede4b7507d93ede8d",
+        },
+        {
             "type": "TLSA",
             "class": "IN",
             "name": "_25._tcp.mail.ietf.org",
             "cert_usage": 3,
             "selector": 1,
             "matching_type": 1,
-            "certificate": "b05d5a0b10095ab7d38710aa70b85c5227cfb9cae23c93ee2bf8fdbedfffdb39"
-        }
+            "certificate": "b05d5a0b10095ab7d38710aa70b85c5227cfb9cae23c93ee2bf8fdbedfffdb39",
+        },
     ]
 
     ECS_MAPPINGS = {
         "171.67.68.0/24": "2.3.4.5",
         "131.159.92.0/24": "3.4.5.6",
-        "129.127.149.0/24": "1.2.3.4"
+        "129.127.149.0/24": "1.2.3.4",
     }
 
     def assertSuccess(self, res, cmd, query_type):
@@ -600,11 +619,14 @@ class Tests(unittest.TestCase):
             del answer["ttl"]
         a = sorted(res["results"][query_type]["data"]["answers"], key=lambda x: x[key])
         b = sorted(correct, key=lambda x: x[key])
-        helptext = "%s\nExpected:\n%s\n\nActual:\n%s" % (cmd,
-                                                         json.dumps(b, indent=4), json.dumps(a, indent=4))
+        helptext = "%s\nExpected:\n%s\n\nActual:\n%s" % (
+            cmd,
+            json.dumps(b, indent=4),
+            json.dumps(a, indent=4),
+        )
 
         def _lowercase(obj):
-            """ Make dictionary lowercase """
+            """Make dictionary lowercase"""
             if isinstance(obj, dict):
                 for k, v in obj.items():
                     if k == "name":
@@ -622,11 +644,16 @@ class Tests(unittest.TestCase):
 
     def assertEqualMXLookup(self, res, correct):
         self.assertEqual(res["name"], correct["name"])
-        self.assertEqual(res["results"]["MXLOOKUP"]["status"], correct["results"]["MXLOOKUP"]["status"])
+        self.assertEqual(
+            res["results"]["MXLOOKUP"]["status"],
+            correct["results"]["MXLOOKUP"]["status"],
+        )
         for exchange in res["results"]["MXLOOKUP"]["data"]["exchanges"]:
             del exchange["ttl"]
-        self.assertEqual(recursiveSort(res["results"]["MXLOOKUP"]["data"]["exchanges"]),
-                         recursiveSort(correct["results"]["MXLOOKUP"]["data"]["exchanges"]))
+        self.assertEqual(
+            recursiveSort(res["results"]["MXLOOKUP"]["data"]["exchanges"]),
+            recursiveSort(correct["results"]["MXLOOKUP"]["data"]["exchanges"]),
+        )
 
     def assertEqualALookup(self, res, correct, query_type):
         self.assertEqual(res["name"], correct["name"])
@@ -635,22 +662,33 @@ class Tests(unittest.TestCase):
         self.assertEqual(res["status"], correct_A_lookup["status"])
         if "ipv4_addresses" in correct_A_lookup["data"]:
             self.assertIn("ipv4_addresses", res["data"])
-            self.assertEqual(sorted(res["data"]["ipv4_addresses"]), sorted(correct_A_lookup["data"]["ipv4_addresses"]))
+            self.assertEqual(
+                sorted(res["data"]["ipv4_addresses"]),
+                sorted(correct_A_lookup["data"]["ipv4_addresses"]),
+            )
         else:
             self.assertNotIn("ipv4_addresses", res["data"])
         if "ipv6_addresses" in correct_A_lookup["data"]:
             self.assertIn("ipv6_addresses", res["data"])
-            self.assertEqual(sorted(res["data"]["ipv6_addresses"]), sorted(correct_A_lookup["data"]["ipv6_addresses"]))
+            self.assertEqual(
+                sorted(res["data"]["ipv6_addresses"]),
+                sorted(correct_A_lookup["data"]["ipv6_addresses"]),
+            )
         else:
             self.assertNotIn("ipv6_addresses", res["data"])
 
     def assertEqualNSLookup(self, res, correct):
         self.assertEqual(res["name"], correct["name"])
-        self.assertEqual(res["results"]["NSLOOKUP"]["status"], correct["results"]["NSLOOKUP"]["status"])
+        self.assertEqual(
+            res["results"]["NSLOOKUP"]["status"],
+            correct["results"]["NSLOOKUP"]["status"],
+        )
         for server in res["results"]["NSLOOKUP"]["data"]["servers"]:
             del server["ttl"]
-        self.assertEqual(recursiveSort(res["results"]["NSLOOKUP"]["data"]["servers"]),
-                         recursiveSort(correct["results"]["NSLOOKUP"]["data"]["servers"]))
+        self.assertEqual(
+            recursiveSort(res["results"]["NSLOOKUP"]["data"]["servers"]),
+            recursiveSort(correct["results"]["NSLOOKUP"]["data"]["servers"]),
+        )
 
     def assertEqualTypes(self, res, list):
         res_types = set()
@@ -714,9 +752,13 @@ class Tests(unittest.TestCase):
         self.assertSuccess(res[1], cmd, "A")
         if res[0]["name"] == "zdns-testing.com":
             self.assertEqualAnswers(res[0], self.ROOT_A_ANSWERS, cmd, "A")
-            self.assertEqualAnswers(res[1], self.ROOT_A_A_ZDNS_TESTING_COM_ANSWERS, cmd, "A")
+            self.assertEqualAnswers(
+                res[1], self.ROOT_A_A_ZDNS_TESTING_COM_ANSWERS, cmd, "A"
+            )
         else:
-            self.assertEqualAnswers(res[0], self.ROOT_A_A_ZDNS_TESTING_COM_ANSWERS, cmd, "A")
+            self.assertEqualAnswers(
+                res[0], self.ROOT_A_A_ZDNS_TESTING_COM_ANSWERS, cmd, "A"
+            )
             self.assertEqualAnswers(res[1], self.ROOT_A_ANSWERS, cmd, "A")
 
     def test_multiple_modules(self):
@@ -766,9 +808,13 @@ class Tests(unittest.TestCase):
                 elif r["name"] == "zdns-testing.com" and query_type == "AAAA":
                     self.assertEqualAnswers(r, self.ROOT_AAAA_ANSWERS, cmd, "AAAA")
                 elif r["name"] == "mx1.zdns-testing.com" and query_type == "A":
-                    self.assertEqualAnswers(r, self.A_MX1_ZDNS_TESTING_COM_ANSWERS, cmd, "A")
+                    self.assertEqualAnswers(
+                        r, self.A_MX1_ZDNS_TESTING_COM_ANSWERS, cmd, "A"
+                    )
                 elif r["name"] == "mx1.zdns-testing.com" and query_type == "AAAA":
-                    self.assertEqualAnswers(r, self.AAAA_MX1_ZDNS_TESTING_COM_ANSWERS, cmd, "AAAA")
+                    self.assertEqualAnswers(
+                        r, self.AAAA_MX1_ZDNS_TESTING_COM_ANSWERS, cmd, "AAAA"
+                    )
                 else:
                     self.fail("Unexpected response")
         # delete file
@@ -1021,7 +1067,6 @@ class Tests(unittest.TestCase):
         self.assertTrue(usedCloudflare)
         self.assertTrue(usedGoogle)
 
-
     def test_name_server_mode_with_doh(self):
         c = "A dns.google cloudflare-dns.com --override-name=www.zdns-testing.com --name-server-mode --https --threads=1"
         name = ""
@@ -1142,8 +1187,10 @@ class Tests(unittest.TestCase):
         self.assertSuccess(res, cmd, "AXFR")
         f = open("testing/axfr.json")
         axfr_answer = json.load(f)
-        self.assertEqualAxfrLookup(res["results"]["AXFR"]["data"]["servers"][0]["records"],
-                                   axfr_answer["data"]["servers"][0]["records"])
+        self.assertEqualAxfrLookup(
+            res["results"]["AXFR"]["data"]["servers"][0]["records"],
+            axfr_answer["data"]["servers"][0]["records"],
+        )
         f.close()
 
     def test_soa(self):
@@ -1178,14 +1225,18 @@ class Tests(unittest.TestCase):
         c = "TXT --tcp-only --name-servers=8.8.8.8:53"  # Azure DNS does not provide results.
         name = "large-text.zdns-testing.com"
         cmd, res = self.run_zdns(c, name)
-        self.assertEqualAnswers(res, self.TCP_LARGE_TXT_ANSWERS, cmd, "TXT", key="answer")
+        self.assertEqualAnswers(
+            res, self.TCP_LARGE_TXT_ANSWERS, cmd, "TXT", key="answer"
+        )
 
     def test_too_big_txt_all(self):
         c = "TXT --name-servers=8.8.8.8:53"
         name = "large-text.zdns-testing.com"
         cmd, res = self.run_zdns(c, name)
         self.assertEqual(res["results"]["TXT"]["data"]["protocol"], "tcp")
-        self.assertEqualAnswers(res, self.TCP_LARGE_TXT_ANSWERS, cmd, "TXT", key="answer")
+        self.assertEqualAnswers(
+            res, self.TCP_LARGE_TXT_ANSWERS, cmd, "TXT", key="answer"
+        )
 
     def test_override_name(self):
         c = "A --override-name=zdns-testing.com"
@@ -1210,7 +1261,9 @@ class Tests(unittest.TestCase):
     def test_local_addr_interface_warning(self):
         c = "A --local-addr 192.168.1.5 --local-interface en0"
         name = "zdns-testing.com"
-        self.run_zdns_check_failure(c, name, "--local-addr and --local-interface cannot both be specified")
+        self.run_zdns_check_failure(
+            c, name, "--local-addr and --local-interface cannot both be specified"
+        )
 
     def test_edns0_client_subnet(self):
         name = "ecs-geo.zdns-testing.com"
@@ -1223,11 +1276,22 @@ class Tests(unittest.TestCase):
             family = 1 if ip_address(address).version == 4 else 2
             original_res = res
             res = res["results"]["A"]
-            self.assertEqual(address, res["data"]['additionals'][0]['csubnet']['address'])
-            self.assertEqual(int(netmask), res["data"]['additionals'][0]['csubnet']["source_netmask"])
-            self.assertEqual(family, res["data"]['additionals'][0]['csubnet']['family'])
-            self.assertTrue("source_scope" in res["data"]['additionals'][0]['csubnet'])
-            correct = [{"type": "A", "class": "IN", "answer": ip_addr, "name": "ecs-geo.zdns-testing.com"}]
+            self.assertEqual(
+                address, res["data"]["additionals"][0]["csubnet"]["address"]
+            )
+            self.assertEqual(
+                int(netmask), res["data"]["additionals"][0]["csubnet"]["source_netmask"]
+            )
+            self.assertEqual(family, res["data"]["additionals"][0]["csubnet"]["family"])
+            self.assertTrue("source_scope" in res["data"]["additionals"][0]["csubnet"])
+            correct = [
+                {
+                    "type": "A",
+                    "class": "IN",
+                    "answer": ip_addr,
+                    "name": "ecs-geo.zdns-testing.com",
+                }
+            ]
             self.assertEqualAnswers(original_res, correct, cmd, "A")
 
     def test_edns0_nsid(self):
@@ -1237,20 +1301,24 @@ class Tests(unittest.TestCase):
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd, "A")
         res = res["results"]["A"]
-        self.assertTrue("nsid" in res["data"]['additionals'][0])
-        self.assertTrue(res["data"]['additionals'][0]['nsid']['nsid'].startswith("gpdns-"))
+        self.assertTrue("nsid" in res["data"]["additionals"][0])
+        self.assertTrue(
+            res["data"]["additionals"][0]["nsid"]["nsid"].startswith("gpdns-")
+        )
 
     def test_edns0_ede_1(self):
         name = "dnssec.fail"
         # using Cloudflare Public DNS (1.1.1.1) that implements EDE
         c = f"A --name-servers=1.1.1.1:53"
         cmd, res = self.run_zdns(c, name)
-        self.assertServFail(res, cmd, 'A')
+        self.assertServFail(res, cmd, "A")
         res = res["results"]["A"]
-        self.assertTrue("ede" in res["data"]['additionals'][0])
-        ede_obj = res["data"]['additionals'][0]["ede"][0]
+        self.assertTrue("ede" in res["data"]["additionals"][0])
+        ede_obj = res["data"]["additionals"][0]["ede"][0]
         self.assertEqual("DNSKEY Missing", ede_obj["error_text"])
-        self.assertEqual("no SEP matching the DS found for dnssec.fail.", ede_obj["extra_text"])
+        self.assertEqual(
+            "no SEP matching the DS found for dnssec.fail.", ede_obj["extra_text"]
+        )
         self.assertEqual(9, ede_obj["info_code"])
 
     def test_edns0_ede_2_cd(self):
@@ -1260,10 +1328,12 @@ class Tests(unittest.TestCase):
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd, "A")
         res = res["results"]["A"]
-        self.assertTrue("ede" in res["data"]['additionals'][0])
-        ede_obj = res["data"]['additionals'][0]["ede"][0]
+        self.assertTrue("ede" in res["data"]["additionals"][0])
+        ede_obj = res["data"]["additionals"][0]["ede"][0]
         self.assertEqual("DNSKEY Missing", ede_obj["error_text"])
-        self.assertEqual("no SEP matching the DS found for dnssec.fail.", ede_obj["extra_text"])
+        self.assertEqual(
+            "no SEP matching the DS found for dnssec.fail.", ede_obj["extra_text"]
+        )
         self.assertEqual(9, ede_obj["info_code"])
 
     def test_dnssec_response(self):
@@ -1273,8 +1343,62 @@ class Tests(unittest.TestCase):
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd, "SOA")
         res = res["results"]["SOA"]
-        self.assertEqual('do', res["data"]['additionals'][0]['flags'])
+        self.assertEqual("do", res["data"]["additionals"][0]["flags"])
         self.assertEqualTypes(res, ["SOA", "RRSIG"])
+
+    def test_dnssec_validation_secure(self):
+        # checks if dnssec validation is performed
+        DOMAINS = [
+            "cloudflare.com",
+            "internetsociety.org",
+            "dnssec-tools.org",
+            "dnssec-deployment.org",
+        ]
+        for domain in DOMAINS:
+            c = f"A {domain} --iterative --validate-dnssec --result-verbosity=long"
+            name = "."
+            cmd, res = self.run_zdns(c, name)
+            self.assertSuccess(res, cmd, "A")
+            dnssec = res["results"]["A"]["data"]["dnssec"]
+            self.assertEqual(dnssec["status"], "Secure")
+            self.assertTrue(len(dnssec["ds"]) > 0)
+            self.assertTrue(len(dnssec["dnskey"]) > 0)
+
+    def test_dnssec_validation_secure_circular_multiple_ksk(self):
+        # checks if dnssec validation can handle multiple KSKs and circular NS dependencies
+        c = "A example.com --iterative --validate-dnssec --result-verbosity=long"
+        name = "."
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd, "A")
+        dnssec = res["results"]["A"]["data"]["dnssec"]
+        self.assertEqual(dnssec["status"], "Secure")
+
+        # This may be flaky if IANA decides to change the KSKs for the zone
+        # Double check if this fails, or consider removing this test
+        self.assertTrue(len(dnssec["ds"]) >= 2)
+        self.assertTrue(len(dnssec["dnskey"]) >= 2)
+
+    def test_dnssec_validation_insecure(self):
+        # checks if dnssec validation reports insecure (not signed) zones correctly
+        c = "A outlook.com --iterative --validate-dnssec --result-verbosity=long"
+        name = "."
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd, "A")
+        dnssec = res["results"]["A"]["data"]["dnssec"]
+        self.assertEqual(dnssec["status"], "Insecure")
+        self.assertTrue(len(dnssec["ds"]) == 0)
+        self.assertTrue(len(dnssec["dnskey"]) == 0)
+
+    def test_dnssec_validation_bogus(self):
+        # checks if dnssec validation reports bogus zones correctly
+        DOMAINS = ["dnssec-failed.org", "rhybar.cz"]
+        for domain in DOMAINS:
+            c = f"A {domain} --iterative --validate-dnssec --result-verbosity=long"
+            name = "."
+            cmd, res = self.run_zdns(c, name)
+            self.assertSuccess(res, cmd, "A")
+            dnssec = res["results"]["A"]["data"]["dnssec"]
+            self.assertEqual(dnssec["status"], "Bogus")
 
     def test_cd_bit_not_set(self):
         c = "A --name-servers=8.8.8.8:53"
@@ -1296,7 +1420,9 @@ class Tests(unittest.TestCase):
         res = res["results"]["A"]
         assert "timestamp" in res
         date = datetime.datetime.strptime(res["timestamp"], "%Y-%m-%dT%H:%M:%S%z")
-        self.assertTrue(date.microsecond == 0)  # microseconds should be 0 since we didn't call with --nanoseconds
+        self.assertTrue(
+            date.microsecond == 0
+        )  # microseconds should be 0 since we didn't call with --nanoseconds
 
     def test_timetamps_nanoseconds(self):
         c = "A --nanoseconds"
@@ -1314,7 +1440,10 @@ class Tests(unittest.TestCase):
     # test_metadata_file test the `--metadata-file` flag which saves a summary of a scan's metadata output to a file
     def test_metadata_file(self):
         f_name = "temp-metadata.json"
-        c = "A google.com yahoo.com cloudflare.com zdns-testing.com --metadata-file=" + f_name
+        c = (
+            "A google.com yahoo.com cloudflare.com zdns-testing.com --metadata-file="
+            + f_name
+        )
         name = ""
         cmd, res = self.run_zdns_multiline_output(c, name)
         for r in res:
@@ -1345,8 +1474,12 @@ class Tests(unittest.TestCase):
         ini_file_name = "test_metadata_file_multiple_modules.ini"
         with open(ini_file_name, "w") as f:
             f.write(ini_file_contents)
-        c = ("MULTIPLE -c " + ini_file_name + " google.com yahoo.com cloudflare.com zdns-testing.com --metadata-file="
-             + metadata_file_name)
+        c = (
+            "MULTIPLE -c "
+            + ini_file_name
+            + " google.com yahoo.com cloudflare.com zdns-testing.com --metadata-file="
+            + metadata_file_name
+        )
         name = ""
         cmd, res = self.run_zdns_multiline_output(c, name)
         for r in res:
@@ -1376,7 +1509,6 @@ class Tests(unittest.TestCase):
         self.assertSuccess(res, cmd, "A")
         self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd, "A")
 
-
     def test_a_lookup_IP_name_server_with_input(self):
         c = "A"
         name = "zdns-testing.com,1.1.1.1"
@@ -1391,8 +1523,11 @@ class Tests(unittest.TestCase):
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd, "A")
         self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd, "A")
-        self.assertEqual(res["results"]["A"]["data"]["resolver"], "8.8.8.8:53", "user-supplied name server with input "
-                                                                                "should take precedence")
+        self.assertEqual(
+            res["results"]["A"]["data"]["resolver"],
+            "8.8.8.8:53",
+            "user-supplied name server with input " "should take precedence",
+        )
 
     def test_a_lookup_IP_name_server_with_input_flag_loopback_mismatch(self):
         c = "A --name-servers=127.0.0.1"
@@ -1400,8 +1535,11 @@ class Tests(unittest.TestCase):
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd, "A")
         self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd, "A")
-        self.assertEqual(res["results"]["A"]["data"]["resolver"], "8.8.8.8:53", "user-supplied name server with input "
-                                                                                "should take precedence")
+        self.assertEqual(
+            res["results"]["A"]["data"]["resolver"],
+            "8.8.8.8:53",
+            "user-supplied name server with input " "should take precedence",
+        )
 
     def test_dnssec_option(self):
         c = "A --dnssec --name-servers=1.0.0.1"
@@ -1425,9 +1563,10 @@ class Tests(unittest.TestCase):
         second_duration = res[1]["results"]["A"]["duration"]
         # a bit of a hacky test, but we're checking that if we query the same domain with the same nameserver,
         # the second query has a much smaller response time than the first to show it's being cached
-        self.assertTrue(first_duration / 50 > second_duration, f"Second query {second_duration} should be faster than the first {first_duration}")
-
-
+        self.assertTrue(
+            first_duration / 50 > second_duration,
+            f"Second query {second_duration} should be faster than the first {first_duration}",
+        )
 
 
 if __name__ == "__main__":

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -12,7 +12,7 @@ from ipaddress import ip_address
 
 def recursiveSort(obj):
     def listSort(l):
-        assert type(l) == type(list())
+        assert (type(l) == type(list()))
         new_list = []
         for item in l:
             item = recursiveSort(item)
@@ -23,7 +23,7 @@ def recursiveSort(obj):
             return sorted(new_list)
 
     def dictSort(d):
-        assert type(d) == type(dict())
+        assert (type(d) == type(dict()))
         for key in d:
             d[key] = recursiveSort(d[key])
         return d
@@ -42,9 +42,7 @@ class Tests(unittest.TestCase):
     ZDNS_EXECUTABLE = "./zdns"
     ADDITIONAL_FLAGS = " --threads=10"  # flags used with every test
 
-    def run_zdns_check_failure(
-        self, flags, name, expected_err, executable=ZDNS_EXECUTABLE
-    ):
+    def run_zdns_check_failure(self, flags, name, expected_err, executable=ZDNS_EXECUTABLE):
         flags = flags + self.ADDITIONAL_FLAGS
         c = f"echo '{name}' | {executable} {flags}; exit 0"
         o = subprocess.check_output(c, shell=True, stderr=subprocess.STDOUT)
@@ -58,14 +56,12 @@ class Tests(unittest.TestCase):
 
     # Runs zdns with a given name(s) input and flags, returns the command and JSON objects from the piped JSON-Lines output
     # Used when running a ZDNS command that should return multiple lines of output, and you want those in a list
-    def run_zdns_multiline_output(
-        self, flags, name, executable=ZDNS_EXECUTABLE, append_flags=True
-    ):
+    def run_zdns_multiline_output(self, flags, name, executable=ZDNS_EXECUTABLE, append_flags=True):
         if append_flags:
             flags = flags + self.ADDITIONAL_FLAGS
         c = f"echo '{name}' | {executable} {flags}"
         o = subprocess.check_output(c, shell=True)
-        output_lines = o.decode("utf-8").strip().splitlines()
+        output_lines = o.decode('utf-8').strip().splitlines()
         json_objects = [json.loads(line.rstrip()) for line in output_lines]
         return c, json_objects
 
@@ -73,91 +69,47 @@ class Tests(unittest.TestCase):
 
     ROOT_A_A_ZDNS_TESTING_COM = {"21.9.87.65"}  # a.zdns-testing.com
 
-    ROOT_A_ANSWERS = [
-        {"type": "A", "class": "IN", "answer": x, "name": "zdns-testing.com"}
-        for x in ROOT_A_ZDNS_TESTING_COM
-    ]
+    ROOT_A_ANSWERS = [{"type": "A", "class": "IN", "answer": x,
+                       "name": "zdns-testing.com"} for x in ROOT_A_ZDNS_TESTING_COM]
 
-    ROOT_A_A_ZDNS_TESTING_COM_ANSWERS = [
-        {"type": "A", "class": "IN", "answer": x, "name": "a.zdns-testing.com"}
-        for x in ROOT_A_A_ZDNS_TESTING_COM
-    ]
+    ROOT_A_A_ZDNS_TESTING_COM_ANSWERS = [{"type": "A", "class": "IN", "answer": x,
+                                          "name": "a.zdns-testing.com"} for x in ROOT_A_A_ZDNS_TESTING_COM]
 
     ROOT_AAAA = {"fd5a:3bce:8713::1", "fde6:9bb3:dbd6::2", "fdb3:ac76:a577::3"}
 
-    ROOT_AAAA_ANSWERS = [
-        {"type": "AAAA", "class": "IN", "answer": x, "name": "zdns-testing.com"}
-        for x in ROOT_AAAA
-    ]
+    ROOT_AAAA_ANSWERS = [{"type": "AAAA", "class": "IN", "answer": x,
+                          "name": "zdns-testing.com"} for x in ROOT_AAAA]
 
     MX_SERVERS = [
-        {
-            "answer": "mx1.zdns-testing.com.",
-            "preference": 1,
-            "type": "MX",
-            "class": "IN",
-            "name": "zdns-testing.com",
-        },
-        {
-            "answer": "mx2.zdns-testing.com.",
-            "preference": 5,
-            "type": "MX",
-            "class": "IN",
-            "name": "zdns-testing.com",
-        },
-        {
-            "answer": "mx1.censys.io.",
-            "preference": 10,
-            "type": "MX",
-            "class": "IN",
-            "name": "zdns-testing.com",
-        },
+        {"answer": "mx1.zdns-testing.com.", "preference": 1, "type": "MX", "class": "IN", 'name': 'zdns-testing.com'},
+        {"answer": "mx2.zdns-testing.com.", "preference": 5, "type": "MX", "class": "IN", 'name': 'zdns-testing.com'},
+        {"answer": "mx1.censys.io.", "preference": 10, "type": "MX", "class": "IN", 'name': 'zdns-testing.com'},
     ]
 
     A_MX1_ZDNS_TESTING_COM = {"1.2.3.4", "2.3.4.5"}
 
     AAAA_MX1_ZDNS_TESTING_COM = {"fdb3:ac76:a577::4", "fdb3:ac76:a577::5"}
 
-    A_MX1_ZDNS_TESTING_COM_ANSWERS = [
-        {"type": "A", "class": "IN", "answer": x, "name": "mx1.zdns-testing.com"}
-        for x in A_MX1_ZDNS_TESTING_COM
-    ]
-    AAAA_MX1_ZDNS_TESTING_COM_ANSWERS = [
-        {"type": "AAAA", "class": "IN", "answer": x, "name": "mx1.zdns-testing.com"}
-        for x in AAAA_MX1_ZDNS_TESTING_COM
-    ]
+    A_MX1_ZDNS_TESTING_COM_ANSWERS = [{"type": "A", "class": "IN", "answer": x, "name": "mx1.zdns-testing.com"}
+                                      for x in A_MX1_ZDNS_TESTING_COM]
+    AAAA_MX1_ZDNS_TESTING_COM_ANSWERS = [{"type": "AAAA", "class": "IN", "answer": x, "name": "mx1.zdns-testing.com"}
+                                         for x in AAAA_MX1_ZDNS_TESTING_COM]
 
     NS_SERVERS = [
-        {
-            "type": "NS",
-            "class": "IN",
-            "name": "zdns-testing.com",
-            "answer": "ns-cloud-c2.googledomains.com.",
-        },
-        {
-            "type": "NS",
-            "class": "IN",
-            "name": "zdns-testing.com",
-            "answer": "ns-cloud-c3.googledomains.com.",
-        },
-        {
-            "type": "NS",
-            "class": "IN",
-            "name": "zdns-testing.com",
-            "answer": "ns-cloud-c1.googledomains.com.",
-        },
-        {
-            "type": "NS",
-            "class": "IN",
-            "name": "zdns-testing.com",
-            "answer": "ns-cloud-c4.googledomains.com.",
-        },
+        {"type": "NS", "class": "IN", "name": "zdns-testing.com",
+         "answer": "ns-cloud-c2.googledomains.com."},
+        {"type": "NS", "class": "IN", "name": "zdns-testing.com",
+         "answer": "ns-cloud-c3.googledomains.com."},
+        {"type": "NS", "class": "IN", "name": "zdns-testing.com",
+         "answer": "ns-cloud-c1.googledomains.com."},
+        {"type": "NS", "class": "IN", "name": "zdns-testing.com",
+         "answer": "ns-cloud-c4.googledomains.com."},
     ]
 
     NXDOMAIN_ANSWER = {
         "name": "zdns-testing-nxdomain.com",
         "class": "IN",
-        "status": "NXDOMAIN",
+        "status": "NXDOMAIN"
     }
 
     MX_LOOKUP_ANSWER = {
@@ -173,42 +125,42 @@ class Tests(unittest.TestCase):
                             "type": "MX",
                             "class": "IN",
                             "preference": 1,
-                            "ipv4_addresses": ["1.2.3.4", "2.3.4.5"],
+                            "ipv4_addresses": [
+                                "1.2.3.4",
+                                "2.3.4.5"
+                            ],
                             "ipv6_addresses": [
                                 "fdb3:ac76:a577::4",
-                                "fdb3:ac76:a577::5",
+                                "fdb3:ac76:a577::5"
                             ],
+
                         },
                         {
                             "name": "mx2.zdns-testing.com",
                             "type": "MX",
                             "class": "IN",
                             "preference": 5,
-                            "ipv4_addresses": ["5.6.7.8"],
+                            "ipv4_addresses": [
+                                "5.6.7.8"
+                            ],
                         },
                         {
                             "name": "mx1.censys.io",
                             "type": "MX",
                             "class": "IN",
                             "preference": 10,
-                        },
+                        }
                     ]
-                },
+                }
             }
-        },
+        }
     }
 
     MX_LOOKUP_ANSWER_IPV4 = copy.deepcopy(MX_LOOKUP_ANSWER)
-    del MX_LOOKUP_ANSWER_IPV4["results"]["MXLOOKUP"]["data"]["exchanges"][0][
-        "ipv6_addresses"
-    ]
+    del MX_LOOKUP_ANSWER_IPV4["results"]["MXLOOKUP"]["data"]["exchanges"][0]["ipv6_addresses"]
     MX_LOOKUP_ANSWER_IPV6 = copy.deepcopy(MX_LOOKUP_ANSWER)
-    del MX_LOOKUP_ANSWER_IPV6["results"]["MXLOOKUP"]["data"]["exchanges"][0][
-        "ipv4_addresses"
-    ]
-    del MX_LOOKUP_ANSWER_IPV6["results"]["MXLOOKUP"]["data"]["exchanges"][1][
-        "ipv4_addresses"
-    ]
+    del MX_LOOKUP_ANSWER_IPV6["results"]["MXLOOKUP"]["data"]["exchanges"][0]["ipv4_addresses"]
+    del MX_LOOKUP_ANSWER_IPV6["results"]["MXLOOKUP"]["data"]["exchanges"][1]["ipv4_addresses"]
 
     A_LOOKUP_WWW_ZDNS_TESTING = {
         "name": "www.zdns-testing.com",
@@ -217,15 +169,19 @@ class Tests(unittest.TestCase):
                 "class": "IN",
                 "status": "NOERROR",
                 "data": {
-                    "ipv4_addresses": ["1.2.3.4", "2.3.4.5", "3.4.5.6"],
+                    "ipv4_addresses": [
+                        "1.2.3.4",
+                        "2.3.4.5",
+                        "3.4.5.6"
+                    ],
                     "ipv6_addresses": [
                         "fde6:9bb3:dbd6::2",
                         "fd5a:3bce:8713::1",
-                        "fdb3:ac76:a577::3",
-                    ],
-                },
+                        "fdb3:ac76:a577::3"
+                    ]
+                }
             }
-        },
+        }
     }
 
     A_LOOKUP_WWW_ZDNS_TESTING_IPv6 = {
@@ -238,11 +194,11 @@ class Tests(unittest.TestCase):
                     "ipv6_addresses": [
                         "fde6:9bb3:dbd6::2",
                         "fd5a:3bce:8713::1",
-                        "fdb3:ac76:a577::3",
+                        "fdb3:ac76:a577::3"
                     ]
-                },
+                }
             }
-        },
+        }
     }
 
     A_LOOKUP_CNAME_CHAIN_03 = {
@@ -255,9 +211,9 @@ class Tests(unittest.TestCase):
                     "ipv4_addresses": [
                         "1.2.3.4",
                     ]
-                },
+                }
             }
-        },
+        }
     }
 
     A_LOOKUP_IPV4_WWW_ZDNS_TESTING = copy.deepcopy(A_LOOKUP_WWW_ZDNS_TESTING)
@@ -273,44 +229,56 @@ class Tests(unittest.TestCase):
                 "data": {
                     "servers": [
                         {
-                            "ipv4_addresses": ["216.239.34.108"],
-                            "ipv6_addresses": ["2001:4860:4802:34::6c"],
+                            "ipv4_addresses": [
+                                "216.239.34.108"
+                            ],
+                            "ipv6_addresses": [
+                                "2001:4860:4802:34::6c"
+                            ],
                             "name": "ns-cloud-c2.googledomains.com",
-                            "type": "NS",
+                            "type": "NS"
                         },
                         {
-                            "ipv4_addresses": ["216.239.32.108"],
-                            "ipv6_addresses": ["2001:4860:4802:32::6c"],
+                            "ipv4_addresses": [
+                                "216.239.32.108"
+                            ],
+                            "ipv6_addresses": [
+                                "2001:4860:4802:32::6c"
+                            ],
                             "name": "ns-cloud-c1.googledomains.com",
-                            "type": "NS",
+                            "type": "NS"
                         },
                         {
-                            "ipv4_addresses": ["216.239.38.108"],
-                            "ipv6_addresses": ["2001:4860:4802:38::6c"],
+                            "ipv4_addresses": [
+                                "216.239.38.108"
+                            ],
+                            "ipv6_addresses": [
+                                "2001:4860:4802:38::6c"
+                            ],
                             "name": "ns-cloud-c4.googledomains.com",
-                            "type": "NS",
+                            "type": "NS"
                         },
                         {
-                            "ipv4_addresses": ["216.239.36.108"],
-                            "ipv6_addresses": ["2001:4860:4802:36::6c"],
+                            "ipv4_addresses": [
+                                "216.239.36.108"
+                            ],
+                            "ipv6_addresses": [
+                                "2001:4860:4802:36::6c"
+                            ],
                             "name": "ns-cloud-c3.googledomains.com",
-                            "type": "NS",
-                        },
+                            "type": "NS"
+                        }
                     ]
-                },
+                }
             }
-        },
+        }
     }
 
     NS_LOOKUP_IPV4_WWW_ZDNS_TESTING = copy.deepcopy(NS_LOOKUP_WWW_ZDNS_TESTING)
-    for server in NS_LOOKUP_IPV4_WWW_ZDNS_TESTING["results"]["NSLOOKUP"]["data"][
-        "servers"
-    ]:
+    for server in NS_LOOKUP_IPV4_WWW_ZDNS_TESTING["results"]["NSLOOKUP"]["data"]["servers"]:
         del server["ipv6_addresses"]
     NS_LOOKUP_IPV6_WWW_ZDNS_TESTING = copy.deepcopy(NS_LOOKUP_WWW_ZDNS_TESTING)
-    for server in NS_LOOKUP_IPV6_WWW_ZDNS_TESTING["results"]["NSLOOKUP"]["data"][
-        "servers"
-    ]:
+    for server in NS_LOOKUP_IPV6_WWW_ZDNS_TESTING["results"]["NSLOOKUP"]["data"]["servers"]:
         del server["ipv4_addresses"]
 
     PTR_LOOKUP_GOOGLE_PUB = [
@@ -318,7 +286,7 @@ class Tests(unittest.TestCase):
             "type": "PTR",
             "class": "IN",
             "name": "8.8.8.8.in-addr.arpa",
-            "answer": "dns.google.",
+            "answer": "dns.google."
         }
     ]
 
@@ -329,7 +297,7 @@ class Tests(unittest.TestCase):
             "name": "zdns-testing.com",
             "tag": "issue",
             "value": "letsencrypt.org",
-            "flag": 0,
+            "flag": 0
         }
     ]
 
@@ -338,7 +306,7 @@ class Tests(unittest.TestCase):
             "type": "TXT",
             "class": "IN",
             "name": "test_txt.zdns-testing.com",
-            "answer": "Hello World!",
+            "answer": "Hello World!"
         }
     ]
 
@@ -361,9 +329,9 @@ class Tests(unittest.TestCase):
                 "recursion_available": False,
                 "authenticated": False,
                 "checking_disabled": False,
-                "error_code": 0,
-            },
-        },
+                "error_code": 0
+            }
+        }
     }
 
     TCP_LARGE_TXT_ANSWERS = [
@@ -371,85 +339,85 @@ class Tests(unittest.TestCase):
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "surveys, informed by our own experiences conducting a long-term research survey over the past year.",
+            "answer": "surveys, informed by our own experiences conducting a long-term research survey over the past year."
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "and explore the security implications of high speed Internet-scale network surveys, both offensive and defensive. ",
+            "answer": "and explore the security implications of high speed Internet-scale network surveys, both offensive and defensive. "
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "in under 45 minutes from user space on a single machine, approaching the theoretical maximum speed of gigabit Ethernet.",
+            "answer": "in under 45 minutes from user space on a single machine, approaching the theoretical maximum speed of gigabit Ethernet."
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "We introduce ZMap, a modular, open-source network scanner specifically architected to perform Internet-wide scans and capable of surveying the entire IPv4 address space",
+            "answer": "We introduce ZMap, a modular, open-source network scanner specifically architected to perform Internet-wide scans and capable of surveying the entire IPv4 address space"
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Internet-wide network scanning has numerous security applications, including exposing new vulnerabilities and tracking the adoption of defensive mechanisms, but probing the entire public address space with existing tools is both difficult and slow.",
+            "answer": "Internet-wide network scanning has numerous security applications, including exposing new vulnerabilities and tracking the adoption of defensive mechanisms, but probing the entire public address space with existing tools is both difficult and slow."
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "We also discuss best practices for good Internet citizenship when performing Internet-wide",
+            "answer": "We also discuss best practices for good Internet citizenship when performing Internet-wide"
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "We present the scanner architecture, experimentally characterize its performance and accuracy, ",
+            "answer": "We present the scanner architecture, experimentally characterize its performance and accuracy, "
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+            "answer": "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.",
+            "answer": "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo."
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            "answer": "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.",
+            "answer": "Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt."
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+            "answer": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
+            "answer": "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
         },
         {
             "type": "TXT",
             "class": "IN",
             "name": "large-text.zdns-testing.com",
-            "answer": "Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.",
+            "answer": "Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem."
         },
     ]
 
@@ -458,7 +426,7 @@ class Tests(unittest.TestCase):
             "type": "CNAME",
             "class": "IN",
             "name": "www.zdns-testing.com",
-            "answer": "zdns-testing.com.",
+            "answer": "zdns-testing.com."
         }
     ]
 
@@ -467,11 +435,23 @@ class Tests(unittest.TestCase):
             "type": "CNAME",
             "class": "IN",
             "name": "www.zdns-testing.com",
-            "answer": "zdns-testing.com.",
-        },
-        {"type": "A", "class": "IN", "name": "zdns-testing.com", "answer": "1.2.3.4"},
-        {"type": "A", "class": "IN", "name": "zdns-testing.com", "answer": "2.3.4.5"},
-        {"type": "A", "class": "IN", "name": "zdns-testing.com", "answer": "3.4.5.6"},
+            "answer": "zdns-testing.com."
+        }, {
+            "type": "A",
+            "class": "IN",
+            "name": "zdns-testing.com",
+            "answer": "1.2.3.4"
+        }, {
+            "type": "A",
+            "class": "IN",
+            "name": "zdns-testing.com",
+            "answer": "2.3.4.5"
+        }, {
+            "type": "A",
+            "class": "IN",
+            "name": "zdns-testing.com",
+            "answer": "3.4.5.6"
+        }
     ]
 
     WWW_CNAME_AND_AAAA_ANSWERS = [
@@ -479,26 +459,23 @@ class Tests(unittest.TestCase):
             "type": "CNAME",
             "class": "IN",
             "name": "www.zdns-testing.com",
-            "answer": "zdns-testing.com.",
-        },
-        {
+            "answer": "zdns-testing.com."
+        }, {
             "type": "AAAA",
             "class": "IN",
             "name": "zdns-testing.com",
-            "answer": "fd5a:3bce:8713::1",
-        },
-        {
+            "answer": "fd5a:3bce:8713::1"
+        }, {
             "type": "AAAA",
             "class": "IN",
             "name": "zdns-testing.com",
-            "answer": "fde6:9bb3:dbd6::2",
-        },
-        {
+            "answer": "fde6:9bb3:dbd6::2"
+        }, {
             "type": "AAAA",
             "class": "IN",
             "name": "zdns-testing.com",
-            "answer": "fdb3:ac76:a577::3",
-        },
+            "answer": "fdb3:ac76:a577::3"
+        }
     ]
 
     CNAME_LOOP_ANSWERS = [
@@ -507,13 +484,12 @@ class Tests(unittest.TestCase):
             "class": "IN",
             "name": "cname-loop.zdns-testing.com",
             "answer": "cname-loop.esrg.stanford.edu.",
-        },
-        {
+        }, {
             "type": "CNAME",
             "class": "IN",
             "name": "cname-loop.esrg.stanford.edu",
             "answer": "cname-loop.zdns-testing.com.",
-        },
+        }
     ]
 
     # an A record behind a DNAME record
@@ -529,20 +505,25 @@ class Tests(unittest.TestCase):
             "class": "IN",
             "name": "a.zdns-dname.esrg.stanford.edu",
             "answer": "a.zdns-testing.com.",
-        },
-        {
+        }, {
             "type": "A",
             "class": "IN",
             "name": "a.zdns-testing.com",
             "answer": "21.9.87.65",
-        },
+        }
     ]
 
     DMARC_ANSWER = {
-        "data": {"dmarc": "v=DMARC1; p=none; rua=mailto:postmaster@censys.io"}
+        "data": {
+            "dmarc": "v=DMARC1; p=none; rua=mailto:postmaster@censys.io"
+        }
     }
 
-    SPF_ANSWER = {"data": {"spf": "v=spf1 mx include:_spf.google.com -all"}}
+    SPF_ANSWER = {
+        "data": {
+            "spf": "v=spf1 mx include:_spf.google.com -all"
+        }
+    }
 
     SOA_ANSWERS = [
         {
@@ -555,7 +536,8 @@ class Tests(unittest.TestCase):
             "refresh": 21600,
             "retry": 3600,
             "expire": 259200,
-            "min_ttl": 300,
+            "min_ttl": 300
+
         }
     ]
 
@@ -567,7 +549,7 @@ class Tests(unittest.TestCase):
             "port": 5060,
             "priority": 10,
             "target": "sip-anycast-1.voice.google.com.",
-            "weight": 1,
+            "weight": 1
         },
         {
             "type": "SRV",
@@ -576,8 +558,8 @@ class Tests(unittest.TestCase):
             "port": 5060,
             "priority": 20,
             "target": "sip-anycast-2.voice.google.com.",
-            "weight": 1,
-        },
+            "weight": 1
+        }
     ]
 
     TLSA_ANSWERS = [
@@ -588,23 +570,22 @@ class Tests(unittest.TestCase):
             "cert_usage": 3,
             "selector": 1,
             "matching_type": 1,
-            "certificate": "2a8f1dbc25611cd32da057c5dde9c4d55db6dd9b386b402ede4b7507d93ede8d",
-        },
-        {
+            "certificate": "2a8f1dbc25611cd32da057c5dde9c4d55db6dd9b386b402ede4b7507d93ede8d"
+        }, {
             "type": "TLSA",
             "class": "IN",
             "name": "_25._tcp.mail.ietf.org",
             "cert_usage": 3,
             "selector": 1,
             "matching_type": 1,
-            "certificate": "b05d5a0b10095ab7d38710aa70b85c5227cfb9cae23c93ee2bf8fdbedfffdb39",
-        },
+            "certificate": "b05d5a0b10095ab7d38710aa70b85c5227cfb9cae23c93ee2bf8fdbedfffdb39"
+        }
     ]
 
     ECS_MAPPINGS = {
         "171.67.68.0/24": "2.3.4.5",
         "131.159.92.0/24": "3.4.5.6",
-        "129.127.149.0/24": "1.2.3.4",
+        "129.127.149.0/24": "1.2.3.4"
     }
 
     def assertSuccess(self, res, cmd, query_type):
@@ -619,14 +600,11 @@ class Tests(unittest.TestCase):
             del answer["ttl"]
         a = sorted(res["results"][query_type]["data"]["answers"], key=lambda x: x[key])
         b = sorted(correct, key=lambda x: x[key])
-        helptext = "%s\nExpected:\n%s\n\nActual:\n%s" % (
-            cmd,
-            json.dumps(b, indent=4),
-            json.dumps(a, indent=4),
-        )
+        helptext = "%s\nExpected:\n%s\n\nActual:\n%s" % (cmd,
+                                                         json.dumps(b, indent=4), json.dumps(a, indent=4))
 
         def _lowercase(obj):
-            """Make dictionary lowercase"""
+            """ Make dictionary lowercase """
             if isinstance(obj, dict):
                 for k, v in obj.items():
                     if k == "name":
@@ -644,16 +622,11 @@ class Tests(unittest.TestCase):
 
     def assertEqualMXLookup(self, res, correct):
         self.assertEqual(res["name"], correct["name"])
-        self.assertEqual(
-            res["results"]["MXLOOKUP"]["status"],
-            correct["results"]["MXLOOKUP"]["status"],
-        )
+        self.assertEqual(res["results"]["MXLOOKUP"]["status"], correct["results"]["MXLOOKUP"]["status"])
         for exchange in res["results"]["MXLOOKUP"]["data"]["exchanges"]:
             del exchange["ttl"]
-        self.assertEqual(
-            recursiveSort(res["results"]["MXLOOKUP"]["data"]["exchanges"]),
-            recursiveSort(correct["results"]["MXLOOKUP"]["data"]["exchanges"]),
-        )
+        self.assertEqual(recursiveSort(res["results"]["MXLOOKUP"]["data"]["exchanges"]),
+                         recursiveSort(correct["results"]["MXLOOKUP"]["data"]["exchanges"]))
 
     def assertEqualALookup(self, res, correct, query_type):
         self.assertEqual(res["name"], correct["name"])
@@ -662,33 +635,22 @@ class Tests(unittest.TestCase):
         self.assertEqual(res["status"], correct_A_lookup["status"])
         if "ipv4_addresses" in correct_A_lookup["data"]:
             self.assertIn("ipv4_addresses", res["data"])
-            self.assertEqual(
-                sorted(res["data"]["ipv4_addresses"]),
-                sorted(correct_A_lookup["data"]["ipv4_addresses"]),
-            )
+            self.assertEqual(sorted(res["data"]["ipv4_addresses"]), sorted(correct_A_lookup["data"]["ipv4_addresses"]))
         else:
             self.assertNotIn("ipv4_addresses", res["data"])
         if "ipv6_addresses" in correct_A_lookup["data"]:
             self.assertIn("ipv6_addresses", res["data"])
-            self.assertEqual(
-                sorted(res["data"]["ipv6_addresses"]),
-                sorted(correct_A_lookup["data"]["ipv6_addresses"]),
-            )
+            self.assertEqual(sorted(res["data"]["ipv6_addresses"]), sorted(correct_A_lookup["data"]["ipv6_addresses"]))
         else:
             self.assertNotIn("ipv6_addresses", res["data"])
 
     def assertEqualNSLookup(self, res, correct):
         self.assertEqual(res["name"], correct["name"])
-        self.assertEqual(
-            res["results"]["NSLOOKUP"]["status"],
-            correct["results"]["NSLOOKUP"]["status"],
-        )
+        self.assertEqual(res["results"]["NSLOOKUP"]["status"], correct["results"]["NSLOOKUP"]["status"])
         for server in res["results"]["NSLOOKUP"]["data"]["servers"]:
             del server["ttl"]
-        self.assertEqual(
-            recursiveSort(res["results"]["NSLOOKUP"]["data"]["servers"]),
-            recursiveSort(correct["results"]["NSLOOKUP"]["data"]["servers"]),
-        )
+        self.assertEqual(recursiveSort(res["results"]["NSLOOKUP"]["data"]["servers"]),
+                         recursiveSort(correct["results"]["NSLOOKUP"]["data"]["servers"]))
 
     def assertEqualTypes(self, res, list):
         res_types = set()
@@ -752,13 +714,9 @@ class Tests(unittest.TestCase):
         self.assertSuccess(res[1], cmd, "A")
         if res[0]["name"] == "zdns-testing.com":
             self.assertEqualAnswers(res[0], self.ROOT_A_ANSWERS, cmd, "A")
-            self.assertEqualAnswers(
-                res[1], self.ROOT_A_A_ZDNS_TESTING_COM_ANSWERS, cmd, "A"
-            )
+            self.assertEqualAnswers(res[1], self.ROOT_A_A_ZDNS_TESTING_COM_ANSWERS, cmd, "A")
         else:
-            self.assertEqualAnswers(
-                res[0], self.ROOT_A_A_ZDNS_TESTING_COM_ANSWERS, cmd, "A"
-            )
+            self.assertEqualAnswers(res[0], self.ROOT_A_A_ZDNS_TESTING_COM_ANSWERS, cmd, "A")
             self.assertEqualAnswers(res[1], self.ROOT_A_ANSWERS, cmd, "A")
 
     def test_multiple_modules(self):
@@ -808,13 +766,9 @@ class Tests(unittest.TestCase):
                 elif r["name"] == "zdns-testing.com" and query_type == "AAAA":
                     self.assertEqualAnswers(r, self.ROOT_AAAA_ANSWERS, cmd, "AAAA")
                 elif r["name"] == "mx1.zdns-testing.com" and query_type == "A":
-                    self.assertEqualAnswers(
-                        r, self.A_MX1_ZDNS_TESTING_COM_ANSWERS, cmd, "A"
-                    )
+                    self.assertEqualAnswers(r, self.A_MX1_ZDNS_TESTING_COM_ANSWERS, cmd, "A")
                 elif r["name"] == "mx1.zdns-testing.com" and query_type == "AAAA":
-                    self.assertEqualAnswers(
-                        r, self.AAAA_MX1_ZDNS_TESTING_COM_ANSWERS, cmd, "AAAA"
-                    )
+                    self.assertEqualAnswers(r, self.AAAA_MX1_ZDNS_TESTING_COM_ANSWERS, cmd, "AAAA")
                 else:
                     self.fail("Unexpected response")
         # delete file
@@ -1067,6 +1021,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(usedCloudflare)
         self.assertTrue(usedGoogle)
 
+
     def test_name_server_mode_with_doh(self):
         c = "A dns.google cloudflare-dns.com --override-name=www.zdns-testing.com --name-server-mode --https --threads=1"
         name = ""
@@ -1187,10 +1142,8 @@ class Tests(unittest.TestCase):
         self.assertSuccess(res, cmd, "AXFR")
         f = open("testing/axfr.json")
         axfr_answer = json.load(f)
-        self.assertEqualAxfrLookup(
-            res["results"]["AXFR"]["data"]["servers"][0]["records"],
-            axfr_answer["data"]["servers"][0]["records"],
-        )
+        self.assertEqualAxfrLookup(res["results"]["AXFR"]["data"]["servers"][0]["records"],
+                                   axfr_answer["data"]["servers"][0]["records"])
         f.close()
 
     def test_soa(self):
@@ -1225,18 +1178,14 @@ class Tests(unittest.TestCase):
         c = "TXT --tcp-only --name-servers=8.8.8.8:53"  # Azure DNS does not provide results.
         name = "large-text.zdns-testing.com"
         cmd, res = self.run_zdns(c, name)
-        self.assertEqualAnswers(
-            res, self.TCP_LARGE_TXT_ANSWERS, cmd, "TXT", key="answer"
-        )
+        self.assertEqualAnswers(res, self.TCP_LARGE_TXT_ANSWERS, cmd, "TXT", key="answer")
 
     def test_too_big_txt_all(self):
         c = "TXT --name-servers=8.8.8.8:53"
         name = "large-text.zdns-testing.com"
         cmd, res = self.run_zdns(c, name)
         self.assertEqual(res["results"]["TXT"]["data"]["protocol"], "tcp")
-        self.assertEqualAnswers(
-            res, self.TCP_LARGE_TXT_ANSWERS, cmd, "TXT", key="answer"
-        )
+        self.assertEqualAnswers(res, self.TCP_LARGE_TXT_ANSWERS, cmd, "TXT", key="answer")
 
     def test_override_name(self):
         c = "A --override-name=zdns-testing.com"
@@ -1261,9 +1210,7 @@ class Tests(unittest.TestCase):
     def test_local_addr_interface_warning(self):
         c = "A --local-addr 192.168.1.5 --local-interface en0"
         name = "zdns-testing.com"
-        self.run_zdns_check_failure(
-            c, name, "--local-addr and --local-interface cannot both be specified"
-        )
+        self.run_zdns_check_failure(c, name, "--local-addr and --local-interface cannot both be specified")
 
     def test_edns0_client_subnet(self):
         name = "ecs-geo.zdns-testing.com"
@@ -1276,22 +1223,11 @@ class Tests(unittest.TestCase):
             family = 1 if ip_address(address).version == 4 else 2
             original_res = res
             res = res["results"]["A"]
-            self.assertEqual(
-                address, res["data"]["additionals"][0]["csubnet"]["address"]
-            )
-            self.assertEqual(
-                int(netmask), res["data"]["additionals"][0]["csubnet"]["source_netmask"]
-            )
-            self.assertEqual(family, res["data"]["additionals"][0]["csubnet"]["family"])
-            self.assertTrue("source_scope" in res["data"]["additionals"][0]["csubnet"])
-            correct = [
-                {
-                    "type": "A",
-                    "class": "IN",
-                    "answer": ip_addr,
-                    "name": "ecs-geo.zdns-testing.com",
-                }
-            ]
+            self.assertEqual(address, res["data"]['additionals'][0]['csubnet']['address'])
+            self.assertEqual(int(netmask), res["data"]['additionals'][0]['csubnet']["source_netmask"])
+            self.assertEqual(family, res["data"]['additionals'][0]['csubnet']['family'])
+            self.assertTrue("source_scope" in res["data"]['additionals'][0]['csubnet'])
+            correct = [{"type": "A", "class": "IN", "answer": ip_addr, "name": "ecs-geo.zdns-testing.com"}]
             self.assertEqualAnswers(original_res, correct, cmd, "A")
 
     def test_edns0_nsid(self):
@@ -1301,24 +1237,20 @@ class Tests(unittest.TestCase):
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd, "A")
         res = res["results"]["A"]
-        self.assertTrue("nsid" in res["data"]["additionals"][0])
-        self.assertTrue(
-            res["data"]["additionals"][0]["nsid"]["nsid"].startswith("gpdns-")
-        )
+        self.assertTrue("nsid" in res["data"]['additionals'][0])
+        self.assertTrue(res["data"]['additionals'][0]['nsid']['nsid'].startswith("gpdns-"))
 
     def test_edns0_ede_1(self):
         name = "dnssec.fail"
         # using Cloudflare Public DNS (1.1.1.1) that implements EDE
         c = f"A --name-servers=1.1.1.1:53"
         cmd, res = self.run_zdns(c, name)
-        self.assertServFail(res, cmd, "A")
+        self.assertServFail(res, cmd, 'A')
         res = res["results"]["A"]
-        self.assertTrue("ede" in res["data"]["additionals"][0])
-        ede_obj = res["data"]["additionals"][0]["ede"][0]
+        self.assertTrue("ede" in res["data"]['additionals'][0])
+        ede_obj = res["data"]['additionals'][0]["ede"][0]
         self.assertEqual("DNSKEY Missing", ede_obj["error_text"])
-        self.assertEqual(
-            "no SEP matching the DS found for dnssec.fail.", ede_obj["extra_text"]
-        )
+        self.assertEqual("no SEP matching the DS found for dnssec.fail.", ede_obj["extra_text"])
         self.assertEqual(9, ede_obj["info_code"])
 
     def test_edns0_ede_2_cd(self):
@@ -1328,12 +1260,10 @@ class Tests(unittest.TestCase):
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd, "A")
         res = res["results"]["A"]
-        self.assertTrue("ede" in res["data"]["additionals"][0])
-        ede_obj = res["data"]["additionals"][0]["ede"][0]
+        self.assertTrue("ede" in res["data"]['additionals'][0])
+        ede_obj = res["data"]['additionals'][0]["ede"][0]
         self.assertEqual("DNSKEY Missing", ede_obj["error_text"])
-        self.assertEqual(
-            "no SEP matching the DS found for dnssec.fail.", ede_obj["extra_text"]
-        )
+        self.assertEqual("no SEP matching the DS found for dnssec.fail.", ede_obj["extra_text"])
         self.assertEqual(9, ede_obj["info_code"])
 
     def test_dnssec_response(self):
@@ -1343,57 +1273,8 @@ class Tests(unittest.TestCase):
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd, "SOA")
         res = res["results"]["SOA"]
-        self.assertEqual("do", res["data"]["additionals"][0]["flags"])
+        self.assertEqual('do', res["data"]['additionals'][0]['flags'])
         self.assertEqualTypes(res, ["SOA", "RRSIG"])
-
-    def test_dnssec_validation_secure(self):
-        # checks if dnssec validation is performed
-        DOMAINS = [
-            "cloudflare.com",
-            "internetsociety.org",
-            "dnssec-tools.org",
-            "dnssec-deployment.org",
-        ]
-        for domain in DOMAINS:
-            c = f"A {domain} --iterative --validate-dnssec --result-verbosity=long"
-            name = "."
-            cmd, res = self.run_zdns(c, name)
-            self.assertSuccess(res, cmd, "A")
-            dnssec = res["results"]["A"]["data"]["dnssec"]
-            self.assertEqual(dnssec["status"], "Secure")
-            self.assertTrue(len(dnssec["ds"]) > 0)
-            self.assertTrue(len(dnssec["dnskey"]) > 0)
-
-    def test_dnssec_validation_secure_circular(self):
-        # checks if dnssec validation can handle circular NS dependencies
-        c = "A example.com --iterative --validate-dnssec --result-verbosity=long"
-        name = "."
-        cmd, res = self.run_zdns(c, name)
-        self.assertSuccess(res, cmd, "A")
-        dnssec = res["results"]["A"]["data"]["dnssec"]
-        self.assertEqual(dnssec["status"], "Secure")
-
-    def test_dnssec_validation_insecure(self):
-        # checks if dnssec validation reports insecure (not signed) zones correctly
-        c = "A outlook.com --iterative --validate-dnssec --result-verbosity=long"
-        name = "."
-        cmd, res = self.run_zdns(c, name)
-        self.assertSuccess(res, cmd, "A")
-        dnssec = res["results"]["A"]["data"]["dnssec"]
-        self.assertEqual(dnssec["status"], "Insecure")
-        self.assertTrue(len(dnssec["ds"]) == 0)
-        self.assertTrue(len(dnssec["dnskey"]) == 0)
-
-    def test_dnssec_validation_bogus(self):
-        # checks if dnssec validation reports bogus zones correctly
-        DOMAINS = ["dnssec-failed.org", "rhybar.cz"]
-        for domain in DOMAINS:
-            c = f"A {domain} --iterative --validate-dnssec --result-verbosity=long"
-            name = "."
-            cmd, res = self.run_zdns(c, name)
-            self.assertSuccess(res, cmd, "A")
-            dnssec = res["results"]["A"]["data"]["dnssec"]
-            self.assertEqual(dnssec["status"], "Bogus")
 
     def test_cd_bit_not_set(self):
         c = "A --name-servers=8.8.8.8:53"
@@ -1415,9 +1296,7 @@ class Tests(unittest.TestCase):
         res = res["results"]["A"]
         assert "timestamp" in res
         date = datetime.datetime.strptime(res["timestamp"], "%Y-%m-%dT%H:%M:%S%z")
-        self.assertTrue(
-            date.microsecond == 0
-        )  # microseconds should be 0 since we didn't call with --nanoseconds
+        self.assertTrue(date.microsecond == 0)  # microseconds should be 0 since we didn't call with --nanoseconds
 
     def test_timetamps_nanoseconds(self):
         c = "A --nanoseconds"
@@ -1435,10 +1314,7 @@ class Tests(unittest.TestCase):
     # test_metadata_file test the `--metadata-file` flag which saves a summary of a scan's metadata output to a file
     def test_metadata_file(self):
         f_name = "temp-metadata.json"
-        c = (
-            "A google.com yahoo.com cloudflare.com zdns-testing.com --metadata-file="
-            + f_name
-        )
+        c = "A google.com yahoo.com cloudflare.com zdns-testing.com --metadata-file=" + f_name
         name = ""
         cmd, res = self.run_zdns_multiline_output(c, name)
         for r in res:
@@ -1469,12 +1345,8 @@ class Tests(unittest.TestCase):
         ini_file_name = "test_metadata_file_multiple_modules.ini"
         with open(ini_file_name, "w") as f:
             f.write(ini_file_contents)
-        c = (
-            "MULTIPLE -c "
-            + ini_file_name
-            + " google.com yahoo.com cloudflare.com zdns-testing.com --metadata-file="
-            + metadata_file_name
-        )
+        c = ("MULTIPLE -c " + ini_file_name + " google.com yahoo.com cloudflare.com zdns-testing.com --metadata-file="
+             + metadata_file_name)
         name = ""
         cmd, res = self.run_zdns_multiline_output(c, name)
         for r in res:
@@ -1504,6 +1376,7 @@ class Tests(unittest.TestCase):
         self.assertSuccess(res, cmd, "A")
         self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd, "A")
 
+
     def test_a_lookup_IP_name_server_with_input(self):
         c = "A"
         name = "zdns-testing.com,1.1.1.1"
@@ -1518,11 +1391,8 @@ class Tests(unittest.TestCase):
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd, "A")
         self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd, "A")
-        self.assertEqual(
-            res["results"]["A"]["data"]["resolver"],
-            "8.8.8.8:53",
-            "user-supplied name server with input " "should take precedence",
-        )
+        self.assertEqual(res["results"]["A"]["data"]["resolver"], "8.8.8.8:53", "user-supplied name server with input "
+                                                                                "should take precedence")
 
     def test_a_lookup_IP_name_server_with_input_flag_loopback_mismatch(self):
         c = "A --name-servers=127.0.0.1"
@@ -1530,11 +1400,8 @@ class Tests(unittest.TestCase):
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd, "A")
         self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd, "A")
-        self.assertEqual(
-            res["results"]["A"]["data"]["resolver"],
-            "8.8.8.8:53",
-            "user-supplied name server with input " "should take precedence",
-        )
+        self.assertEqual(res["results"]["A"]["data"]["resolver"], "8.8.8.8:53", "user-supplied name server with input "
+                                                                                "should take precedence")
 
     def test_dnssec_option(self):
         c = "A --dnssec --name-servers=1.0.0.1"
@@ -1558,10 +1425,9 @@ class Tests(unittest.TestCase):
         second_duration = res[1]["results"]["A"]["duration"]
         # a bit of a hacky test, but we're checking that if we query the same domain with the same nameserver,
         # the second query has a much smaller response time than the first to show it's being cached
-        self.assertTrue(
-            first_duration / 50 > second_duration,
-            f"Second query {second_duration} should be faster than the first {first_duration}",
-        )
+        self.assertTrue(first_duration / 50 > second_duration, f"Second query {second_duration} should be faster than the first {first_duration}")
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
resolves #441

# Purpose
Adds support for validating DNSSEC records up to the root's chain-of-trust

The level of detail in the validation results depends on the `--result-verbosity=` flag. In the `short` mode, validation results are not output (equivalent to no validation). In the `normal` mode, only the overall validation status is output. In the `long` mode, all relevant records used for validating this specific result (DS, DNSKEY, RRSIG) and the validation results for each individual RRset are printed. In the `trace` mode, all validation details for the entire query chain are available along the trace.

Since we are a DNS scanning tool, the resolution results may still hold value even in cases of DNSSEC validation failure. Therefore, a validation failure does not lead to a resolution failure - i.e., the resolution results will still be output normally. It is the responsibility of data consumers to check the DNSSEC validation status before using the results.

Example usage:
```shell
go run . A example.com --iterative --validate-dnssec --result-verbosity=long
```

Example output (long):
```json
{
    "class": "IN",
    "name": "example.com",
    "results": {
        "A": {
            "data": {
                "answers": [
                    {
                        "answer": "93.184.215.14",
                        "class": "IN",
                        "name": "example.com",
                        "ttl": 3600,
                        "type": "A"
                    },
                    {
                        "algorithm": 13,
                        "class": "IN",
                        "expiration": "20241206041826",
                        "inception": "20241115121713",
                        "keytag": 60915,
                        "labels": 2,
                        "name": "example.com",
                        "original_ttl": 3600,
                        "signature": "vRP5fmIUOIHdIXJsnFkSLYL84OEh4isvOeIkPdGR1Ro+YUs4tTNO6J3ajnDvcIZfc5p+j8R35Z/SOOqD9ZY95w==",
                        "signer_name": "example.com.",
                        "ttl": 3600,
                        "type": "RRSIG",
                        "type_covered": 1
                    }
                ],
                "dnssec": {
                    "additionals": [
                        {
                            "error": "",
                            "rrset": {
                                "class": 4096,
                                "name": ".",
                                "type": 41
                            },
                            "sig": null,
                            "status": "Insecure"
                        }
                    ],
                    "answer": [
                        {
                            "error": "",
                            "rrset": {
                                "class": 1,
                                "name": "example.com.",
                                "type": 1
                            },
                            "sig": {
                                "algorithm": 13,
                                "class": "IN",
                                "expiration": "20241206041826",
                                "inception": "20241115121713",
                                "keytag": 60915,
                                "labels": 2,
                                "name": "example.com",
                                "original_ttl": 3600,
                                "signature": "vRP5fmIUOIHdIXJsnFkSLYL84OEh4isvOeIkPdGR1Ro+YUs4tTNO6J3ajnDvcIZfc5p+j8R35Z/SOOqD9ZY95w==",
                                "signer_name": "example.com.",
                                "ttl": 3600,
                                "type": "RRSIG",
                                "type_covered": 1
                            },
                            "status": "Secure"
                        }
                    ],
                    "authoritative": [
                        {
                            "error": "",
                            "rrset": {
                                "class": 1,
                                "name": "example.com.",
                                "type": 2
                            },
                            "sig": {
                                "algorithm": 13,
                                "class": "IN",
                                "expiration": "20241206020003",
                                "inception": "20241115121713",
                                "keytag": 60915,
                                "labels": 2,
                                "name": "example.com",
                                "original_ttl": 86400,
                                "signature": "9W8bAJT/4vA3nH8QU/NeM1n8bZZWn5PBkN26ix827VQGWY0YdMniks/1YCIaVNl16xly4s5IsVDtI9rLvaZORw==",
                                "signer_name": "example.com.",
                                "ttl": 86400,
                                "type": "RRSIG",
                                "type_covered": 2
                            },
                            "status": "Secure"
                        }
                    ],
                    "dnskey": [
                        {
                            "algorithm": 13,
                            "class": "IN",
                            "flags": 256,
                            "name": "example.com",
                            "protocol": 3,
                            "public_key": "ai2pvpijJjeNTpBu4yg6T375JqIStPtLABDTAILb+f4J7XpofUNXGQn6FpQvZ6CARWn2xQapbjGtDRjTf4qYxg==",
                            "ttl": 3600,
                            "type": "DNSKEY"
                        }
                    ],
                    "ds": [
                        {
                            "algorithm": 13,
                            "class": "IN",
                            "digest": "be74359954660069d5c63d200c39f5603827d7dd02b56f120ee9f3a86764247c",
                            "digest_type": 2,
                            "key_tag": 370,
                            "name": "example.com",
                            "ttl": 3600,
                            "type": "DS"
                        }
                    ],
                    "status": "Secure"
                },
                "flags": {
                    "authenticated": false,
                    "authoritative": true,
                    "checking_disabled": false,
                    "error_code": 0,
                    "opcode": 0,
                    "recursion_available": false,
                    "recursion_desired": false,
                    "response": true,
                    "truncated": false
                },
                "protocol": "udp",
            },
            "duration": 1.072630625,
            "status": "NOERROR",
        }
    }
}
```

Example output (normal):
```json
{
    "name": "example.com",
    "results": {
        "A": {
            "data": {
                "answers": [
                    {
                        "answer": "93.184.215.14",
                        "class": "IN",
                        "name": "example.com",
                        "ttl": 3600,
                        "type": "A"
                    },
                    {
                        "algorithm": 13,
                        "class": "IN",
                        "expiration": "20241206041826",
                        "inception": "20241115121713",
                        "keytag": 60915,
                        "labels": 2,
                        "name": "example.com",
                        "original_ttl": 3600,
                        "signature": "vRP5fmIUOIHdIXJsnFkSLYL84OEh4isvOeIkPdGR1Ro+YUs4tTNO6J3ajnDvcIZfc5p+j8R35Z/SOOqD9ZY95w==",
                        "signer_name": "example.com.",
                        "ttl": 3600,
                        "type": "RRSIG",
                        "type_covered": 1
                    }
                ],
                "dnssec": {
                    "status": "Secure"
                },
                "protocol": "udp"
            },
            "duration": 0.803631958,
            "status": "NOERROR"
        }
    }
}
```

- [x] Implement error status handling according to [RFC 4035, Section 4.3](https://www.rfc-editor.org/rfc/rfc4035.html)
- [x] Ensure proper handling of non-secure cases
- [x] Share retries 
- [x] Address all linter issues
- [x] Limit DNSSEC to iterative mode only?
- [x] CLI option
