### PR TITLE
patch: fix TLSA test

### DIFF
--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -570,14 +570,6 @@ class Tests(unittest.TestCase):
             "cert_usage": 3,
             "selector": 1,
             "matching_type": 1,
-            "certificate": "2a8f1dbc25611cd32da057c5dde9c4d55db6dd9b386b402ede4b7507d93ede8d"
-        }, {
-            "type": "TLSA",
-            "class": "IN",
-            "name": "_25._tcp.mail.ietf.org",
-            "cert_usage": 3,
-            "selector": 1,
-            "matching_type": 1,
             "certificate": "b05d5a0b10095ab7d38710aa70b85c5227cfb9cae23c93ee2bf8fdbedfffdb39"
         }
     ]


### PR DESCRIPTION
It appears that the IETF has removed one of its TLSA records.
