### PR TITLE
Handle ANY-type Records

### DIFF
--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -1461,7 +1461,9 @@ func populateResults(records []interface{}, dnsType uint16, candidateSet map[str
 		// Verify that the answer type matches requested type
 		if VerifyAddress(ans.Type, ans.Answer) {
 			ansType := dns.StringToType[ans.Type]
-			if dnsType == ansType {
+			// Either this record is the type we're looking for, or we're performing an ANY lookup and this isn't a
+			// CNAME or DNAME (we'll need to follow those)
+			if dnsType == ansType || (dns.TypeANY == dnsType && ansType != dns.TypeCNAME && ansType != dns.TypeDNAME) {
 				candidateSet[lowerCaseName] = append(candidateSet[lowerCaseName], ans)
 			} else if dns.TypeCNAME == ansType {
 				cnameSet[lowerCaseName] = append(cnameSet[lowerCaseName], ans)

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -860,6 +860,16 @@ class Tests(unittest.TestCase):
         self.assertSuccess(res, cmd, "AAAA")
         self.assertEqualAnswers(res, self.WWW_CNAME_AND_AAAA_ANSWERS, cmd, "AAAA")
 
+    def test_any(self):
+        c = "ANY --iterative"
+        name = "zdns-testing.com"
+        cmd, res = self.run_zdns(c, name)
+        self.assertSuccess(res, cmd, "ANY")
+        # ANY's implementation is nameserver dependent. Per RFC 8482, it can just return an HINFO record and it won't
+        # send all other records. It can just send back a status NOTIMP like cloudflare's resolvers do.
+        # Our nameservers do send back records, so we'll just check that the response is not empty.
+        self.assertTrue(len(res["results"]["ANY"]["data"]["answers"]) > 0)
+
     def test_caa(self):
         c = "CAA"
         name = "zdns-testing.com"


### PR DESCRIPTION
## Description
As found in #546, we weren't handling `ANY` DNS queries correctly. If the user performs a `ANY` request, we should consider all returned records as "candidates" or valid responses to the question. This does that and adds an integration test.

## Testing
Additionally, I compared to `dig` for `www.zdns-testing.com` (CNAME) and `zdns-testing.com` and saw similar responses.

Resolves #546 