### PR TITLE
bump zdns version to 2.0.0

### DIFF
--- a/src/zdns/util.go
+++ b/src/zdns/util.go
@@ -26,7 +26,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-const ZDNSVersion = "1.1.0"
+const ZDNSVersion = "2.0.0"
 
 func dotName(name string) string {
 	if name == "." {


### PR DESCRIPTION
Bumping before tagging the release candidate for `v2.0.0`
```
$ ./zdns --version
zdns version 2.0.0
```