### PR TITLE
Bug fix for use-after-close connection in AXFR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/weppos/publicsuffix-go v0.40.3-0.20250127173806-e489a31678ca // indirect
 	github.com/zmap/rc2 v0.0.0-20190804163417-abaa70531248 // indirect
 	golang.org/x/crypto v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -253,6 +253,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/src/modules/axfr/axfr.go
+++ b/src/modules/axfr/axfr.go
@@ -79,6 +79,10 @@ func (axfrMod *AxfrLookupModule) doAXFR(name string, server *zdns.NameServer) AX
 	}
 	m := new(dns.Msg)
 	m.SetAxfr(dotName(name))
+	defer func() {
+		// The below function will close the connection after use, so we should set it to nil to ensure it's never used again.
+		axfrMod.Conn = nil
+	}()
 	if a, err := axfrMod.In(m, net.JoinHostPort(server.IP.String(), "53")); err != nil {
 		retv.Status = zdns.StatusError
 		retv.Error = err.Error()

--- a/src/modules/axfr/axfr.go
+++ b/src/modules/axfr/axfr.go
@@ -35,7 +35,23 @@ type AxfrLookupModule struct {
 	NSModule      nslookup.NSLookupModule
 	BlacklistPath string `long:"blacklist-file" description:"path to blacklist file" default:""`
 	Blacklist     *safeblacklist.SafeBlacklist
-	dns.Transfer
+	TransferFact  TransferFactory
+}
+
+// TransferInterface used to enable mocking for dns.In
+type TransferInterface interface {
+	In(m *dns.Msg, address string) (chan *dns.Envelope, error)
+}
+
+// TransferFactory each AXFR module isn't thread-safe, so we need to create a new Transfer object for each AXFR lookup
+type TransferFactory interface {
+	NewTransfer() TransferInterface
+}
+
+type RealTransferFactory struct{}
+
+func (f *RealTransferFactory) NewTransfer() TransferInterface {
+	return &dns.Transfer{}
 }
 
 type AXFRServerResult struct {
@@ -58,11 +74,7 @@ func dotName(name string) string {
 	return strings.Join([]string{name, "."}, "")
 }
 
-type TransferClient struct {
-	dns.Transfer
-}
-
-func (axfrMod *AxfrLookupModule) doAXFR(name string, server *zdns.NameServer) AXFRServerResult {
+func (axfrMod *AxfrLookupModule) doAXFR(transfer TransferInterface, name string, server *zdns.NameServer) AXFRServerResult {
 	var retv AXFRServerResult
 	retv.Server = server.IP.String()
 	// check if the server address is blacklisted and if so, exclude
@@ -79,11 +91,7 @@ func (axfrMod *AxfrLookupModule) doAXFR(name string, server *zdns.NameServer) AX
 	}
 	m := new(dns.Msg)
 	m.SetAxfr(dotName(name))
-	defer func() {
-		// The below function will close the connection after use, so we should set it to nil to ensure it's never used again.
-		axfrMod.Conn = nil
-	}()
-	if a, err := axfrMod.In(m, net.JoinHostPort(server.IP.String(), "53")); err != nil {
+	if a, err := transfer.In(m, net.JoinHostPort(server.IP.String(), "53")); err != nil {
 		retv.Status = zdns.StatusError
 		retv.Error = err.Error()
 		return retv
@@ -107,6 +115,8 @@ func (axfrMod *AxfrLookupModule) doAXFR(name string, server *zdns.NameServer) AX
 
 func (axfrMod *AxfrLookupModule) Lookup(resolver *zdns.Resolver, name string, nameServer *zdns.NameServer) (interface{}, zdns.Trace, zdns.Status, error) {
 	var retv AXFRResult
+	// create a new AXFR transfer object
+	transfer := axfrMod.TransferFact.NewTransfer()
 	if nameServer == nil {
 		parsedNS, trace, status, err := axfrMod.NSModule.Lookup(resolver, name, nameServer)
 		if status != zdns.StatusNoError {
@@ -119,11 +129,11 @@ func (axfrMod *AxfrLookupModule) Lookup(resolver *zdns.Resolver, name string, na
 		for _, server := range castedNS.Servers {
 			if len(server.IPv4Addresses) > 0 {
 				ns := &zdns.NameServer{IP: net.ParseIP(server.IPv4Addresses[0])}
-				retv.Servers = append(retv.Servers, axfrMod.doAXFR(name, ns))
+				retv.Servers = append(retv.Servers, axfrMod.doAXFR(transfer, name, ns))
 			}
 		}
 	} else {
-		retv.Servers = append(retv.Servers, axfrMod.doAXFR(name, nameServer))
+		retv.Servers = append(retv.Servers, axfrMod.doAXFR(transfer, name, nameServer))
 	}
 	return retv, nil, zdns.StatusNoError, nil
 }
@@ -172,5 +182,6 @@ func (axfrMod *AxfrLookupModule) CLIInit(gc *cli.CLIConf, rc *zdns.ResolverConfi
 	if err = axfrMod.BasicLookupModule.CLIInit(gc, rc); err != nil {
 		return errors.Wrap(err, "failed to initialize basic lookup module")
 	}
+	axfrMod.TransferFact = &RealTransferFactory{} // Default factory
 	return nil
 }


### PR DESCRIPTION
Closes #522 

@smeinecke Thank you for the thorough bug report, made it a lot easier to debug.

On inspection with `git bisect` this was caused by the CLI + Library refactor (`c192044`). In the old code, there was a `dns.Transfer` in every `RoutineLookupFactory`, importantly, per-thread.

In the new code, there was one in the `AXFRModule` which is shared by multiple threads. The first lookup would have opened a connection and then closed it. The second lookup has logic that if the connection is `nil`, it'll open a new one. However if it is non-nil (but closed), it'll attempt to write. This resulted in the error.

The fix is to have a connection per `Lookup()`. Needed to use an interface factory so we can mock this in the unit tests.

## Testing
```
echo -e "zonetransfer.me,81.4.108.41\nzonetransfer.me,5.196.105.10" | ./zdns AXFR
echo -e "zonetransfer.me,81.4.108.41\nzonetransfer.me,5.196.105.10" | ./zdns AXFR --threads=1
```