### PR TITLE
export type TransportMode

### DIFF
--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -73,7 +73,7 @@ type ResolverConfig struct {
 	Retries  int
 	LogLevel log.Level
 
-	TransportMode         transportMode
+	TransportMode         TransportMode
 	IPVersionMode         IPVersionMode
 	IterationIPPreference IterationIPPreference // preference for IPv4 or IPv6 lookups in iterative queries
 	ShouldRecycleSockets  bool
@@ -282,7 +282,7 @@ type Resolver struct {
 	pendingQueries   map[Question]bool // map of pending queries, to prevent cyclic queries
 	logLevel         log.Level
 
-	transportMode         transportMode
+	transportMode         TransportMode
 	ipVersionMode         IPVersionMode
 	iterationIPPreference IterationIPPreference
 	shouldRecycleSockets  bool

--- a/src/zdns/types.go
+++ b/src/zdns/types.go
@@ -27,10 +27,10 @@ const (
 	TCPProtocol = "tcp"
 )
 
-type transportMode int
+type TransportMode int
 
 const (
-	UDPOrTCP transportMode = iota
+	UDPOrTCP TransportMode = iota
 	UDPOnly
 	TCPOnly
 )
@@ -41,7 +41,7 @@ const (
 	DefaultDoTPort = 853
 )
 
-func GetTransportMode(useUDP, useTCP bool) transportMode {
+func GetTransportMode(useUDP, useTCP bool) TransportMode {
 	if useUDP && useTCP {
 		return UDPOrTCP
 	} else if useUDP {
@@ -52,7 +52,7 @@ func GetTransportMode(useUDP, useTCP bool) transportMode {
 	return UDPOrTCP
 }
 
-func (tm transportMode) isValid() (bool, string) {
+func (tm TransportMode) isValid() (bool, string) {
 	isValid := tm >= 0 && tm <= 2
 	if !isValid {
 		return false, fmt.Sprintf("invalid transport mode: %d", tm)


### PR DESCRIPTION
Unexported type alias is used as return type for an exported method `GetTransportMode`. This does not trigger an error, but still should be consistent.

https://github.com/zmap/zdns/blob/ee2e3068b4a3f57479da5f963d378745ec42f39f/src/zdns/types.go#L44