### PR TITLE
Improved IPv6 link local resolver error and add unit testing for parsing function

### DIFF
--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -345,7 +345,7 @@ func populateIPTransportMode(gc *CLIConf, config *zdns.ResolverConfig) (*zdns.Re
 	ipv4NSStrings, ipv6NSStrings, err = zdns.GetDNSServers(config.DNSConfigFilePath)
 	if err != nil {
 		log.Fatalf("ZDNS is unable to parse resolvers file. ZDNS only supports IPv4 and IPv6 addresses with an optional port, "+
-			" either 111.222.333.444:9953 or [1111:2222::3333]:9953. ZDNS does not support link-local IPv6 resolvers. "+
+			" either 111.222.333.444:9953 or [1111:2222::3333]:9953. "+
 			"Please either modify your %s file or use '--name-servers'. Error: %v", config.DNSConfigFilePath, err)
 	}
 	if len(ipv4NSStrings) == 0 && len(ipv6NSStrings) == 0 {

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -344,7 +344,9 @@ func populateIPTransportMode(gc *CLIConf, config *zdns.ResolverConfig) (*zdns.Re
 	// check OS' default resolver(s) to determine if we support IPv4 or IPv6
 	ipv4NSStrings, ipv6NSStrings, err = zdns.GetDNSServers(config.DNSConfigFilePath)
 	if err != nil {
-		log.Fatal("unable to parse resolvers file, please use '--name-servers': ", err)
+		log.Fatalf("ZDNS is unable to parse resolvers file. ZDNS only supports IPv4 and IPv6 addresses with an optional port, "+
+			" either 111.222.333.444:9953 or [1111:2222::3333]:9953. ZDNS does not support link-local IPv6 resolvers. "+
+			"Please either modify your %s file or use '--name-servers'. Error: %v", config.DNSConfigFilePath, err)
 	}
 	if len(ipv4NSStrings) == 0 && len(ipv6NSStrings) == 0 {
 		return nil, errors.New("no nameservers found with OS defaults. Please specify desired nameservers with --name-servers")

--- a/src/internal/util/util.go
+++ b/src/internal/util/util.go
@@ -29,6 +29,7 @@ const (
 	DefaultDNSPort         = "53"
 	DefaultHTTPSPort       = "443"
 	DefaultTLSPort         = "853"
+	InvalidPortErrorMsg    = "invalid port"
 )
 
 func SplitHostPort(inaddr string) (net.IP, int, error) {
@@ -44,7 +45,7 @@ func SplitHostPort(inaddr string) (net.IP, int, error) {
 
 	portInt, err := strconv.Atoi(port)
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "invalid port")
+		return nil, 0, errors.Wrap(err, InvalidPortErrorMsg)
 	}
 
 	return ip, portInt, nil

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -42,7 +42,7 @@ func GetDNSServers(path string) (ipv4, ipv6 []string, err error) {
 		return nil, nil, fmt.Errorf("error opening DNS config file (%s): %w", path, err)
 	}
 	defer func(file *os.File) {
-		err = file.Close()
+		err := file.Close()
 		if err != nil {
 			log.Errorf("error closing DNS config file (%s): %s", path, err)
 		}


### PR DESCRIPTION
Resolves #512 

Following the discussion on the issue #512, I wanted to improve the error messages around why a given line will fail to parse in `/etc/resolv.conf`. This PR:

-  improves our parsing function to offer more granular errors
- Make parsing function operate on an `io.Reader` to enable easier unit-testing of the parsing
- Fix a bug found with the unit test where we couldn't parse an IPv6 address with a port, or certain shortened IPv6 addresses

Per `man resolvctl`, the `dns` section specifies that nameservers may take the form: "That is, the acceptable full formats are "111.222.333.444:9953%ifname#example.com" for IPv4 and "[1111:2222::3333]:9953%ifname#example.com" for IPv6."

We don't support domain names with nameservers in `/etc/resolv.conf` or per-interface nameservers.

## Testing
### Link-Local IPv6 Address

```
$ cat /etc/resolv.conf     
...
nameserver [2001:db8:3333:4444:5555:6666:7777:8888]:53%eth0

~/zdns on  phillip/512-improved-link-local-resolver-error ⌚ 10:42:36
$ ./zdns A prstephens.com
FATA[0000] ZDNS is unable to parse resolvers file. ZDNS only supports IPv4 and IPv6 addresses with an optional port,  either 111.222.333.444:9953 or [1111:2222::3333]:9953. Please either modify your /etc/resolv.conf file or use '--name-servers'. Error: could not parse IP address ([2001:db8:3333:4444:5555:6666:7777:8888]:53%eth0) from config. We do not support specifying link-local IPv6 addresses or per-interface nameservers 
```

### Passing Domain Names with IP addresses
```
$ cat /etc/resolv.conf   
...
nameserver 1.1.1.1#cloudflare.com

~/zdns on  phillip/512-improved-link-local-resolver-error ⌚ 10:48:28
$ ./zdns A prstephens.com
FATA[0000] ZDNS is unable to parse resolvers file. ZDNS only supports IPv4 and IPv6 addresses with an optional port,  either 111.222.333.444:9953 or [1111:2222::3333]:9953. Please either modify your /etc/resolv.conf file or use '--name-servers'. Error: could not parse IP address (1.1.1.1#cloudflare.com) from config. We do not support specifying domain names for nameservers 
```

### Base Case - Works
```
$ cat /etc/resolv.conf     
...
search stanford.edu
nameserver 1.1.1.1

~/zdns on  phillip/512-improved-link-local-resolver-error ⌚ 10:49:56
$ ./zdns A prstephens.com  
{"name":"prstephens.com","results":{"A":{"data":{"additionals":[{"flags":"","type":"EDNS0","udpsize":1232,"version":0}],"answers":[{"answer":"104.21.96.65","class":"IN","name":"prstephens.com","ttl":300,"type":"A"},{"answer":"172.67.173.251","class":"IN","name":"prstephens.com","ttl":300,"type":"A"}],"protocol":"udp","resolver":"1.1.1.1:53"},"duration":0.022647458,"status":"NOERROR","timestamp":"2025-03-12T10:49:59-07:00"}}}
00h:00m:00s; Scan Complete; 1 names scanned; 42.48 names/sec; 100.0% success rate; NOERROR: 1
```