### PR TITLE
Avoid double-marshal'ing strings (uint byte arrays)

### DIFF
--- a/src/cli/util.go
+++ b/src/cli/util.go
@@ -140,7 +140,10 @@ func marshalIntSlice(v interface{}) ([]byte, error) {
 			case uint8:
 				converted := make([]byte, len(v))
 				for i, val := range v {
-					converted[i] = val.(byte)
+					converted[i], ok = val.(byte)
+				}
+				if !ok {
+					return nil, errors.New("failed to convert interface to byte (uint8)")
 				}
 				return converted, nil
 			case uint16:

--- a/src/cli/util.go
+++ b/src/cli/util.go
@@ -71,7 +71,7 @@ func marshalIntSlice(v interface{}) ([]byte, error) {
 	case []uint:
 		return json.Marshal(v)
 	case []uint8:
-		return json.Marshal(v)
+		return v, nil
 	case []uint16:
 		return json.Marshal(v)
 	case []uint32:
@@ -138,14 +138,11 @@ func marshalIntSlice(v interface{}) ([]byte, error) {
 				}
 				return json.Marshal(converted)
 			case uint8:
-				converted := make([]uint8, len(v))
+				converted := make([]byte, len(v))
 				for i, val := range v {
-					converted[i], ok = val.(uint8)
-					if !ok {
-						return nil, errors.New("failed to convert interface to uint8")
-					}
+					converted[i] = val.(byte)
 				}
-				return json.Marshal(converted)
+				return converted, nil
 			case uint16:
 				converted := make([]uint16, len(v))
 				for i, val := range v {

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -684,7 +684,9 @@ func handleWorkerInput(gc *CLIConf, rc *zdns.ResolverConfig, line string, resolv
 		if err != nil {
 			log.Fatalf("unable to marshal result to JSON: %v", err)
 		}
+		//log.Warn("Data: ", data)
 		cleansedData := replaceIntSliceInterface(data)
+		//log.Warn("Data: ", cleansedData)
 		jsonRes, err := json.Marshal(cleansedData)
 		if err != nil {
 			log.Fatalf("unable to marshal JSON result: %v", err)

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -684,9 +684,7 @@ func handleWorkerInput(gc *CLIConf, rc *zdns.ResolverConfig, line string, resolv
 		if err != nil {
 			log.Fatalf("unable to marshal result to JSON: %v", err)
 		}
-		//log.Warn("Data: ", data)
 		cleansedData := replaceIntSliceInterface(data)
-		//log.Warn("Data: ", cleansedData)
 		jsonRes, err := json.Marshal(cleansedData)
 		if err != nil {
 			log.Fatalf("unable to marshal JSON result: %v", err)


### PR DESCRIPTION
Closes #463 
Since strings are represented as `uint8` arrays, we were double-marshal'ing the string here. This caused the bug seen where when you decoded the base-64 encoded string, you got another base-64 encoded string in quotes.

## Testing
```
$ echo defo.ie | ./zdns HTTPS --name-servers 8.8.8.8                                                                                         

{"name":"defo.ie","results":{"HTTPS":{"data":{"additionals":[{"flags":"","type":"EDNS0","udpsize":512,"version":0}],"answers":[{"class":"IN","name":"defo.ie","priority":1,"svcparams":{"ech":"AED+DQA8awAgACD/2gZ+zTEEWYcDbLHxYEmDqk8SJPcAu2p3EOCdkPQMdAAEAAEAAQANY292ZXIuZGVmby5pZQAA","ipv4hint":["213.108.108.101"],"ipv6hint":["2a00:c6c0:0:116:5::10"]},"target":".","ttl":1800,"type":"HTTPS"}],"protocol":"udp","resolver":"8.8.8.8:53"},"duration":0.297062125,"status":"NOERROR","timestamp":"2024-11-01T13:13:11-04:00"}}}

$ echo "AED+DQA8awAgACD/2gZ+zTEEWYcDbLHxYEmDqk8SJPcAu2p3EOCdkPQMdAAEAAEAAQANY292ZXIuZGVmby5pZQAA" | base64 -d
<k  ��~�1Y�l��`I��O$��jw����
cover.defo.ie%   
```

### This also fixes where we were base-64 encoding many strings when printing the TLS handshake

```
~/zdns on  main! ⌚ 13:25:38
$ echo "cloudflare.com" | ./zdns A --threads=2 --https --verify-server-cert --root-cas-file="/Users/phillip/Desktop/macos-root-certs.pem"  | grep -o -E '.{0,5}:\"I.{0,5}' | wc -l
      80 # 80 strings were doubly base-64 encoded

~/zdns on  phillip/463-double-encode-bug! ⌚ 13:25:50
$ echo "cloudflare.com" | ./zdns A --threads=2 --https --verify-server-cert --root-cas-file="/Users/phillip/Desktop/macos-root-certs.pem"  | grep -o -E '.{0,5}:\"I.{0,5}' | wc -l
       2


$ echo "cloudflare.com" | ./zdns A --threads=2 --https --verify-server-cert --root-cas-file="/Users/phillip/Desktop/macos-root-certs.pem"  | grep -o -E '.{0,5}:\"I.{0,5}'
lass":"IN","n
lass":"IN","n
```