### PR TITLE
Edited version for 1.23 -> 1.23.0 to fix toolchain issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zmap/zdns
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/hashicorp/go-version v1.7.0


### PR DESCRIPTION
Noticed when running `make install` on a VM that our toolchain line in `go.mod` is causing issues if the current toolchain isn't correct:

On latest `main`:
```
$ make install
go generate ./...
go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available
make: *** [makefile:4: generate] Error 1
```

We need to specify the full version based on this [dialogue](https://github.com/golang/go/issues/62278).