### PR TITLE
add int overflow check for 32-bit systems

### DIFF
--- a/src/internal/cachehash/shardedcachehash.go
+++ b/src/internal/cachehash/shardedcachehash.go
@@ -35,7 +35,13 @@ func (c *ShardedCacheHash) Init(maxLen int, shards int) {
 
 func (c *ShardedCacheHash) getShardID(k interface{}) int {
 	kb := []byte(fmt.Sprintf("%v", k))
-	return int(crc32.ChecksumIEEE(kb)) % c.shardsLen
+	hash := int(crc32.ChecksumIEEE(kb))
+	// crc32 returns a 32-bit unsigned integer. On 32-bit systems, this int cast can return negative values.
+	// To ensure we always have 0 <= shard ID < shardsLen, we take the absolute value of the hash.
+	if hash < 0 {
+		hash = -hash
+	}
+	return hash % c.shardsLen
 }
 
 func (c *ShardedCacheHash) getShard(k interface{}) *CacheHash {


### PR DESCRIPTION
This PR adds a check for the int cast of a 32-bit unsigned integer coming from a CRC32 checksum to catch an integer overflow that occurs on 32-bit systems.

On a 32-bit system, this checksum very frequently was cast to a negative `int` since `int()` defaults to making an integer of the same bit length as the OS. So 64-bit ints on 64-bit OS's and 32-bit int on 32-bit OS's.

```go
	hash := int(crc32.ChecksumIEEE(kb))
 	// crc32 returns a 32-bit unsigned integer. On 32-bit systems, this int cast can return negative values.
 	// To ensure we always have 0 <= shard ID < shardsLen, we take the absolute value of the hash.
 	if hash < 0 {
 		hash = -hash
 	}
 	return hash % c.shardsLen
```
It's fine if we have collisions since this is a hash table and IMO this is a cheap fix.

## Problems Elsewhere?
This raises the question of do we have these sorts of bugs elsewhere in the codebase. I did a `grep` for `int()` conversions and didn't see any exactly like this issue. I also spot-checked `zdns` in a 32-bit docker container with around 10 input domains and it successfully resolved all with no issues.

I can't imagine that many users want 32-bit support and therefore am doubtful that it's worth extending testing infrastructure to cover this. But I think since this bug caused an integer overflow 50% of the time and it's a small fix, it's worth it to add this. We can add 32-bit integration tests if more users of 32-bit systems complain.

## Testing
Used this Dockerfile to test
```docker
FROM arm32v7/golang

WORKDIR /app

COPY . .
RUN go mod download
RUN make

CMD ["/bin/bash"]
```
Build with:                                  
```shell
docker build -f ./.github/workflows/32-bit.Dockerfile -t 32-bit-zdns . && \
docker run -it --rm 32-bit-zdns     
```

## Related Issues
Resolves #551 