### PR TITLE
remove unused "+build" tags

### DIFF
--- a/src/cli/ulimit_check.go
+++ b/src/cli/ulimit_check.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 /*
  * ZDNS Copyright 2020 Regents of the University of Michigan

--- a/src/cli/ulimit_check_unknown.go
+++ b/src/cli/ulimit_check_unknown.go
@@ -1,5 +1,4 @@
 //go:build !linux && !darwin
-// +build !linux,!darwin
 
 /*
  * ZDNS Copyright 2020 Regents of the University of Michigan

--- a/src/zdns/answers_generate.go
+++ b/src/zdns/answers_generate.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 /*
  * ZDNS Copyright 2024 Regents of the University of Michigan


### PR DESCRIPTION
We require Go >= 1.18 since v1.0.0 and do have redundant "go:build" tags present, so no need to provide legacy build tags.

---

**Reference:**

> Since the release of Go 1.18 marks the end of support for Go 1.16, all supported versions of Go now understand `//go:build` lines. In Go 1.18, `go fix` now removes the now-obsolete `// +build` lines in modules declaring `go 1.18` or later in their `go.mod` files.

https://tip.golang.org/doc/go1.18#go-build-lines