### PR TITLE
Bump the version in go.mod v1 -> v2

### DIFF
--- a/benchmark/main.go
+++ b/benchmark/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/schollz/progressbar/v3"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 const (

--- a/benchmark/stats.go
+++ b/benchmark/stats.go
@@ -21,7 +21,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 // Stats holds the statistics for the benchmark

--- a/examples/all_nameservers_lookup/main.go
+++ b/examples/all_nameservers_lookup/main.go
@@ -20,8 +20,8 @@ import (
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/zmap/zdns/examples/utils"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/examples/utils"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 func main() {

--- a/examples/multi_thread_lookup/multi_threaded.go
+++ b/examples/multi_thread_lookup/multi_threaded.go
@@ -21,8 +21,8 @@ import (
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/zmap/zdns/examples/utils"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/examples/utils"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 func main() {

--- a/examples/single_lookup/simple.go
+++ b/examples/single_lookup/simple.go
@@ -21,8 +21,8 @@ import (
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/zmap/zdns/examples/utils"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/examples/utils"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zmap/zdns
+module github.com/zmap/zdns/v2
 
 go 1.23.0
 

--- a/main.go
+++ b/main.go
@@ -20,16 +20,16 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/zmap/zdns/src/cli"
+	"github.com/zmap/zdns/v2/src/cli"
 	// the order of these imports is important, as the modules are registered in the init() functions.
 	// Import modules after the basic cmd pkg
-	_ "github.com/zmap/zdns/src/modules/alookup"
-	_ "github.com/zmap/zdns/src/modules/axfr"
-	_ "github.com/zmap/zdns/src/modules/bindversion"
-	_ "github.com/zmap/zdns/src/modules/dmarc"
-	_ "github.com/zmap/zdns/src/modules/mxlookup"
-	_ "github.com/zmap/zdns/src/modules/nslookup"
-	_ "github.com/zmap/zdns/src/modules/spf"
+	_ "github.com/zmap/zdns/v2/src/modules/alookup"
+	_ "github.com/zmap/zdns/v2/src/modules/axfr"
+	_ "github.com/zmap/zdns/v2/src/modules/bindversion"
+	_ "github.com/zmap/zdns/v2/src/modules/dmarc"
+	_ "github.com/zmap/zdns/v2/src/modules/mxlookup"
+	_ "github.com/zmap/zdns/v2/src/modules/nslookup"
+	_ "github.com/zmap/zdns/v2/src/modules/spf"
 )
 
 func main() {

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -26,7 +26,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	flags "github.com/zmap/zflags"
 
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 var parser *flags.Parser

--- a/src/cli/iohandlers/file_handlers.go
+++ b/src/cli/iohandlers/file_handlers.go
@@ -23,7 +23,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/zmap/zdns/src/internal/util"
+	"github.com/zmap/zdns/v2/src/internal/util"
 )
 
 type FileInputHandler struct {

--- a/src/cli/iohandlers/status_handler.go
+++ b/src/cli/iohandlers/status_handler.go
@@ -25,8 +25,8 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/zmap/zdns/src/internal/util"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/internal/util"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 type StatusHandler struct {

--- a/src/cli/modules.go
+++ b/src/cli/modules.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 type LookupModule interface {

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -35,10 +35,10 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/zmap/zdns/src/cli/iohandlers"
-	blacklist "github.com/zmap/zdns/src/internal/safeblacklist"
-	"github.com/zmap/zdns/src/internal/util"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/cli/iohandlers"
+	blacklist "github.com/zmap/zdns/v2/src/internal/safeblacklist"
+	"github.com/zmap/zdns/v2/src/internal/util"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 type routineMetadata struct {

--- a/src/cli/worker_manager_test.go
+++ b/src/cli/worker_manager_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 func TestConvertNameServerStringToNameServer(t *testing.T) {

--- a/src/modules/alookup/a_lookup.go
+++ b/src/modules/alookup/a_lookup.go
@@ -17,8 +17,8 @@ package alookup
 import (
 	"github.com/pkg/errors"
 
-	"github.com/zmap/zdns/src/cli"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/cli"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 type ALookupModule struct {

--- a/src/modules/axfr/axfr.go
+++ b/src/modules/axfr/axfr.go
@@ -20,14 +20,14 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/zmap/zdns/src/cli"
-	"github.com/zmap/zdns/src/internal/safeblacklist"
-	"github.com/zmap/zdns/src/modules/nslookup"
+	"github.com/zmap/zdns/v2/src/cli"
+	"github.com/zmap/zdns/v2/src/internal/safeblacklist"
+	"github.com/zmap/zdns/v2/src/modules/nslookup"
 
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 type AxfrLookupModule struct {

--- a/src/modules/axfr/axfr_test.go
+++ b/src/modules/axfr/axfr_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"gotest.tools/v3/assert"
 
-	"github.com/zmap/zdns/src/cli"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/cli"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 // Map from IPv4 address of server to DNS records

--- a/src/modules/bindversion/bindversion.go
+++ b/src/modules/bindversion/bindversion.go
@@ -20,8 +20,8 @@ import (
 	"github.com/miekg/dns"
 	"github.com/pkg/errors"
 
-	"github.com/zmap/zdns/src/cli"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/cli"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 const (

--- a/src/modules/bindversion/bindversion_test.go
+++ b/src/modules/bindversion/bindversion_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/miekg/dns"
 	"gotest.tools/v3/assert"
 
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 type QueryRecord struct {

--- a/src/modules/dmarc/dmarc.go
+++ b/src/modules/dmarc/dmarc.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/miekg/dns"
 
-	"github.com/zmap/zdns/src/cli"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/cli"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 const dmarcPrefixRegexp = "^[vV][\x09\x20]*=[\x09\x20]*DMARC1[\x09\x20]*;[\x09\x20]*"

--- a/src/modules/dmarc/dmarc_test.go
+++ b/src/modules/dmarc/dmarc_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/miekg/dns"
 	"gotest.tools/v3/assert"
 
-	"github.com/zmap/zdns/src/cli"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/cli"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 type QueryRecord struct {

--- a/src/modules/mxlookup/mx_lookup.go
+++ b/src/modules/mxlookup/mx_lookup.go
@@ -21,8 +21,8 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/zmap/zdns/src/cli"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/cli"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 type CachedAddresses struct {

--- a/src/modules/nslookup/ns_lookup.go
+++ b/src/modules/nslookup/ns_lookup.go
@@ -18,8 +18,8 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/zmap/zdns/src/cli"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/cli"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 func init() {

--- a/src/modules/spf/spf.go
+++ b/src/modules/spf/spf.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/miekg/dns"
 
-	"github.com/zmap/zdns/src/cli"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/cli"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 const spfPrefixRegexp = "(?i)^v=spf1"

--- a/src/modules/spf/spf_test.go
+++ b/src/modules/spf/spf_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/miekg/dns"
 	"gotest.tools/v3/assert"
 
-	"github.com/zmap/zdns/src/cli"
-	"github.com/zmap/zdns/src/zdns"
+	"github.com/zmap/zdns/v2/src/cli"
+	"github.com/zmap/zdns/v2/src/zdns"
 )
 
 type QueryRecord struct {

--- a/src/zdns/alookup.go
+++ b/src/zdns/alookup.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/miekg/dns"
 
-	"github.com/zmap/zdns/src/internal/util"
+	"github.com/zmap/zdns/v2/src/internal/util"
 )
 
 // DoTargetedLookup performs a lookup of the given name against the given nameserver, looking up both IPv4 and IPv6 addresses

--- a/src/zdns/answers_generate.go
+++ b/src/zdns/answers_generate.go
@@ -125,7 +125,7 @@ func (ans Answer) BaseAns() *Answer { return &ans }
 
 func main() {
 	// Import and type-check the package
-	pkg, err := loadModule("github.com/zmap/zdns/src/zdns")
+	pkg, err := loadModule("github.com/zmap/zdns/v2/src/zdns")
 	fatalIfErr(err)
 	scope := pkg.Scope()
 

--- a/src/zdns/cache.go
+++ b/src/zdns/cache.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/miekg/dns"
 
-	"github.com/zmap/zdns/src/internal/cachehash"
-	"github.com/zmap/zdns/src/internal/util"
+	"github.com/zmap/zdns/v2/src/internal/cachehash"
+	"github.com/zmap/zdns/v2/src/internal/util"
 )
 
 type IsCached bool

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -31,7 +31,7 @@ import (
 	"github.com/zmap/zgrab2/lib/http"
 	"github.com/zmap/zgrab2/lib/output"
 
-	"github.com/zmap/zdns/src/internal/util"
+	"github.com/zmap/zdns/v2/src/internal/util"
 )
 
 var ErrorContextExpired = errors.New("context expired")

--- a/src/zdns/lookup_test.go
+++ b/src/zdns/lookup_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/miekg/dns"
 
-	"github.com/zmap/zdns/src/internal/util"
+	"github.com/zmap/zdns/v2/src/internal/util"
 )
 
 type nameAndIP struct {

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -31,8 +31,8 @@ import (
 	"github.com/zmap/zcrypto/tls"
 	"github.com/zmap/zgrab2/lib/http"
 
-	blacklist "github.com/zmap/zdns/src/internal/safeblacklist"
-	"github.com/zmap/zdns/src/internal/util"
+	blacklist "github.com/zmap/zdns/v2/src/internal/safeblacklist"
+	"github.com/zmap/zdns/v2/src/internal/util"
 )
 
 const (

--- a/src/zdns/types.go
+++ b/src/zdns/types.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/zmap/zdns/src/internal/util"
+	"github.com/zmap/zdns/v2/src/internal/util"
 )
 
 const (


### PR DESCRIPTION
This is necessary since otherwise [Go's pkg repo](https://pkg.go.dev/github.com/zmap/zdns?tab=versions) won't pick up new changes. It currently says last version of the library is `v1.1.0`.