### PR TITLE
update golang to v1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
       - name: Build
         run: |
           go version
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
       - name: Other lint
         run: |
           go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/large_scan_integration_test.yml
+++ b/.github/workflows/large_scan_integration_test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Build
         run: |
           go version

--- a/.github/workflows/make_benchmark.yml
+++ b/.github/workflows/make_benchmark.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Go Version Check
         run: |
           go version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zmap/zdns/v2
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/hashicorp/go-version v1.7.0


### PR DESCRIPTION
With go 1.25.0 released 3 weeks ago on August 12 [1], go 1.23 is now EoL. Update one increment to v1.24.

Briefly tested with locally installed  go1.24.6 linux/amd64 without any regression.

----

[1] https://go.dev/doc/devel/release#go1.25.0