### PR TITLE
fix some typos and update go report link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ZDNS
 ====
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/zmap/zdns)](https://goreportcard.com/report/github.com/zmap/zdns)
+[![Go Report Card](https://goreportcard.com/badge/github.com/zmap/zdns/v2)](https://goreportcard.com/report/github.com/zmap/zdns/v2)
 
 ZDNS is a command-line utility that provides high-speed DNS lookups. ZDNS is
 written in Go and contains its own recursive resolution code and a cache

--- a/src/cli/iohandlers/status_handler.go
+++ b/src/cli/iohandlers/status_handler.go
@@ -98,7 +98,7 @@ statusLoop:
 				stats.domainsScanned,
 				float64(stats.domainsScanned)/timeSinceStart.Seconds(),
 				float64(stats.domainsSuccess*100)/float64(stats.domainsScanned),
-				getStatusOccuranceString(stats.statusOccurance))
+				getStatusOccurrenceString(stats.statusOccurance))
 			if _, err := statusFile.WriteString(s); err != nil {
 				return errors.Wrap(err, "unable to write periodic status update")
 			}
@@ -139,32 +139,32 @@ statusLoop:
 		stats.domainsScanned,
 		float64(stats.domainsScanned)/time.Since(stats.scanStartTime).Seconds(),
 		float64(stats.domainsSuccess*100)/float64(stats.domainsScanned),
-		getStatusOccuranceString(stats.statusOccurance))
+		getStatusOccurrenceString(stats.statusOccurance))
 	if _, err := statusFile.WriteString(s); err != nil {
 		return errors.Wrap(err, "unable to write final status update")
 	}
 	return nil
 }
 
-func getStatusOccuranceString(statusOccurances map[zdns.Status]int) string {
-	type statusAndOccurance struct {
-		status    zdns.Status
-		occurance int
+func getStatusOccurrenceString(statusOccurrences map[zdns.Status]int) string {
+	type statusAndOccurrence struct {
+		status     zdns.Status
+		occurrence int
 	}
-	statusesAndOccurances := make([]statusAndOccurance, 0, len(statusOccurances))
-	for status, occurance := range statusOccurances {
-		statusesAndOccurances = append(statusesAndOccurances, statusAndOccurance{
-			status:    status,
-			occurance: occurance,
+	statusesAndOccurrences := make([]statusAndOccurrence, 0, len(statusOccurrences))
+	for status, occurrence := range statusOccurrences {
+		statusesAndOccurrences = append(statusesAndOccurrences, statusAndOccurrence{
+			status:     status,
+			occurrence: occurrence,
 		})
 	}
-	// sort by occurance
-	sort.Slice(statusesAndOccurances, func(i, j int) bool {
-		return statusesAndOccurances[i].occurance > statusesAndOccurances[j].occurance
+	// sort by occurrence
+	sort.Slice(statusesAndOccurrences, func(i, j int) bool {
+		return statusesAndOccurrences[i].occurrence > statusesAndOccurrences[j].occurrence
 	})
 	returnStr := ""
-	for _, statusOccurance := range statusesAndOccurances {
-		returnStr += fmt.Sprintf("%s: %d, ", statusOccurance.status, statusOccurance.occurance)
+	for _, statusOccurrence := range statusesAndOccurrences {
+		returnStr += fmt.Sprintf("%s: %d, ", statusOccurrence.status, statusOccurrence.occurrence)
 	}
 	// remove trailing comma
 	returnStr = strings.TrimSuffix(returnStr, ", ")

--- a/src/internal/util/util.go
+++ b/src/internal/util/util.go
@@ -84,7 +84,7 @@ func Contains[T comparable](slice []T, entity T) bool {
 // Avoids a gotcha in Go where since append modifies the underlying memory of the input slice, doing
 // newSlice := append(slice1, slice2) can modify slice1. See https://go.dev/doc/effective_go#append
 // A std. library concat was added in go 1.22, but this is for backwards compatibility. https://pkg.go.dev/slices#Concat
-// This is mostly similiar to the std. library concat, but with a few differences so it compiles on go 1.20.
+// This is mostly similar to the std. library concat, but with a few differences so it compiles on go 1.20.
 func Concat[S ~[]E, E any](slices ...S) S {
 	size := 0
 	for _, s := range slices {

--- a/src/zdns/answers.go
+++ b/src/zdns/answers.go
@@ -508,7 +508,7 @@ func formatLOCCoordinates(rawLat, rawLong, rawAlt uint32, size, horizPre, vertPr
 		altMeters, sizeMeters, horizPreMeters, vertPreMeters)
 }
 
-// decodeSizePrecision converts raw size and percision values to meters
+// decodeSizePrecision converts raw size and precision values to meters
 // Conversion according to section 2 of RFC 1876
 func decodeSizePrecision(rawValue uint8) float64 {
 	fourBitMask := uint8(0x0F)

--- a/src/zdns/answers_test.go
+++ b/src/zdns/answers_test.go
@@ -116,7 +116,7 @@ func TestFormatLOCCoordinates(t *testing.T) {
 
 		// Test for different precision values
 		{
-			name:     "Various Percisions",
+			name:     "Various Precisions",
 			lat:      2147483648 + 152514000, // 42 21 54 N
 			long:     2147483648 - 255960000, // 71 06 00 W
 			alt:      20000000,               // 100000.00m
@@ -126,7 +126,7 @@ func TestFormatLOCCoordinates(t *testing.T) {
 			expected: "42 21 54.000 N 71 6 0.000 W 100000.00m 100m 10m 3000m",
 		},
 		{
-			name:     "Zero Percision",
+			name:     "Zero Precision",
 			lat:      2147483648 + 152514000, // 42 21 54 N
 			long:     2147483648 - 255960000, // 71 06 00 W
 			alt:      9990000,                // -100.00m
@@ -136,7 +136,7 @@ func TestFormatLOCCoordinates(t *testing.T) {
 			expected: "42 21 54.000 N 71 6 0.000 W -100.00m 0m 0m 0m",
 		},
 		{
-			name:     "Minumum Percision",
+			name:     "Minimum Precision",
 			lat:      2147483648 + 152514000, // 42 21 54 N
 			long:     2147483648 - 255960000, // 71 06 00 W
 			alt:      9990000,                // -100.00m
@@ -146,7 +146,7 @@ func TestFormatLOCCoordinates(t *testing.T) {
 			expected: "42 21 54.000 N 71 6 0.000 W -100.00m 0.01m 0.01m 0.01m",
 		},
 		{
-			name:     "Maximum Percision",
+			name:     "Maximum Precision",
 			lat:      2147483648 + 152514000, // 42 21 54 N
 			long:     2147483648 - 255960000, // 71 06 00 W
 			alt:      9990000,                // -100.00m

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -679,7 +679,7 @@ func (r *Resolver) queryAllNameServersInLayer(ctx context.Context, perNameServer
 			}
 		}
 		if extResult == nil {
-			log.Debugf("LookupAllNameserversIterative of name %s against nameserver %s ran out of retries, continueing to next nameserver", q.Name, nameServer.IP.String())
+			log.Debugf("LookupAllNameserversIterative of name %s against nameserver %s ran out of retries, continuing to next nameserver", q.Name, nameServer.IP.String())
 		} else {
 			currentLayerResults = append(currentLayerResults, *extResult)
 		}
@@ -1385,7 +1385,7 @@ func (r *Resolver) extractAuthority(ctx context.Context, authority interface{}, 
 		q.RetriesRemaining = &r.retriesRemaining
 
 		// A/AAAA records for NSes are not on the chain of trust, so we don't need to validate DNSSEC
-		// Doing this to save us some time (this can propogate A LOT of queries in certain cases)
+		// Doing this to save us some time (this can propagate A LOT of queries in certain cases)
 		prevSecValue := r.shouldValidateDNSSEC
 		r.shouldValidateDNSSEC = false
 		res, trace, status, _ = r.iterativeLookup(ctx, &q, r.rootNameServers, depth+1, ".", trace)


### PR DESCRIPTION
_Go Report_ link in README.md should point to `/v2` of the project to reflect the latest version.

The report for v2.0.5 looks good (A+), actually better than v1.1.0. So let's fix some typos in comments and local variables to reach 100% across all categories.