### PR TITLE
Silence ZDNS status updates with `make benchmark`

### DIFF
--- a/benchmark/main.go
+++ b/benchmark/main.go
@@ -93,7 +93,7 @@ func main() {
 		log.Panicf("failed to set ZDNS_PPROF environment variable: %v", err)
 	}
 
-	cmd := exec.Command("../zdns", "A", "--iterative", "--verbosity=3", "--threads=100")
+	cmd := exec.Command("../zdns", "A", "--iterative", "--verbosity=3", "--threads=100", "--status-updates-file", "/dev/null")
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {


### PR DESCRIPTION
After adding the per-second logs to ZDNS, the benchmark doesn't print cleanly. This is a simple fix for that.

Before change:
```
$ make benchmark
go generate ./...
go build -o zdns
cd ./benchmark && go run main.go stats.go
Benchmarking ZDNS, Resolving 7000 domains...   5% |█                        | (369/7000, 370 it/s) [0s:17s]
StdErr: 00h:00m:01s; 393 names scanned; 392.79 names/sec; 99.7% success rate; NOERROR: 391, NXDOMAIN: 1, REFUSED: 1
Benchmarking ZDNS, Resolving 7000 domains...  11% |██                       | (832/7000, 429 it/s) [1s:14s]
StdErr: 00h:00m:02s; 851 names scanned; 425.49 names/sec; 99.6% success rate; NOERROR: 844, NXDOMAIN: 4, REFUSED: 3
Benchmarking ZDNS, Resolving 7000 domains...  17% |████                    | (1241/7000, 434 it/s) [2s:13s]
StdErr: 00h:00m:03s; 1255 names scanned; 418.32 names/sec; 99.6% success rate; NOERROR: 1243, NXDOMAIN: 7, REFUSED: 5
Benchmarking ZDNS, Resolving 7000 domains...  21% |█████                   | (1506/7000, 418 it/s) [3s:13s]^Csignal: interrupt
make: *** [makefile:39: benchmark] Interrupt
```

After change:
```
$ make benchmark
go generate ./...
go build -o zdns
cd ./benchmark && go run main.go stats.go
Benchmarking ZDNS, Resolving 7000 domains...  17% |████                    | (1223/7000, 443 it/s) [2s:13s]^Csignal: interrupt
make: *** [makefile:39: benchmark] Interrupt
```