### PR TITLE
Add a proper `--all-nameservers` implementation 

### DIFF
--- a/examples/all_nameservers_lookup/main.go
+++ b/examples/all_nameservers_lookup/main.go
@@ -1,1 +1,63 @@
-package all_nameservers_lookup
+/* ZDNS Copyright 2024 Regents of the University of Michigan
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy
+* of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+* implied. See the License for the specific language governing
+* permissions and limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"net"
+
+	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/zmap/zdns/examples/utils"
+	"github.com/zmap/zdns/src/zdns"
+)
+
+func main() {
+	// Perform the lookup
+	domain := "google.com"
+	dnsQuestion := &zdns.Question{Name: domain, Type: dns.TypeA, Class: dns.ClassINET}
+	resolver := initializeResolver()
+
+	log.Warn("\n\n This lookup just used the Cloudflare recursive resolver, let's run our own recursion.")
+	// Iterative Lookups start at the root nameservers and follow the chain of referrals to the authoritative nameservers.
+	result, _, status, err := resolver.LookupAllNameservers(context.Background(), dnsQuestion, 2)
+	if err != nil {
+		log.Fatal("Error looking up domain: ", err)
+	}
+	log.Warnf("Result: %v", result)
+	log.Warnf("Status: %v", status)
+	resolver.Close()
+}
+
+func initializeResolver() *zdns.Resolver {
+	localAddr, err := utils.GetLocalIPByConnecting()
+	if err != nil {
+		log.Fatal("Error getting local IP: ", err)
+	}
+	// Create a ResolverConfig object
+	resolverConfig := zdns.NewResolverConfig()
+	// Set any desired options on the ResolverConfig object
+	resolverConfig.LogLevel = log.InfoLevel
+	resolverConfig.LocalAddrsV4 = []net.IP{localAddr}
+	resolverConfig.ExternalNameServersV4 = []zdns.NameServer{{IP: net.ParseIP("1.1.1.1"), Port: 53}}
+	resolverConfig.RootNameServersV4 = zdns.RootServersV4
+	resolverConfig.IPVersionMode = zdns.IPv4Only
+	// Create a new Resolver object with the ResolverConfig object, it will retain all settings set on the ResolverConfig object
+	resolver, err := zdns.InitResolver(resolverConfig)
+	if err != nil {
+		log.Fatal("Error initializing resolver: ", err)
+	}
+	return resolver
+}

--- a/examples/all_nameservers_lookup/main.go
+++ b/examples/all_nameservers_lookup/main.go
@@ -1,0 +1,1 @@
+package all_nameservers_lookup

--- a/examples/all_nameservers_lookup/main.go
+++ b/examples/all_nameservers_lookup/main.go
@@ -29,7 +29,7 @@ func main() {
 	domain := "google.com"
 	dnsQuestion := &zdns.Question{Name: domain, Type: dns.TypeA, Class: dns.ClassINET}
 	resolver := initializeResolver()
-	// Iterative Lookups start at the root nameservers and follow the chain of referrals to the authoritative nameservers.
+	// LookupAllNameserversIterative will query all root nameservers, and then all TLD nameservers, and then all authoritative nameservers for the domain.
 	result, _, status, err := resolver.LookupAllNameserversIterative(dnsQuestion, nil)
 	if err != nil {
 		log.Fatal("Error looking up domain: ", err)

--- a/examples/multi_thread_lookup/multi_threaded.go
+++ b/examples/multi_thread_lookup/multi_threaded.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"context"
 	"net"
 	"sync"
 
@@ -44,7 +45,7 @@ func main() {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		result1, _, _, err1 := resolver1.IterativeLookup(dnsQuestion1)
+		result1, _, _, err1 := resolver1.IterativeLookup(context.Background(), dnsQuestion1)
 		if err1 != nil {
 			log.Fatal("Error looking up domain: ", err1)
 		}
@@ -52,7 +53,7 @@ func main() {
 	}()
 	go func() {
 		defer wg.Done()
-		result2, _, _, err2 := resolver2.IterativeLookup(dnsQuestion2)
+		result2, _, _, err2 := resolver2.IterativeLookup(context.Background(), dnsQuestion2)
 		if err2 != nil {
 			log.Fatal("Error looking up domain: ", err2)
 		}

--- a/examples/single_lookup/simple.go
+++ b/examples/single_lookup/simple.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 
@@ -30,7 +31,7 @@ func main() {
 	dnsQuestion := &zdns.Question{Name: domain, Type: dns.TypeA, Class: dns.ClassINET}
 	resolver := initializeResolver()
 
-	result, _, status, err := resolver.ExternalLookup(dnsQuestion, []zdns.NameServer{{IP: net.ParseIP("1.1.1.1"), Port: 53}})
+	result, _, status, err := resolver.ExternalLookup(context.Background(), dnsQuestion, &zdns.NameServer{IP: net.ParseIP("1.1.1.1"), Port: 53})
 	if err != nil {
 		log.Fatal("Error looking up domain: ", err)
 	}
@@ -44,7 +45,7 @@ func main() {
 
 	log.Warn("\n\n This lookup just used the Cloudflare recursive resolver, let's run our own recursion.")
 	// Iterative Lookups start at the root nameservers and follow the chain of referrals to the authoritative nameservers.
-	result, trace, status, err := resolver.IterativeLookup(&zdns.Question{Name: domain, Type: dns.TypeA, Class: dns.ClassINET})
+	result, trace, status, err := resolver.IterativeLookup(context.Background(), &zdns.Question{Name: domain, Type: dns.TypeA, Class: dns.ClassINET})
 	if err != nil {
 		log.Fatal("Error looking up domain: ", err)
 	}

--- a/examples/single_lookup/simple.go
+++ b/examples/single_lookup/simple.go
@@ -30,7 +30,7 @@ func main() {
 	dnsQuestion := &zdns.Question{Name: domain, Type: dns.TypeA, Class: dns.ClassINET}
 	resolver := initializeResolver()
 
-	result, _, status, err := resolver.ExternalLookup(dnsQuestion, &zdns.NameServer{IP: net.ParseIP("1.1.1.1"), Port: 53})
+	result, _, status, err := resolver.ExternalLookup(dnsQuestion, []zdns.NameServer{{IP: net.ParseIP("1.1.1.1"), Port: 53}})
 	if err != nil {
 		log.Fatal("Error looking up domain: ", err)
 	}

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -44,14 +44,14 @@ type StatusHandler interface {
 // GeneralOptions core options for all ZDNS modules
 // Order here is the order they'll be printed to the user, so preserve alphabetical order
 type GeneralOptions struct {
-	LookupAllNameServers bool   `long:"all-nameservers" description:"Perform the lookup via all the nameservers for the domain."`
+	LookupAllNameServers bool   `long:"all-nameservers" description:"Behavior is dependent on --iterative. In --iterative, --all-name-servers will query all root servers, then all gtld servers, etc. recording the responses at each layer. In non-iterative mode, the query will be sent to all external resolvers specified in --name-servers."`
 	CacheSize            int    `long:"cache-size" default:"10000" description:"how many items can be stored in internal recursive cache"`
 	GoMaxProcs           int    `long:"go-processes" default:"0" description:"number of OS processes (GOMAXPROCS by default)"`
 	IterationTimeout     int    `long:"iteration-timeout" default:"8" description:"timeout for a single iterative step in an iterative query, in seconds. Only applicable with --iterative"`
 	IterativeResolution  bool   `long:"iterative" description:"Perform own iteration instead of relying on recursive resolver"`
 	MaxDepth             int    `long:"max-depth" default:"10" description:"how deep should we recurse when performing iterative lookups"`
 	NameServerMode       bool   `long:"name-server-mode" description:"Treats input as nameservers to query with a static query rather than queries to send to a static name server"`
-	NameServersString    string `long:"name-servers" description:"List of DNS servers to use. Can be passed as comma-delimited string or via @/path/to/file. If no port is specified, defaults to 53."`
+	NameServersString    string `long:"name-servers" description:"List of DNS servers to use. Can be passed as comma-delimited string or via @/path/to/file. If no port is specified, defaults to 53. If not provided, defaults to either the default root servers in --iterative or the recursive resolvers specified in /etc/resolv.conf or OS equivalent."`
 	UseNanoseconds       bool   `long:"nanoseconds" description:"Use nanosecond resolution timestamps in output"`
 	NetworkTimeout       int    `long:"network-timeout" default:"2" description:"timeout for round trip network operations, in seconds"`
 	DisableFollowCNAMEs  bool   `long:"no-follow-cnames" description:"do not follow CNAMEs/DNAMEs in the lookup process"`

--- a/src/cli/config_validation.go
+++ b/src/cli/config_validation.go
@@ -128,10 +128,6 @@ func validateClientSubnetString(gc *CLIConf) error {
 }
 
 func parseNameServers(gc *CLIConf) error {
-	if gc.LookupAllNameServers && gc.NameServersString != "" {
-		log.Fatal("name servers cannot be specified in --all-nameservers mode.")
-	}
-
 	if gc.NameServersString != "" {
 		if gc.NameServerMode {
 			log.Fatal("name servers cannot be specified on command line in --name-server-mode")

--- a/src/cli/modules.go
+++ b/src/cli/modules.go
@@ -167,7 +167,7 @@ func (lm *BasicLookupModule) NewFlags() interface{} {
 
 func (lm *BasicLookupModule) Lookup(resolver *zdns.Resolver, lookupName string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
 	if lm.LookupAllNameServers {
-		return resolver.LookupAllNameservers(&zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass}, nameServer)
+		return resolver.LookupAllNameservers(&zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass})
 	}
 	if lm.IsIterative {
 		return resolver.IterativeLookup(&zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass})

--- a/src/cli/modules.go
+++ b/src/cli/modules.go
@@ -14,6 +14,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/miekg/dns"
@@ -179,9 +180,9 @@ func (lm *BasicLookupModule) Lookup(resolver *zdns.Resolver, lookupName string, 
 		return resolver.LookupAllNameserversExternal(&zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass}, nil)
 	}
 	if lm.IsIterative {
-		return resolver.IterativeLookup(&zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass})
+		return resolver.IterativeLookup(context.Background(), &zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass})
 	}
-	return resolver.ExternalLookup(&zdns.Question{Type: lm.DNSType, Class: lm.DNSClass, Name: lookupName}, nameServer)
+	return resolver.ExternalLookup(context.Background(), &zdns.Question{Type: lm.DNSType, Class: lm.DNSClass, Name: lookupName}, nameServer)
 }
 
 func GetLookupModule(name string) (LookupModule, error) {

--- a/src/cli/modules.go
+++ b/src/cli/modules.go
@@ -165,9 +165,15 @@ func (lm *BasicLookupModule) NewFlags() interface{} {
 	return lm
 }
 
+// Lookup performs a DNS lookup using the given resolver and lookupName.
+// The behavior with respect to the nameServers is determined by the LookupAllNameServers and IsIterative fields.
+// non-Iterative + all-Nameservers query -> we'll send a query to each of the resolver's external nameservers
+// non-Iterative query -> we'll send a query to the nameserver provided. If none provided, a random nameserver from the resolver's external nameservers will be used
+// iterative + all-Nameservers query -> we'll send a query to each root NS and query all nameservers down the chain.
+// iterative query -> we'll send a query to a random root NS and query all nameservers down the chain.
 func (lm *BasicLookupModule) Lookup(resolver *zdns.Resolver, lookupName string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
 	if lm.LookupAllNameServers && lm.IsIterative {
-		return resolver.LookupAllNameserversIterative(&zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass})
+		return resolver.LookupAllNameserversIterative(&zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass}, nil)
 	}
 	if lm.LookupAllNameServers {
 		return resolver.LookupAllNameserversExternal(&zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass}, nil)

--- a/src/cli/modules.go
+++ b/src/cli/modules.go
@@ -166,8 +166,11 @@ func (lm *BasicLookupModule) NewFlags() interface{} {
 }
 
 func (lm *BasicLookupModule) Lookup(resolver *zdns.Resolver, lookupName string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
+	if lm.LookupAllNameServers && lm.IsIterative {
+		return resolver.LookupAllNameserversIterative(&zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass})
+	}
 	if lm.LookupAllNameServers {
-		return resolver.LookupAllNameservers(&zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass})
+		return resolver.LookupAllNameserversExternal(&zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass}, nil)
 	}
 	if lm.IsIterative {
 		return resolver.IterativeLookup(&zdns.Question{Name: lookupName, Type: lm.DNSType, Class: lm.DNSClass})

--- a/src/internal/util/util.go
+++ b/src/internal/util/util.go
@@ -57,9 +57,9 @@ func IsStringValidDomainName(domain string) bool {
 }
 
 // HasCtxExpired checks if the context has expired. Common function used in various places.
-func HasCtxExpired(ctx *context.Context) bool {
+func HasCtxExpired(ctx context.Context) bool {
 	select {
-	case <-(*ctx).Done():
+	case <-(ctx).Done():
 		return true
 	default:
 		return false

--- a/src/modules/alookup/a_lookup.go
+++ b/src/modules/alookup/a_lookup.go
@@ -34,6 +34,9 @@ func init() {
 
 // CLIInit initializes the ALookupModule with the given parameters, used to call ALOOKUP from the command line
 func (aMod *ALookupModule) CLIInit(gc *cli.CLIConf, resolverConfig *zdns.ResolverConfig) error {
+	if gc.LookupAllNameServers {
+		return errors.New("ALOOKUP module does not support --all-nameservers")
+	}
 	aMod.Init(aMod.IPv4Lookup, aMod.IPv6Lookup)
 	err := aMod.baseModule.CLIInit(gc, resolverConfig)
 	if err != nil {

--- a/src/modules/axfr/axfr.go
+++ b/src/modules/axfr/axfr.go
@@ -151,6 +151,9 @@ func (axfrMod *AxfrLookupModule) CLIInit(gc *cli.CLIConf, rc *zdns.ResolverConfi
 	if gc.IterativeResolution {
 		log.Fatal("AXFR module does not support iterative resolution")
 	}
+	if gc.LookupAllNameServers {
+		return errors.New("AXFR module does not support --all-nameservers")
+	}
 	var err error
 	if axfrMod.BlacklistPath != "" {
 		axfrMod.Blacklist = safeblacklist.New()

--- a/src/modules/bindversion/bindversion.go
+++ b/src/modules/bindversion/bindversion.go
@@ -16,6 +16,7 @@ package bindversion
 
 import (
 	"github.com/miekg/dns"
+	"github.com/pkg/errors"
 
 	"github.com/zmap/zdns/src/cli"
 	"github.com/zmap/zdns/src/zdns"
@@ -42,6 +43,9 @@ func init() {
 
 // CLIInit initializes the BindVersion lookup module
 func (bindVersionMod *BindVersionLookupModule) CLIInit(gc *cli.CLIConf, rc *zdns.ResolverConfig) error {
+	if gc.LookupAllNameServers {
+		return errors.New("AXFR module does not support --all-nameservers")
+	}
 	return bindVersionMod.BasicLookupModule.CLIInit(gc, rc)
 }
 

--- a/src/modules/bindversion/bindversion.go
+++ b/src/modules/bindversion/bindversion.go
@@ -15,6 +15,7 @@
 package bindversion
 
 import (
+	"context"
 	"github.com/miekg/dns"
 	"github.com/pkg/errors"
 
@@ -55,9 +56,9 @@ func (bindVersionMod *BindVersionLookupModule) Lookup(r *zdns.Resolver, lookupNa
 	var status zdns.Status
 	var err error
 	if bindVersionMod.IsIterative {
-		innerRes, trace, status, err = r.IterativeLookup(&zdns.Question{Name: BindVersionQueryName, Type: dns.TypeTXT, Class: dns.ClassCHAOS})
+		innerRes, trace, status, err = r.IterativeLookup(context.Background(), &zdns.Question{Name: BindVersionQueryName, Type: dns.TypeTXT, Class: dns.ClassCHAOS})
 	} else {
-		innerRes, trace, status, err = r.ExternalLookup(&zdns.Question{Name: BindVersionQueryName, Type: dns.TypeTXT, Class: dns.ClassCHAOS}, nameServer)
+		innerRes, trace, status, err = r.ExternalLookup(context.Background(), &zdns.Question{Name: BindVersionQueryName, Type: dns.TypeTXT, Class: dns.ClassCHAOS}, nameServer)
 	}
 	resString, resStatus, err := zdns.CheckTxtRecords(innerRes, status, nil, err)
 	res := Result{BindVersion: resString}

--- a/src/modules/bindversion/bindversion.go
+++ b/src/modules/bindversion/bindversion.go
@@ -16,6 +16,7 @@ package bindversion
 
 import (
 	"context"
+
 	"github.com/miekg/dns"
 	"github.com/pkg/errors"
 

--- a/src/modules/bindversion/bindversion_test.go
+++ b/src/modules/bindversion/bindversion_test.go
@@ -15,6 +15,7 @@
 package bindversion
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -35,7 +36,7 @@ var queries []QueryRecord
 // DoSingleDstServerLookup(r *Resolver, q Question, nameServer string, isIterative bool) (*SingleQueryResult, Trace, Status, error)
 type MockLookup struct{}
 
-func (ml MockLookup) DoDstServersLookup(r *zdns.Resolver, question zdns.Question, nameServers []zdns.NameServer, isIterative bool) (*zdns.SingleQueryResult, zdns.Trace, zdns.Status, error) {
+func (ml MockLookup) DoDstServersLookup(ctx context.Context, r *zdns.Resolver, question zdns.Question, nameServers []zdns.NameServer, isIterative bool) (*zdns.SingleQueryResult, zdns.Trace, zdns.Status, error) {
 	queries = append(queries, QueryRecord{q: question, NameServer: &nameServers[0]})
 	if res, ok := mockResults[question.Name]; ok {
 		return res, nil, zdns.StatusNoError, nil

--- a/src/modules/dmarc/dmarc.go
+++ b/src/modules/dmarc/dmarc.go
@@ -42,6 +42,9 @@ type DmarcLookupModule struct {
 
 // CLIInit initializes the DMARC lookup module
 func (dmarcMod *DmarcLookupModule) CLIInit(gc *cli.CLIConf, rc *zdns.ResolverConfig) error {
+	if gc.LookupAllNameServers {
+		return errors.New("DMARC module does not support --all-nameservers")
+	}
 	dmarcMod.re = regexp.MustCompile(dmarcPrefixRegexp)
 	dmarcMod.BasicLookupModule.DNSType = dns.TypeTXT
 	dmarcMod.BasicLookupModule.DNSClass = dns.ClassINET

--- a/src/modules/dmarc/dmarc_test.go
+++ b/src/modules/dmarc/dmarc_test.go
@@ -15,6 +15,7 @@
 package dmarc
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -35,7 +36,7 @@ var queries []QueryRecord
 
 type MockLookup struct{}
 
-func (ml MockLookup) DoDstServersLookup(r *zdns.Resolver, question zdns.Question, nameServers []zdns.NameServer, isIterative bool) (*zdns.SingleQueryResult, zdns.Trace, zdns.Status, error) {
+func (ml MockLookup) DoDstServersLookup(ctx context.Context, r *zdns.Resolver, question zdns.Question, nameServers []zdns.NameServer, isIterative bool) (*zdns.SingleQueryResult, zdns.Trace, zdns.Status, error) {
 	queries = append(queries, QueryRecord{question, &nameServers[0]})
 	if res, ok := mockResults[question.Name]; ok {
 		return res, nil, zdns.StatusNoError, nil

--- a/src/modules/mxlookup/mx_lookup.go
+++ b/src/modules/mxlookup/mx_lookup.go
@@ -56,6 +56,9 @@ type MXLookupModule struct {
 
 // CLIInit initializes the MXLookupModule with the given parameters, used to call MXLookup from the command line
 func (mxMod *MXLookupModule) CLIInit(gc *cli.CLIConf, rc *zdns.ResolverConfig) error {
+	if gc.LookupAllNameServers {
+		return errors.New("MXLOOKUP module does not support --all-nameservers")
+	}
 	if !mxMod.IPv4Lookup && !mxMod.IPv6Lookup {
 		// need to use one of the two
 		mxMod.IPv4Lookup = true

--- a/src/modules/mxlookup/mx_lookup.go
+++ b/src/modules/mxlookup/mx_lookup.go
@@ -14,6 +14,7 @@
 package mxlookup
 
 import (
+	"context"
 	"strings"
 
 	"github.com/miekg/dns"
@@ -95,9 +96,9 @@ func (mxMod *MXLookupModule) Lookup(r *zdns.Resolver, lookupName string, nameSer
 	var status zdns.Status
 	var err error
 	if mxMod.BasicLookupModule.IsIterative {
-		res, trace, status, err = r.IterativeLookup(&zdns.Question{Name: lookupName, Type: dns.TypeMX, Class: dns.ClassINET})
+		res, trace, status, err = r.IterativeLookup(context.Background(), &zdns.Question{Name: lookupName, Type: dns.TypeMX, Class: dns.ClassINET})
 	} else {
-		res, trace, status, err = r.ExternalLookup(&zdns.Question{Name: lookupName, Type: dns.TypeMX, Class: dns.ClassINET}, nameServer)
+		res, trace, status, err = r.ExternalLookup(context.Background(), &zdns.Question{Name: lookupName, Type: dns.TypeMX, Class: dns.ClassINET}, nameServer)
 	}
 	if status != zdns.StatusNoError || err != nil {
 		return nil, trace, status, err

--- a/src/modules/nslookup/ns_lookup.go
+++ b/src/modules/nslookup/ns_lookup.go
@@ -37,6 +37,9 @@ type NSLookupModule struct {
 
 // CLIInit initializes the NSLookupModule with the given parameters, used to call NSLookup from the command line
 func (nsMod *NSLookupModule) CLIInit(gc *cli.CLIConf, resolverConf *zdns.ResolverConfig) error {
+	if gc.LookupAllNameServers {
+		return errors.New("NSLOOKUP module does not support --all-nameservers")
+	}
 	if !nsMod.IPv4Lookup && !nsMod.IPv6Lookup {
 		log.Debug("NSModule: neither --ipv4-lookup nor --ipv6-lookup specified, will only request A records for each NS server")
 		nsMod.IPv4Lookup = true

--- a/src/modules/spf/spf.go
+++ b/src/modules/spf/spf.go
@@ -42,6 +42,9 @@ type SpfLookupModule struct {
 
 // CLIInit initializes the SPF lookup module
 func (spfMod *SpfLookupModule) CLIInit(gc *cli.CLIConf, rc *zdns.ResolverConfig) error {
+	if gc.LookupAllNameServers {
+		return errors.New("SPF module does not support --all-nameservers")
+	}
 	spfMod.re = regexp.MustCompile(spfPrefixRegexp)
 	spfMod.BasicLookupModule.DNSType = dns.TypeTXT
 	spfMod.BasicLookupModule.DNSClass = dns.ClassINET

--- a/src/modules/spf/spf_test.go
+++ b/src/modules/spf/spf_test.go
@@ -15,6 +15,7 @@
 package spf
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -35,7 +36,7 @@ var queries []QueryRecord
 
 type MockLookup struct{}
 
-func (ml MockLookup) DoDstServersLookup(r *zdns.Resolver, question zdns.Question, nameServers []zdns.NameServer, isIterative bool) (*zdns.SingleQueryResult, zdns.Trace, zdns.Status, error) {
+func (ml MockLookup) DoDstServersLookup(ctx context.Context, r *zdns.Resolver, question zdns.Question, nameServers []zdns.NameServer, isIterative bool) (*zdns.SingleQueryResult, zdns.Trace, zdns.Status, error) {
 	queries = append(queries, QueryRecord{question, &nameServers[0]})
 	if res, ok := mockResults[question.Name]; ok {
 		return res, nil, zdns.StatusNoError, nil

--- a/src/zdns/alookup.go
+++ b/src/zdns/alookup.go
@@ -24,7 +24,7 @@ import (
 	"github.com/zmap/zdns/src/internal/util"
 )
 
-// DoTargetedLookup performs a lookup of the given name name against the given nameserver, looking up both IPv4 and IPv6 addresses
+// DoTargetedLookup performs a lookup of the given name against the given nameserver, looking up both IPv4 and IPv6 addresses
 // Will follow CNAME records as well as A/AAAA records to get IP addresses
 func (r *Resolver) DoTargetedLookup(name string, nameServer *NameServer, isIterative, lookupA, lookupAAAA bool) (*IPResult, Trace, Status, error) {
 	name = strings.ToLower(name)

--- a/src/zdns/alookup.go
+++ b/src/zdns/alookup.go
@@ -14,6 +14,7 @@
 package zdns
 
 import (
+	"context"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -23,7 +24,7 @@ import (
 	"github.com/zmap/zdns/src/internal/util"
 )
 
-// DoTargetedLookup performs a lookup of the given domain name against the given nameserver, looking up both IPv4 and IPv6 addresses
+// DoTargetedLookup performs a lookup of the given name name against the given nameserver, looking up both IPv4 and IPv6 addresses
 // Will follow CNAME records as well as A/AAAA records to get IP addresses
 func (r *Resolver) DoTargetedLookup(name string, nameServer *NameServer, isIterative, lookupA, lookupAAAA bool) (*IPResult, Trace, Status, error) {
 	name = strings.ToLower(name)
@@ -38,9 +39,9 @@ func (r *Resolver) DoTargetedLookup(name string, nameServer *NameServer, isItera
 	var err error
 
 	if lookupA && isIterative {
-		singleQueryRes, ipv4Trace, ipv4status, err = r.IterativeLookup(&Question{Name: name, Type: dns.TypeA, Class: dns.ClassINET})
+		singleQueryRes, ipv4Trace, ipv4status, err = r.IterativeLookup(context.Background(), &Question{Name: name, Type: dns.TypeA, Class: dns.ClassINET})
 	} else if lookupA {
-		singleQueryRes, ipv4Trace, ipv4status, err = r.ExternalLookup(&Question{Name: name, Type: dns.TypeA, Class: dns.ClassINET}, nameServer)
+		singleQueryRes, ipv4Trace, ipv4status, err = r.ExternalLookup(context.Background(), &Question{Name: name, Type: dns.TypeA, Class: dns.ClassINET}, nameServer)
 	}
 	ipv4, _ = getIPAddressesFromQueryResult(singleQueryRes, "A", name)
 	if len(ipv4) > 0 {
@@ -50,9 +51,9 @@ func (r *Resolver) DoTargetedLookup(name string, nameServer *NameServer, isItera
 	}
 	singleQueryRes = &SingleQueryResult{} // reset result
 	if lookupAAAA && isIterative {
-		singleQueryRes, ipv6Trace, ipv6status, _ = r.IterativeLookup(&Question{Name: name, Type: dns.TypeAAAA, Class: dns.ClassINET})
+		singleQueryRes, ipv6Trace, ipv6status, _ = r.IterativeLookup(context.Background(), &Question{Name: name, Type: dns.TypeAAAA, Class: dns.ClassINET})
 	} else if lookupAAAA {
-		singleQueryRes, ipv6Trace, ipv6status, _ = r.ExternalLookup(&Question{Name: name, Type: dns.TypeAAAA, Class: dns.ClassINET}, nameServer)
+		singleQueryRes, ipv6Trace, ipv6status, _ = r.ExternalLookup(context.Background(), &Question{Name: name, Type: dns.TypeAAAA, Class: dns.ClassINET}, nameServer)
 	}
 	ipv6, _ = getIPAddressesFromQueryResult(singleQueryRes, "AAAA", name)
 	if len(ipv6) > 0 {

--- a/src/zdns/answers.go
+++ b/src/zdns/answers.go
@@ -202,7 +202,7 @@ type SMIMEAAnswer struct {
 
 type SOAAnswer struct {
 	Answer
-	Ns      string `json:"ns" groups:"short,normal,long,trace"`
+	Ns      string `json:"IP" groups:"short,normal,long,trace"`
 	Mbox    string `json:"mbox" groups:"short,normal,long,trace"`
 	Serial  uint32 `json:"serial" groups:"short,normal,long,trace"`
 	Refresh uint32 `json:"refresh" groups:"short,normal,long,trace"`

--- a/src/zdns/answers.go
+++ b/src/zdns/answers.go
@@ -202,7 +202,7 @@ type SMIMEAAnswer struct {
 
 type SOAAnswer struct {
 	Answer
-	Ns      string `json:"IP" groups:"short,normal,long,trace"`
+	Ns      string `json:"ns" groups:"short,normal,long,trace"`
 	Mbox    string `json:"mbox" groups:"short,normal,long,trace"`
 	Serial  uint32 `json:"serial" groups:"short,normal,long,trace"`
 	Refresh uint32 `json:"refresh" groups:"short,normal,long,trace"`

--- a/src/zdns/conf.go
+++ b/src/zdns/conf.go
@@ -52,35 +52,35 @@ const (
 )
 
 var RootServersV4 = []NameServer{
-	{IP: net.ParseIP("198.41.0.4"), Port: 53},     // A
-	{IP: net.ParseIP("170.247.170.2"), Port: 53},  // B - Changed several times, this is current as of July '24
-	{IP: net.ParseIP("192.33.4.12"), Port: 53},    // C
-	{IP: net.ParseIP("199.7.91.13"), Port: 53},    // D
-	{IP: net.ParseIP("192.203.230.10"), Port: 53}, // E
-	{IP: net.ParseIP("192.5.5.241"), Port: 53},    // F
-	{IP: net.ParseIP("192.112.36.4"), Port: 53},   // G
-	{IP: net.ParseIP("198.97.190.53"), Port: 53},  // H
-	{IP: net.ParseIP("192.36.148.17"), Port: 53},  // I
-	{IP: net.ParseIP("192.58.128.30"), Port: 53},  // J
-	{IP: net.ParseIP("193.0.14.129"), Port: 53},   // K
-	{IP: net.ParseIP("199.7.83.42"), Port: 53},    // L
-	{IP: net.ParseIP("202.12.27.33"), Port: 53},   // M
+	{IP: net.ParseIP("198.41.0.4"), Port: 53, DomainName: "a.root-servers.net"},     // A
+	{IP: net.ParseIP("170.247.170.2"), Port: 53, DomainName: "b.root-servers.net"},  // B - Changed several times, this is current as of July '24
+	{IP: net.ParseIP("192.33.4.12"), Port: 53, DomainName: "c.root-servers.net"},    // C
+	{IP: net.ParseIP("199.7.91.13"), Port: 53, DomainName: "d.root-servers.net"},    // D
+	{IP: net.ParseIP("192.203.230.10"), Port: 53, DomainName: "e.root-servers.net"}, // E
+	{IP: net.ParseIP("192.5.5.241"), Port: 53, DomainName: "f.root-servers.net"},    // F
+	{IP: net.ParseIP("192.112.36.4"), Port: 53, DomainName: "g.root-servers.net"},   // G
+	{IP: net.ParseIP("198.97.190.53"), Port: 53, DomainName: "h.root-servers.net"},  // H
+	{IP: net.ParseIP("192.36.148.17"), Port: 53, DomainName: "i.root-servers.net"},  // I
+	{IP: net.ParseIP("192.58.128.30"), Port: 53, DomainName: "j.root-servers.net"},  // J
+	{IP: net.ParseIP("193.0.14.129"), Port: 53, DomainName: "k.root-servers.net"},   // K
+	{IP: net.ParseIP("199.7.83.42"), Port: 53, DomainName: "l.root-servers.net"},    // L
+	{IP: net.ParseIP("202.12.27.33"), Port: 53, DomainName: "m.root-servers.net"},   // M
 }
 
 var RootServersV6 = []NameServer{
-	{IP: net.ParseIP("2001:503:ba3e::2:30"), Port: 53}, // A
-	{IP: net.ParseIP("2801:1b8:10::b"), Port: 53},      // B
-	{IP: net.ParseIP("2001:500:2::c"), Port: 53},       // C
-	{IP: net.ParseIP("2001:500:2d::d"), Port: 53},      // D
-	{IP: net.ParseIP("2001:500:a8::e"), Port: 53},      // E
-	{IP: net.ParseIP("2001:500:2f::f"), Port: 53},      // F
-	{IP: net.ParseIP("2001:500:12::d0d"), Port: 53},    // G
-	{IP: net.ParseIP("2001:500:1::53"), Port: 53},      // H
-	{IP: net.ParseIP("2001:7fe::53"), Port: 53},        // I
-	{IP: net.ParseIP("2001:503:c27::2:30"), Port: 53},  // J
-	{IP: net.ParseIP("2001:7fd::1"), Port: 53},         // K
-	{IP: net.ParseIP("2001:500:9f::42"), Port: 53},     // L
-	{IP: net.ParseIP("2001:dc3::35"), Port: 53},        // M
+	{IP: net.ParseIP("2001:503:ba3e::2:30"), Port: 53, DomainName: "a.root-servers.net"}, // A
+	{IP: net.ParseIP("2801:1b8:10::b"), Port: 53, DomainName: "b.root-servers.net"},      // B
+	{IP: net.ParseIP("2001:500:2::c"), Port: 53, DomainName: "c.root-servers.net"},       // C
+	{IP: net.ParseIP("2001:500:2d::d"), Port: 53, DomainName: "d.root-servers.net"},      // D
+	{IP: net.ParseIP("2001:500:a8::e"), Port: 53, DomainName: "e.root-servers.net"},      // E
+	{IP: net.ParseIP("2001:500:2f::f"), Port: 53, DomainName: "f.root-servers.net"},      // F
+	{IP: net.ParseIP("2001:500:12::d0d"), Port: 53, DomainName: "g.root-servers.net"},    // G
+	{IP: net.ParseIP("2001:500:1::53"), Port: 53, DomainName: "h.root-servers.net"},      // H
+	{IP: net.ParseIP("2001:7fe::53"), Port: 53, DomainName: "i.root-servers.net"},        // I
+	{IP: net.ParseIP("2001:503:c27::2:30"), Port: 53, DomainName: "j.root-servers.net"},  // J
+	{IP: net.ParseIP("2001:7fd::1"), Port: 53, DomainName: "k.root-servers.net"},         // K
+	{IP: net.ParseIP("2001:500:9f::42"), Port: 53, DomainName: "l.root-servers.net"},     // L
+	{IP: net.ParseIP("2001:dc3::35"), Port: 53, DomainName: "m.root-servers.net"},        // M
 }
 
 var DefaultExternalResolversV4 = []NameServer{

--- a/src/zdns/conf.go
+++ b/src/zdns/conf.go
@@ -23,7 +23,7 @@ const (
 )
 
 type TargetedDomain struct {
-	Domain      string   `json:"domain"`
+	Domain      string   `json:"name"`
 	Nameservers []string `json:"nameservers"`
 }
 

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -362,7 +362,11 @@ func (r *Resolver) filterNameServersForUniqueNames(nameServers []NameServer) []N
 // It starts at either the provided rootNameServers or r.rootNameServers if none are provided as arguments and queries all.
 // If the responses contain an authoritative answer, the function will return the result and a trace for each queried nameserver.
 // If the responses do not contain an authoritative answer, the function will continue to the next layer of nameservers.
-// At each layer, we'll de-duplicate the referral nameservers from the previous layer and query them.
+// At each layer, we'll de-duplicate the referral nameservers from the previous layer and query them. For example, if all
+// root nameservers return a-m.gtld-servers.net, we'll only query each gtld-server once.
+//
+// Additionally, we'll query each layer for NS records, and once we have the set of authoritative nameservers, we'll query with
+// the original question type. This helps find sibling nameservers that aren't listed with the TLD.
 func (r *Resolver) LookupAllNameserversIterative(q *Question, rootNameServers []NameServer) (*AllNameServersResult, Trace, Status, error) {
 	perNameServerRetriesLimit := 2
 	ctx, cancel := context.WithTimeout(context.Background(), r.timeout)

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -91,7 +91,7 @@ func (r *Resolver) doDstServersLookup(ctx context.Context, q Question, nameServe
 		// if that looks likely, use it as is
 		if err != nil && !util.IsStringValidDomainName(q.Name) {
 			return nil, nil, StatusIllegalInput, err
-			// q.Name is a valid name name, we can continue
+			// q.Name is a valid name, we can continue
 		} else {
 			// remove trailing "." added by dns.ReverseAddr
 			q.Name = qname[:len(qname)-1]
@@ -707,7 +707,7 @@ func getRandomNonQueriedNameServer(nameServers []NameServer, queriedNameServers 
 
 // cachedLookup performs a DNS lookup with caching
 // returns the result, whether it was cached, the status, and an error if one occurred
-// layer is the name name layer we're currently querying ex: ".", "com.", "example.com."
+// layer is the name layer we're currently querying ex: ".", "com.", "example.com."
 // depth is the current depth of the lookup, used for iterative lookups
 // requestIteration is whether to set the "recursion desired" bit in the DNS query
 // cacheBasedOnNameServer is whether to consider a cache hit based on DNS question and nameserver, or just question
@@ -1277,7 +1277,7 @@ func FindTxtRecord(res *SingleQueryResult, regex *regexp.Regexp) (string, error)
 }
 
 // populateResults is a helper function to populate the candidateSet, cnameSet, and garbage maps to follow CNAMES
-// These maps are keyed by the name name and contain the relevant answers for that name
+// These maps are keyed by the name and contain the relevant answers for that name
 // candidateSet is a map of Answers that have a type matching the requested type.
 // cnameSet is a map of Answers that are CNAME records
 // dnameSet is a map of Answers that are DNAME records

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -337,14 +337,17 @@ func (r *Resolver) LookupAllNameserversIterative(q *Question, rootNameServers []
 		} else {
 			retv.LayeredResponses[currentLayer] = layerResults
 		}
-		if isAuthoritative {
-			return &retv, trace, StatusNoError, nil
-		}
 		// Set the next layer to query
-		currentLayer, err = nextAuthority(q.Name, currentLayer)
+		var newLayer string
+		newLayer, err = nextAuthority(q.Name, currentLayer)
 		if err != nil {
 			return &retv, trace, StatusError, errors.Wrapf(err, "error determining next authority for layer %s", currentLayer)
 		}
+		if newLayer == currentLayer {
+			// we've reached the end of the authority chain, return
+			return &retv, trace, StatusNoError, nil
+		}
+		currentLayer = newLayer
 		currentLayerNameServers, err = r.extractNameServersFromLayerResults(layerResults)
 		if err != nil {
 			return &retv, trace, StatusError, errors.Wrapf(err, "error extracting nameservers from layer %s", currentLayer)

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -514,12 +514,11 @@ func (r *Resolver) queryAllNameServersInLayer(ctx context.Context, perNameServer
 			}
 			result, currTrace, status, err := r.ExternalLookup(ctx, q, &nameServer)
 			trace = append(trace, currTrace...)
-			if err == nil && status == StatusNoError {
-				extResult = &ExtendedResult{
-					Res:        *result,
-					Status:     status,
-					Nameserver: nameServer.DomainName,
-				}
+			extResult = &ExtendedResult{Status: status, Nameserver: nameServer.DomainName}
+			if result != nil {
+				extResult.Res = *result
+			}
+			if err == nil && status == StatusNoError && result != nil {
 				if result.Flags.Authoritative {
 					isAuthoritative = true
 				}

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -353,11 +353,6 @@ func (r *Resolver) LookupAllNameserversIterative(q *Question, rootNameServers []
 		if err != nil {
 			return &retv, trace, StatusError, errors.Wrapf(err, "error determining next authority for layer %s", currentLayer)
 		}
-		//if newLayer == currentLayer {
-		//	// TODO need a better way to know when to break out
-		//	// we've reached the end of the authority chain, return
-		//	//return &retv, trace, StatusNoError, nil
-		//}
 		currentLayer = newLayer
 		var newNameServers []NameServer
 		newNameServers, err = r.extractNameServersFromLayerResults(layerResults)

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -354,6 +354,10 @@ func (r *Resolver) LookupAllNameserversIterative(q *Question, rootNameServers []
 			currentLayerNameServers = append(currentLayerNameServers, newNameServers...)
 			break
 		}
+		if len(newNameServers) == 0 {
+			// we have no more nameservers to query, error
+			return &retv, trace, StatusError, errors.Errorf("no nameservers found for layer %s", currentLayer)
+		}
 		currentLayerNameServers = newNameServers
 		currentLayer = newLayer
 	}

--- a/src/zdns/lookup_test.go
+++ b/src/zdns/lookup_test.go
@@ -1958,7 +1958,7 @@ func verifyNsResult(t *testing.T, servers []NSRecord, expectedServersMap map[str
 }
 
 func verifyCombinedResult(t *testing.T, records map[string][]ExtendedResult, expectedRecords map[string][]ExtendedResult) {
-	for layer, _ := range expectedRecords {
+	for layer := range expectedRecords {
 		assert.Contains(t, records, layer, fmt.Sprintf("Layer %s not found in combined result", layer))
 	}
 	for layer, expectedLayerResults := range expectedRecords {

--- a/src/zdns/lookup_test.go
+++ b/src/zdns/lookup_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"reflect"
 	"regexp"
+	"sort"
 	"testing"
 	"time"
 
@@ -2000,6 +2001,12 @@ func verifyCombinedResult(t *testing.T, records map[string][]ExtendedResult, exp
 		assert.Contains(t, records, layer, fmt.Sprintf("Layer %s not found in combined result", layer))
 	}
 	for layer, expectedLayerResults := range expectedRecords {
+		sort.Slice(records[layer], func(i, j int) bool {
+			return records[layer][i].Nameserver < records[layer][j].Nameserver
+		})
+		sort.Slice(records[layer], func(i, j int) bool {
+			return expectedLayerResults[i].Nameserver < expectedLayerResults[j].Nameserver
+		})
 		if !reflect.DeepEqual(records[layer], expectedLayerResults) {
 			t.Errorf("Combined result not matching for layer %s, expected %v, found %v", layer, expectedLayerResults, records[layer])
 		}

--- a/src/zdns/lookup_test.go
+++ b/src/zdns/lookup_test.go
@@ -1884,50 +1884,31 @@ func TestAllNsLookupErrorInOne(t *testing.T) {
 	verifyCombinedResult(t, results.LayeredResponses, expectedRes)
 }
 
-//	func TestAllNsLookupNXDomain(t *testing.T) {
-//		config := InitTest(t)
-//		config.IPVersionMode = IPv4Only
-//		resolver, err := InitResolver(config)
-//		require.NoError(t, err)
-//
-//		ns1 := &config.ExternalNameServersV4[0]
-//		q := Question{
-//			Type:  dns.TypeNS,
-//			Class: dns.ClassINET,
-//			Name:  "example.com",
-//		}
-//
-//		res, _, status, err := resolver.LookupAllNameserversIterative(&q, ns1)
-//
-//		assert.Equal(t, StatusNXDomain, status)
-//		assert.Nil(t, res)
-//		require.NoError(t, err)
-//	}
-//
-//	func TestAllNsLookupServFail(t *testing.T) {
-//		config := InitTest(t)
-//		config.IPVersionMode = IPv4Only
-//		resolver, err := InitResolver(config)
-//		require.NoError(t, err)
-//
-//		ns1 := &config.ExternalNameServersV4[0]
-//		domain1 := "example.com"
-//		domainNS1 := nameAndIP{name: domain1, IP: ns1.String()}
-//
-//		protocolStatus[domainNS1] = StatusServFail
-//		mockResults[domainNS1] = SingleQueryResult{}
-//
-//		q := Question{
-//			Type:  dns.TypeNS,
-//			Class: dns.ClassINET,
-//			Name:  "example.com",
-//		}
-//		res, _, status, err := resolver.LookupAllNameserversIterative(&q, ns1)
-//
-//		assert.Equal(t, StatusServFail, status)
-//		assert.Nil(t, res)
-//		require.NoError(t, err)
-//	}
+func TestAllNsLookupNXDomain(t *testing.T) {
+	config := InitTest(t)
+	config.IPVersionMode = IPv4Only
+	resolver, err := InitResolver(config)
+	require.NoError(t, err)
+
+	ns1 := &config.ExternalNameServersV4[0]
+	q := Question{
+		Type:  dns.TypeNS,
+		Class: dns.ClassINET,
+		Name:  "example.com",
+	}
+
+	res, _, status, err := resolver.LookupAllNameserversIterative(&q, []NameServer{*ns1})
+
+	expectedResponse := map[string][]ExtendedResult{
+		".": {{Status: StatusNXDomain}},
+	}
+	if !reflect.DeepEqual(res.LayeredResponses, expectedResponse) {
+		t.Errorf("Expected %v, Received %v", expectedResponse, res.LayeredResponses)
+	}
+	assert.Equal(t, StatusError, status)
+	require.Error(t, err) // could not successfully complete lookup, so this should error
+}
+
 func TestInvalidInputsLookup(t *testing.T) {
 	config := InitTest(t)
 	config.LocalAddrsV4 = []net.IP{net.ParseIP("127.0.0.1")}

--- a/src/zdns/lookup_test.go
+++ b/src/zdns/lookup_test.go
@@ -1532,9 +1532,6 @@ func TestAllNsLookupOneNsThreeLevels(t *testing.T) {
 	exampleNSServerIP := "3.3.3.3"
 	exampleNameAAnswer := "4.4.4.4"
 
-	//ns1 := &config.ExternalNameServersV4[0]
-	//ipv4_1 := "127.0.0.2"
-
 	mockResults[nameAndIP{name: exampleName, IP: rootServerIP + ":53"}] = SingleQueryResult{
 		Authorities: []interface{}{
 			Answer{
@@ -1597,6 +1594,7 @@ func TestAllNsLookupOneNsThreeLevels(t *testing.T) {
 			{
 				Status:     StatusNoError,
 				Nameserver: rootServer,
+				Type:       "NS",
 				Res: SingleQueryResult{
 					Authorities: []interface{}{
 						Answer{
@@ -1624,6 +1622,7 @@ func TestAllNsLookupOneNsThreeLevels(t *testing.T) {
 		"com": {
 			{
 				Status:     StatusNoError,
+				Type:       "NS",
 				Nameserver: comServer,
 				Res: SingleQueryResult{
 					Authorities: []interface{}{
@@ -1652,6 +1651,24 @@ func TestAllNsLookupOneNsThreeLevels(t *testing.T) {
 		"example.com": {
 			{
 				Status:     StatusNoError,
+				Type:       "NS",
+				Nameserver: exampleNSServer,
+				Res: SingleQueryResult{
+					Answers: []interface{}{
+						Answer{
+							TTL:    3600,
+							Type:   "A",
+							RrType: dns.TypeA,
+							Class:  "IN",
+							Name:   "example.com.",
+							Answer: "4.4.4.4",
+						},
+					},
+				},
+			},
+			{
+				Status:     StatusNoError,
+				Type:       "A",
 				Nameserver: exampleNSServer,
 				Res: SingleQueryResult{
 					Answers: []interface{}{
@@ -1780,6 +1797,7 @@ func TestAllNsLookupErrorInOne(t *testing.T) {
 		".": {
 			{
 				Status:     StatusNoError,
+				Type:       "NS",
 				Nameserver: rootServer,
 				Res: SingleQueryResult{
 					Authorities: []interface{}{
@@ -1824,11 +1842,13 @@ func TestAllNsLookupErrorInOne(t *testing.T) {
 		"com": {
 			{
 				Status:     StatusServFail,
+				Type:       "NS",
 				Nameserver: comServerA,
 				Res:        SingleQueryResult{},
 			},
 			{
 				Status:     StatusNoError,
+				Type:       "NS",
 				Nameserver: comServerB,
 				Res: SingleQueryResult{
 					Authorities: []interface{}{
@@ -1857,6 +1877,24 @@ func TestAllNsLookupErrorInOne(t *testing.T) {
 		"example.com": {
 			{
 				Status:     StatusNoError,
+				Type:       "NS",
+				Nameserver: exampleNSServer,
+				Res: SingleQueryResult{
+					Answers: []interface{}{
+						Answer{
+							TTL:    3600,
+							Type:   "A",
+							RrType: dns.TypeA,
+							Class:  "IN",
+							Name:   "example.com.",
+							Answer: exampleNameAAnswer,
+						},
+					},
+				},
+			},
+			{
+				Status:     StatusNoError,
+				Type:       "A",
 				Nameserver: exampleNSServer,
 				Res: SingleQueryResult{
 					Answers: []interface{}{
@@ -1900,7 +1938,7 @@ func TestAllNsLookupNXDomain(t *testing.T) {
 	res, _, status, err := resolver.LookupAllNameserversIterative(&q, []NameServer{*ns1})
 
 	expectedResponse := map[string][]ExtendedResult{
-		".": {{Status: StatusNXDomain}},
+		".": {{Status: StatusNXDomain, Type: "NS"}},
 	}
 	if !reflect.DeepEqual(res.LayeredResponses, expectedResponse) {
 		t.Errorf("Expected %v, Received %v", expectedResponse, res.LayeredResponses)

--- a/src/zdns/lookup_test.go
+++ b/src/zdns/lookup_test.go
@@ -1581,7 +1581,7 @@ func TestAllNsLookupOneNs(t *testing.T) {
 		Name:  "example.com",
 	}
 
-	results, _, _, err := resolver.LookupAllNameservers(&q, ns1)
+	results, _, _, err := resolver.LookupAllNameserversIterative(&q, ns1)
 	require.NoError(t, err)
 	verifyCombinedResult(t, results.Results, expectedRes)
 }
@@ -1703,7 +1703,7 @@ func TestAllNsLookupOneNsMultipleIps(t *testing.T) {
 		Name:  "example.com",
 	}
 
-	results, _, _, err := resolver.LookupAllNameservers(&q, ns1)
+	results, _, _, err := resolver.LookupAllNameserversIterative(&q, ns1)
 	require.NoError(t, err)
 	verifyCombinedResult(t, results.Results, expectedRes)
 }
@@ -1816,7 +1816,7 @@ func TestAllNsLookupTwoNs(t *testing.T) {
 		Name:  "example.com",
 	}
 
-	results, _, _, err := resolver.LookupAllNameservers(&q, ns1)
+	results, _, _, err := resolver.LookupAllNameserversIterative(&q, ns1)
 	require.NoError(t, err)
 	verifyCombinedResult(t, results.Results, expectedRes)
 }
@@ -1916,7 +1916,7 @@ func TestAllNsLookupErrorInOne(t *testing.T) {
 		Name:  "example.com",
 	}
 
-	results, _, _, err := resolver.LookupAllNameservers(&q, ns1)
+	results, _, _, err := resolver.LookupAllNameserversIterative(&q, ns1)
 	require.NoError(t, err)
 	verifyCombinedResult(t, results.Results, expectedRes)
 }
@@ -1934,7 +1934,7 @@ func TestAllNsLookupNXDomain(t *testing.T) {
 		Name:  "example.com",
 	}
 
-	res, _, status, err := resolver.LookupAllNameservers(&q, ns1)
+	res, _, status, err := resolver.LookupAllNameserversIterative(&q, ns1)
 
 	assert.Equal(t, StatusNXDomain, status)
 	assert.Nil(t, res)
@@ -1959,7 +1959,7 @@ func TestAllNsLookupServFail(t *testing.T) {
 		Class: dns.ClassINET,
 		Name:  "example.com",
 	}
-	res, _, status, err := resolver.LookupAllNameservers(&q, ns1)
+	res, _, status, err := resolver.LookupAllNameserversIterative(&q, ns1)
 
 	assert.Equal(t, StatusServFail, status)
 	assert.Nil(t, res)

--- a/src/zdns/nslookup.go
+++ b/src/zdns/nslookup.go
@@ -14,6 +14,7 @@
 package zdns
 
 import (
+	"context"
 	"strings"
 
 	"github.com/miekg/dns"
@@ -52,9 +53,9 @@ func (r *Resolver) DoNSLookup(lookupName string, nameServer *NameServer, isItera
 	var status Status
 	var err error
 	if isIterative {
-		ns, trace, status, err = r.IterativeLookup(&Question{Name: lookupName, Type: dns.TypeNS, Class: dns.ClassINET})
+		ns, trace, status, err = r.IterativeLookup(context.Background(), &Question{Name: lookupName, Type: dns.TypeNS, Class: dns.ClassINET})
 	} else {
-		ns, trace, status, err = r.ExternalLookup(&Question{Name: lookupName, Type: dns.TypeNS, Class: dns.ClassINET}, nameServer)
+		ns, trace, status, err = r.ExternalLookup(context.Background(), &Question{Name: lookupName, Type: dns.TypeNS, Class: dns.ClassINET}, nameServer)
 
 	}
 

--- a/src/zdns/qa.go
+++ b/src/zdns/qa.go
@@ -79,7 +79,7 @@ type SingleQueryResult struct {
 	Additional         []interface{} `json:"additionals,omitempty" groups:"short,normal,long,trace"`
 	Authorities        []interface{} `json:"authorities,omitempty" groups:"short,normal,long,trace"`
 	Protocol           string        `json:"protocol" groups:"protocol,normal,long,trace"`
-	Resolver           string        `json:"resolver" groups:"resolver,normal,long,trace"`
+	Resolver           string        `json:"resolver" groups:"resolver,normal,long,trace"` // IP address
 	Flags              DNSFlags      `json:"flags" groups:"flags,long,trace"`
 	TLSServerHandshake interface{}   `json:"tls_handshake,omitempty" groups:"normal,long,trace"` // used for --tls and --https, JSON string of the TLS handshake
 }
@@ -87,12 +87,11 @@ type SingleQueryResult struct {
 type ExtendedResult struct {
 	Res        SingleQueryResult `json:"result,omitempty" groups:"short,normal,long,trace"`
 	Status     Status            `json:"status" groups:"short,normal,long,trace"`
-	Nameserver string            `json:"nameserver" groups:"short,normal,long,trace"`
-	Trace      Trace             `json:"trace,omitempty" groups:"trace"`
+	Nameserver string            `json:"nameserver" groups:"short,normal,long,trace"` // NS domain name
 }
 
-type CombinedResults struct {
-	Results []ExtendedResult `json:"results" groups:"short,normal,long,trace"`
+type AllNameServersResult struct {
+	LayeredResponses map[string][]ExtendedResult `json:"per_layer_responses" groups:"short,normal,long,trace"` //
 }
 
 type IPResult struct {

--- a/src/zdns/qa.go
+++ b/src/zdns/qa.go
@@ -52,7 +52,7 @@ type TraceStep struct {
 	Try        int               `json:"try" groups:"trace"`
 }
 
-// Result contains all the metadata from a complete lookup(s) for a domain. Results is keyed with the ModuleName.
+// Result contains all the metadata from a complete lookup(s) for a name. Results is keyed with the ModuleName.
 type Result struct {
 	AlteredName string                        `json:"altered_name,omitempty" groups:"short,normal,long,trace"`
 	Name        string                        `json:"name,omitempty" groups:"short,normal,long,trace"`
@@ -63,7 +63,7 @@ type Result struct {
 	Results     map[string]SingleModuleResult `json:"results,omitempty" groups:"short,normal,long,trace"`
 }
 
-// SingleModuleResult contains all the metadata from a complete lookup for a domain, potentially after following many CNAMEs/etc.
+// SingleModuleResult contains all the metadata from a complete lookup for a name, potentially after following many CNAMEs/etc.
 type SingleModuleResult struct {
 	Status    string      `json:"status,omitempty" groups:"short,normal,long,trace"`
 	Error     string      `json:"error,omitempty" groups:"short,normal,long,trace"`
@@ -87,7 +87,7 @@ type SingleQueryResult struct {
 type ExtendedResult struct {
 	Res        SingleQueryResult `json:"result,omitempty" groups:"short,normal,long,trace"`
 	Status     Status            `json:"status" groups:"short,normal,long,trace"`
-	Nameserver string            `json:"nameserver" groups:"short,normal,long,trace"` // NS domain name
+	Nameserver string            `json:"nameserver" groups:"short,normal,long,trace"` // NS name name
 }
 
 type AllNameServersResult struct {

--- a/src/zdns/qa.go
+++ b/src/zdns/qa.go
@@ -85,6 +85,7 @@ type SingleQueryResult struct {
 }
 
 type ExtendedResult struct {
+	Type       string            `json:"type" groups:"short,normal,long,trace"`
 	Res        SingleQueryResult `json:"result,omitempty" groups:"short,normal,long,trace"`
 	Status     Status            `json:"status" groups:"short,normal,long,trace"`
 	Nameserver string            `json:"nameserver" groups:"short,normal,long,trace"` // NS name name

--- a/src/zdns/qa.go
+++ b/src/zdns/qa.go
@@ -88,11 +88,11 @@ type ExtendedResult struct {
 	Type       string            `json:"type" groups:"short,normal,long,trace"`
 	Res        SingleQueryResult `json:"result,omitempty" groups:"short,normal,long,trace"`
 	Status     Status            `json:"status" groups:"short,normal,long,trace"`
-	Nameserver string            `json:"nameserver" groups:"short,normal,long,trace"` // NS domain name
+	Nameserver string            `json:"nameserver" groups:"short,normal,long,trace"` // NS name queried for this result
 }
 
 type AllNameServersResult struct {
-	LayeredResponses map[string][]ExtendedResult `json:"per_layer_responses" groups:"short,normal,long,trace"` //
+	LayeredResponses map[string][]ExtendedResult `json:"per_layer_responses" groups:"short,normal,long,trace"`
 }
 
 type IPResult struct {

--- a/src/zdns/qa.go
+++ b/src/zdns/qa.go
@@ -88,7 +88,7 @@ type ExtendedResult struct {
 	Type       string            `json:"type" groups:"short,normal,long,trace"`
 	Res        SingleQueryResult `json:"result,omitempty" groups:"short,normal,long,trace"`
 	Status     Status            `json:"status" groups:"short,normal,long,trace"`
-	Nameserver string            `json:"nameserver" groups:"short,normal,long,trace"` // NS name name
+	Nameserver string            `json:"nameserver" groups:"short,normal,long,trace"` // NS domain name
 }
 
 type AllNameServersResult struct {

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -536,14 +536,14 @@ func (r *Resolver) getConnectionInfo(nameServer *NameServer) (*ConnectionInfo, e
 					}
 					var tlsConn *tls.Conn
 					if len(nameServer.DomainName) != 0 && r.verifyServerCert {
-						// name name provided, we can verify the server's certificate
+						// domain name provided, we can verify the server's certificate
 						tlsConn = tls.Client(conn, &tls.Config{
 							InsecureSkipVerify: false,
 							RootCAs:            r.rootCAs,
 							ServerName:         nameServer.DomainName,
 						})
 					} else {
-						// If no name name is provided, we can't verify the server's certificate
+						// If no name is provided, we can't verify the server's certificate
 						tlsConn = tls.Client(conn, &tls.Config{
 							InsecureSkipVerify: true,
 						})

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1426,7 +1426,7 @@ class Tests(unittest.TestCase):
         provided as additionals in the .com response
         """
         # zdns-testing.com's nameservers are all in the .com zone, so we should only have to query the .com nameservers
-        c = "A zdns-testing.com --all-nameservers --iterative"
+        c = "A zdns-testing.com --all-nameservers --iterative --timeout=30"
         cmd,res = self.run_zdns(c, "")
         self.assertSuccess(res, cmd, "A")
         # Check for layers
@@ -1482,7 +1482,7 @@ class Tests(unittest.TestCase):
         provide the IPs in additionals.
         """
         # example.com has nameservers in .com, .org, and .net, we'll have to iteratively figure out their IP addresses too
-        c = "A example.com --all-nameservers --iterative"
+        c = "A example.com --all-nameservers --iterative --timeout=30"
         cmd,res = self.run_zdns(c, "")
         self.assertSuccess(res, cmd, "A")
         # Check for layers

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1482,7 +1482,7 @@ class Tests(unittest.TestCase):
 
     def test_lookup_all_nameservers_external_lookup(self):
         """
-        Test that --all-nameservers lookups work with external resolvers: cloudflare.com
+        Test that --all-nameservers lookups work with external resolvers: cloudflare.com and google.com
         """
         c = "A google.com --all-nameservers --name-servers='1.1.1.1,8.8.8.8'"
         cmd,res = self.run_zdns(c, "")

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1419,6 +1419,78 @@ class Tests(unittest.TestCase):
         # the second query has a much smaller response time than the first to show it's being cached
         self.assertTrue(first_duration / 50 > second_duration, f"Second query {second_duration} should be faster than the first {first_duration}")
 
+    def test_lookup_all_nameservers_single_zone_iterative(self):
+        """
+        Test that --all-nameservers --iterative lookups work with domains whose nameservers are all in the same zone
+        :return:
+        """
+        # google.com's nameservers are all in the .com zone, so we should only have to query the .com nameservers
+        c = "A google.com --all-nameservers --iterative"
+        cmd,res = self.run_zdns(c, "")
+        self.assertSuccess(res, cmd, "A")
+        # Check for layers
+        self.assertIn(".", res["results"]["A"]["data"]["per_layer_responses"], "Should have the root (.) layer")
+        self.assertIn("com", res["results"]["A"]["data"]["per_layer_responses"], "Should have the .com layer")
+        self.assertIn("google.com", res["results"]["A"]["data"]["per_layer_responses"], "Should have the google.com layer")
+        # check for a.root-servers.net, b.root-servers.net, ... m.root-servers.net
+        self.check_for_existance_of_root_and_com_nses(res)
+        # check for the google.com nameservers
+        actual_google_nses = []
+        for entry in res["results"]["A"]["data"]["per_layer_responses"]["google.com"]:
+            actual_google_nses.append(entry["nameserver"])
+        expected_google_nses = ["ns1.google.com", "ns2.google.com", "ns3.google.com", "ns4.google.com"]
+        for ns in expected_google_nses:
+            self.assertIn(ns, actual_google_nses, "Should have the google.com nameservers")
+
+    def check_for_existance_of_root_and_com_nses(self, res):
+        actual_root_ns = []
+        for entry in res["results"]["A"]["data"]["per_layer_responses"]["."]:
+            actual_root_ns.append(entry["nameserver"])
+        for letter in "abcdefghijklm":
+            self.assertIn(f"{letter}.root-servers.net", actual_root_ns, "Should have the root nameservers")
+        # check for the .com nameservers
+        actual_com_nses = []
+        for entry in res["results"]["A"]["data"]["per_layer_responses"]["com"]:
+            actual_com_nses.append(entry["nameserver"])
+        for letter in "abcdefghijklm":
+            self.assertIn(f"{letter}.gtld-servers.net", actual_com_nses, "Should have the .com nameservers")
+
+    def test_lookup_all_nameservers_multi_zone_iterative(self):
+        """
+        Test that --all-nameservers lookups work with domains whose nameservers have their nameservers in different zones
+        In this case, example.com has a/b.iana-servers.net as nameservers, which are in the .com zone, but whose nameservers
+        are dig -t NS iana-servers.com -> ns.icann.org, a/b/c.iana-servers.net.
+        """
+        # example.com has nameservers in .com, .org, and .net, we'll have to iteratively figure out their IP addresses too
+        c = "A example.com --all-nameservers --iterative"
+        cmd,res = self.run_zdns(c, "")
+        self.assertSuccess(res, cmd, "A")
+        # Check for layers
+        self.assertIn(".", res["results"]["A"]["data"]["per_layer_responses"], "Should have the root (.) layer")
+        self.assertIn("com", res["results"]["A"]["data"]["per_layer_responses"], "Should have the .com layer")
+        self.assertIn("example.com", res["results"]["A"]["data"]["per_layer_responses"], "Should have the example.com layer")
+        self.check_for_existance_of_root_and_com_nses(res)
+        # check for the example.com nameservers
+        actual_example_nses = []
+        for entry in res["results"]["A"]["data"]["per_layer_responses"]["example.com"]:
+            actual_example_nses.append(entry["nameserver"])
+        expected_example_nses = ["a.iana-servers.net", "b.iana-servers.net"]
+        for ns in expected_example_nses:
+            self.assertIn(ns, actual_example_nses, "Should have the example.com nameservers")
+
+    def test_lookup_all_nameservers_external_lookup(self):
+        """
+        Test that --all-nameservers lookups work with external resolvers
+        """
+        c = "A google.com --all-nameservers --name-servers='1.1.1.1,8.8.8.8'"
+        cmd,res = self.run_zdns(c, "")
+        self.assertSuccess(res, cmd, "A")
+        actual_resolvers = []
+        for entry in res["results"]["A"]["data"]:
+            actual_resolvers.append(entry["resolver"])
+        expected_resolvers = ["1.1.1.1:53", "8.8.8.8:53"]
+        for resolver in expected_resolvers:
+            self.assertIn(resolver, actual_resolvers, "Should have the expected resolvers")
 
 
 

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1426,7 +1426,7 @@ class Tests(unittest.TestCase):
         provided as additionals in the .com response
         """
         # zdns-testing.com's nameservers are all in the .com zone, so we should only have to query the .com nameservers
-        c = "A zdns-testing.com --all-nameservers --iterative --timeout=30"
+        c = "A zdns-testing.com --all-nameservers --iterative --timeout=60"
         cmd,res = self.run_zdns(c, "")
         self.assertSuccess(res, cmd, "A")
         # Check for layers
@@ -1482,7 +1482,7 @@ class Tests(unittest.TestCase):
         provide the IPs in additionals.
         """
         # example.com has nameservers in .com, .org, and .net, we'll have to iteratively figure out their IP addresses too
-        c = "A example.com --all-nameservers --iterative --timeout=30"
+        c = "A example.com --all-nameservers --iterative --timeout=60"
         cmd,res = self.run_zdns(c, "")
         self.assertSuccess(res, cmd, "A")
         # Check for layers

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1422,7 +1422,8 @@ class Tests(unittest.TestCase):
     def test_lookup_all_nameservers_single_zone_iterative(self):
         """
         Test that --all-nameservers --iterative lookups work with domains whose nameservers are all in the same zone
-        :return:
+        google.com has nameservers ns1/2/3/4.google.com, which are all in the .com zone and so will have their IPs
+        provided as additionals in the .com response
         """
         # google.com's nameservers are all in the .com zone, so we should only have to query the .com nameservers
         c = "A google.com --all-nameservers --iterative"
@@ -1459,7 +1460,8 @@ class Tests(unittest.TestCase):
         """
         Test that --all-nameservers lookups work with domains whose nameservers have their nameservers in different zones
         In this case, example.com has a/b.iana-servers.net as nameservers, which are in the .com zone, but whose nameservers
-        are dig -t NS iana-servers.com -> ns.icann.org, a/b/c.iana-servers.net.
+        are dig -t NS iana-servers.com -> ns.icann.org, a/b/c.iana-servers.net. This means the .com nameservers will not
+        provide the IPs in additionals.
         """
         # example.com has nameservers in .com, .org, and .net, we'll have to iteratively figure out their IP addresses too
         c = "A example.com --all-nameservers --iterative"
@@ -1480,7 +1482,7 @@ class Tests(unittest.TestCase):
 
     def test_lookup_all_nameservers_external_lookup(self):
         """
-        Test that --all-nameservers lookups work with external resolvers
+        Test that --all-nameservers lookups work with external resolvers: cloudflare.com
         """
         c = "A google.com --all-nameservers --name-servers='1.1.1.1,8.8.8.8'"
         cmd,res = self.run_zdns(c, "")


### PR DESCRIPTION
Resolves #352 , #302, and #362

# Overview
<img width="554" alt="image" src="https://github.com/user-attachments/assets/795676b5-101a-4f1e-8eb6-2b1058387e4b" />


 1. Starting with the set of all root nameservers, query all nameservers with an `NS` query and collect their responses.
 2. From these responses, gather the next layer's unique nameservers
 3. Query the next layer's nameservers. Repeat steps 1-3 until we no longer get any new new servers (are at the leaf nodes)
 4. Do one final query with the caller's query type to the set of leaf nameservers

This allows us to handle cases where the leaf nameservers store additional nameservers for the given domain, as was pointed out in #352 with `dumalinao.gov.ph`.

# Limitations
- Cannot handle CNAMEs where the names point to by the CNAME is in a different zone. In this way, we'd be similar to `dig +trace`
```
$ dig -t A cname-chain-10.zdns-testing.com +trace +nodnssec  

; <<>> DiG 9.10.6 <<>> -t A cname-chain-10.zdns-testing.com +trace +nodnssec
;; global options: +cmd
.                       506109  IN      NS      f.root-servers.net.
.                       506109  IN      NS      j.root-servers.net.
.                       506109  IN      NS      b.root-servers.net.
.                       506109  IN      NS      c.root-servers.net.
.                       506109  IN      NS      g.root-servers.net.
.                       506109  IN      NS      a.root-servers.net.
.                       506109  IN      NS      k.root-servers.net.
.                       506109  IN      NS      d.root-servers.net.
.                       506109  IN      NS      h.root-servers.net.
.                       506109  IN      NS      i.root-servers.net.
.                       506109  IN      NS      m.root-servers.net.
.                       506109  IN      NS      l.root-servers.net.
.                       506109  IN      NS      e.root-servers.net.
;; Received 823 bytes from 192.168.254.254#53(192.168.254.254) in 24 ms

com.                    172800  IN      NS      f.gtld-servers.net.
com.                    172800  IN      NS      k.gtld-servers.net.
com.                    172800  IN      NS      c.gtld-servers.net.
com.                    172800  IN      NS      i.gtld-servers.net.
com.                    172800  IN      NS      e.gtld-servers.net.
com.                    172800  IN      NS      g.gtld-servers.net.
com.                    172800  IN      NS      h.gtld-servers.net.
com.                    172800  IN      NS      b.gtld-servers.net.
com.                    172800  IN      NS      d.gtld-servers.net.
com.                    172800  IN      NS      a.gtld-servers.net.
com.                    172800  IN      NS      j.gtld-servers.net.
com.                    172800  IN      NS      m.gtld-servers.net.
com.                    172800  IN      NS      l.gtld-servers.net.
;; Received 859 bytes from 202.12.27.33#53(m.root-servers.net) in 81 ms

zdns-testing.com.       172800  IN      NS      ns-cloud-c1.googledomains.com.
zdns-testing.com.       172800  IN      NS      ns-cloud-c2.googledomains.com.
zdns-testing.com.       172800  IN      NS      ns-cloud-c3.googledomains.com.
zdns-testing.com.       172800  IN      NS      ns-cloud-c4.googledomains.com.
;; Received 354 bytes from 192.42.93.30#53(g.gtld-servers.net) in 42 ms

cname-chain-10.zdns-testing.com. 300 IN CNAME   cname-chain-11.esrg.stanford.edu.
;; Received 106 bytes from 216.239.36.108#53(ns-cloud-c3.googledomains.com) in 34 ms
```

We don't currently have the CNAME following as you would have with the normal `--iterative` mode

```
$ dig -t A cname-chain-10.zdns-testing.com +nodnssec  

;; ANSWER SECTION:
cname-chain-10.zdns-testing.com. 187 IN CNAME   cname-chain-11.esrg.stanford.edu.
cname-chain-11.esrg.stanford.edu. 83935 IN CNAME cname-chain-12.zdns-testing.com.
cname-chain-12.zdns-testing.com. 187 IN A       1.2.3.4
```

## Testing

Sanity-checked with test domains - example.com, google.com, zdns-testing.com, and dumalinao.gov.ph (per #352)

Ran larger scan with decent success rate - 
```
00h:02m:01s; Scan Complete; 1000 names scanned; 8.25 names/sec; 91.9% success rate; NOERROR: 919, ERROR: 45, TIMEOUT: 36
```

[Github Gist](https://gist.github.com/phillip-stephens/169104de06374ce324060b879e5e0456#file-output-json) for `example.com`