### PR TITLE
Add functionality to parse zone files

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,18 @@ $ echo "google.com,1.1.1.1\nfacebook.com,8.8.8.8" | zdns A
 {"name":"facebook.com","results":{"A":{"data":{"additionals":[...],"answers":[...],"protocol":"udp","resolver":"8.8.8.8:53"},"duration":0.061365459,"status":"NOERROR","timestamp":"2024-09-13T09:51:34-04:00"}}}
 ````
 
+### Zone Files
+
+Zone files (from ICANN CZDS or similar) can be used as an input source for ZDNS with the `--zone-file` flag. This enables parsing zone files from either stdin (default) or a file with the `--input-file` flag.
+
+By default, ZDNS will extract only the name from each zone file record. If you'd also like to resolve the names referenced in the answer section of record types such as CNAMEs or NS records, you can use the `--zone-file-include-targets` CLI flag.
+
+For example, with `--zone-file-include-targets` and this DNS zone file entry:
+```
+example.com. 3600 IN NS ns1.example.com
+```
+both `example.com` and `ns1.example.com` would be resolved.
+
 Local Recursion
 ---------------
 

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -107,6 +107,8 @@ type InputOutputOptions struct {
 	ResultVerbosity              string `long:"result-verbosity" default:"normal" description:"Sets verbosity of each output record. Options: short, normal, long, trace"`
 	StatusUpdatesFilePath        string `short:"u" long:"status-updates-file" default:"-" description:"file to write scan progress to, defaults to stderr"`
 	Verbosity                    int    `long:"verbosity" default:"3" description:"log verbosity: 1 (lowest)--5 (highest)"`
+	ZoneFileFormat               bool   `long:"zone-file" description:"input file is a DNS zone file"`
+	ZoneFileIncludeTargets       bool   `long:"include-targets" description:"include target domains from zone file records (e.g., nameservers from NS records). Only used with --zone-file"`
 }
 
 type CLIConf struct {

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -108,7 +108,7 @@ type InputOutputOptions struct {
 	StatusUpdatesFilePath        string `short:"u" long:"status-updates-file" default:"-" description:"file to write scan progress to, defaults to stderr"`
 	Verbosity                    int    `long:"verbosity" default:"3" description:"log verbosity: 1 (lowest)--5 (highest)"`
 	ZoneFileFormat               bool   `long:"zone-file" description:"input file is a DNS zone file"`
-	ZoneFileIncludeTargets       bool   `long:"include-targets" description:"include target domains from zone file records (e.g., nameservers from NS records). Only used with --zone-file"`
+	ZoneFileIncludeTargets       bool   `long:"zone-file-include-targets" description:"include target domains from zone file records (e.g., nameservers from NS records). Only used with --zone-file"`
 }
 
 type CLIConf struct {

--- a/src/cli/iohandlers/zonefile_handler.go
+++ b/src/cli/iohandlers/zonefile_handler.go
@@ -58,9 +58,9 @@ func (h *ZoneFileInputHandler) parseZoneLine(line string) []string {
 	if name != "" {
 		domains = append(domains, name)
 	}
-if !h.includeTargets {
-    return domains
-}
+	if !h.includeTargets {
+		return domains
+	}
 	// Find the record type by skipping TTL (numeric) and CLASS (IN)
 	// Standard format: NAME TTL CLASS TYPE RDATA
 	typeIndex := -1

--- a/src/cli/iohandlers/zonefile_handler.go
+++ b/src/cli/iohandlers/zonefile_handler.go
@@ -1,0 +1,155 @@
+/*
+ * ZDNS Copyright 2024 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package iohandlers
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/zmap/zdns/v2/src/internal/util"
+)
+
+type ZoneFileInputHandler struct {
+	filepath       string
+	includeTargets bool
+}
+
+func NewZoneFileInputHandler(filepath string, includeTargets bool) *ZoneFileInputHandler {
+	return &ZoneFileInputHandler{
+		filepath:       filepath,
+		includeTargets: includeTargets,
+	}
+}
+
+// parseZoneLine parses a zone file record and returns domains to query.
+func (h *ZoneFileInputHandler) parseZoneLine(line string) []string {
+	line = strings.TrimSpace(line)
+
+	if line == "" || strings.HasPrefix(line, ";") {
+		return nil
+	}
+
+	fields := strings.Fields(line)
+	if len(fields) < 3 {
+		return nil
+	}
+
+	domains := make([]string, 0, 2)
+
+	name := strings.ToLower(fields[0])
+	name = strings.TrimSuffix(name, ".")
+	if name != "" {
+		domains = append(domains, name)
+	}
+
+	// Find the record type by skipping TTL (numeric) and CLASS (IN)
+	// Standard format: NAME TTL CLASS TYPE RDATA
+	typeIndex := -1
+	for i := 1; i < len(fields) && i < 4; i++ {
+		upperField := strings.ToUpper(fields[i])
+		// Skip CLASS field (IN only)
+		if upperField == "IN" || upperField == "INET" {
+			continue
+		}
+		// Skip TTL field (numeric)
+		isNumeric := true
+		for _, r := range upperField {
+			if r < '0' || r > '9' {
+				isNumeric = false
+				break
+			}
+		}
+		if !isNumeric {
+			typeIndex = i
+			break
+		}
+	}
+
+	if typeIndex == -1 || typeIndex >= len(fields)-1 {
+		return domains
+	}
+
+	recordType := strings.ToUpper(fields[typeIndex])
+	rdataStart := typeIndex + 1
+
+	if h.includeTargets && rdataStart < len(fields) {
+		var target string
+		switch recordType {
+		case "NS", "CNAME", "DNAME", "PTR", "SOA":
+			if len(fields) > rdataStart {
+				target = strings.ToLower(fields[rdataStart])
+				target = strings.TrimSuffix(target, ".")
+			}
+		case "MX":
+			if len(fields) > rdataStart+1 {
+				target = strings.ToLower(fields[rdataStart+1])
+				target = strings.TrimSuffix(target, ".")
+			}
+		case "SRV":
+			if len(fields) > rdataStart+3 {
+				target = strings.ToLower(fields[rdataStart+3])
+				target = strings.TrimSuffix(target, ".")
+			}
+		}
+
+		if target != "" {
+			domains = append(domains, target)
+		}
+	}
+
+	return domains
+}
+
+func (h *ZoneFileInputHandler) FeedChannel(ctx context.Context, in chan<- string, wg *sync.WaitGroup) error {
+	defer close(in)
+	defer (*wg).Done()
+
+	var f *os.File
+	if h.filepath == "" || h.filepath == "-" {
+		f = os.Stdin
+	} else {
+		var err error
+		f, err = os.Open(h.filepath)
+		if err != nil {
+			log.Fatalf("unable to open zone file: %v", err)
+		}
+		defer f.Close()
+	}
+
+	s := bufio.NewScanner(f)
+	buf := make([]byte, 0, 64*1024)
+	s.Buffer(buf, 1024*1024)
+
+	for s.Scan() {
+		if util.HasCtxExpired(ctx) {
+			return nil
+		}
+
+		domains := h.parseZoneLine(s.Text())
+		for _, domain := range domains {
+			in <- domain
+		}
+	}
+
+	if err := s.Err(); err != nil {
+		log.Fatalf("unable to read zone file: %v", err)
+	}
+	return nil
+}

--- a/src/cli/iohandlers/zonefile_handler.go
+++ b/src/cli/iohandlers/zonefile_handler.go
@@ -58,7 +58,9 @@ func (h *ZoneFileInputHandler) parseZoneLine(line string) []string {
 	if name != "" {
 		domains = append(domains, name)
 	}
-
+if !h.includeTargets {
+    return domains
+}
 	// Find the record type by skipping TTL (numeric) and CLASS (IN)
 	// Standard format: NAME TTL CLASS TYPE RDATA
 	typeIndex := -1

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -147,7 +147,7 @@ func populateCLIConfig(gc *CLIConf) *CLIConf {
 		log.Fatal("Zone file mode is incompatible with name server mode")
 	}
 	if gc.ZoneFileIncludeTargets && !gc.ZoneFileFormat {
-		log.Fatal("--include-targets can only be used with --zone-file")
+		log.Fatal("--zone-file-include-targets can only be used with --zone-file")
 	}
 	if gc.ZoneFileFormat && gc.AlexaFormat {
 		log.Fatal("Zone file mode is incompatible with Alexa format")

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -143,6 +143,18 @@ func populateCLIConfig(gc *CLIConf) *CLIConf {
 	if gc.NameServerMode && gc.MetadataFormat {
 		log.Fatal("Metadata mode is incompatible with name server mode")
 	}
+	if gc.NameServerMode && gc.ZoneFileFormat {
+		log.Fatal("Zone file mode is incompatible with name server mode")
+	}
+	if gc.ZoneFileIncludeTargets && !gc.ZoneFileFormat {
+		log.Fatal("--include-targets can only be used with --zone-file")
+	}
+	if gc.ZoneFileFormat && gc.AlexaFormat {
+		log.Fatal("Zone file mode is incompatible with Alexa format")
+	}
+	if gc.ZoneFileFormat && gc.MetadataFormat {
+		log.Fatal("Zone file mode is incompatible with metadata format")
+	}
 	if gc.NameServerMode && gc.NameOverride == "" && gc.CLIModule != BINDVERSION {
 		log.Fatal("Static Name must be defined with --override-name in --name-server-mode unless DNS module does not expect names (e.g., BINDVERSION).")
 	}
@@ -160,7 +172,11 @@ func populateCLIConfig(gc *CLIConf) *CLIConf {
 		// using domains from command line
 		gc.InputHandler = iohandlers.NewStringSliceInputHandler(GC.Domains)
 	} else if gc.InputHandler == nil {
-		gc.InputHandler = iohandlers.NewFileInputHandler(gc.InputFilePath)
+		if gc.ZoneFileFormat {
+			gc.InputHandler = iohandlers.NewZoneFileInputHandler(gc.InputFilePath, gc.ZoneFileIncludeTargets)
+		} else {
+			gc.InputHandler = iohandlers.NewFileInputHandler(gc.InputFilePath)
+		}
 	}
 	if gc.OutputHandler == nil {
 		gc.OutputHandler = iohandlers.NewFileOutputHandler(gc.OutputFilePath)

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1784,45 +1784,5 @@ _http._tcp.example.com.	3600	IN	SRV	10	5	80	server.example.com.
         finally:
             os.remove(zone_file)
 
-    def test_zone_file_real_format(self):
-        zone_content = """
-zdns-testing.com.	3600	IN	SOA	ns-cloud-c1.googledomains.com. cloud-dns-hostmaster.google.com. 2 21600 3600 259200 300
-zdns-testing.com.	3600	IN	NS	ns-cloud-c1.googledomains.com.
-zdns-testing.com.	3600	IN	NS	ns-cloud-c2.googledomains.com.
-zdns-testing.com.	300	IN	A	1.2.3.4
-www.zdns-testing.com.	300	IN	CNAME	zdns-testing.com.
-mx1.zdns-testing.com.	300	IN	A	1.2.3.4
-zdns-testing.com.	300	IN	MX	1	mx1.zdns-testing.com.
-zdns-testing.com.	900	IN	CAA	0	issue	"letsencrypt.org"
-; Comment line
-"""
-        zone_file = "test_zone_real_format.zone"
-        with open(zone_file, "w") as f:
-            f.write(zone_content)
-
-        try:
-            c = f"A --input-file={zone_file} --zone-file --include-targets"
-            cmd = f"{self.ZDNS_EXECUTABLE} {c} {self.ADDITIONAL_FLAGS}"
-            o = subprocess.check_output(cmd, shell=True)
-            output_lines = o.decode("utf-8").strip().splitlines()
-
-            names = set()
-            for line in output_lines:
-                result = json.loads(line)
-                names.add(result["name"])
-
-            # Should extract names and targets from NS, CNAME, MX records; SOA mname
-            expected_names = {
-                "zdns-testing.com",
-                "www.zdns-testing.com",
-                "mx1.zdns-testing.com",
-                "ns-cloud-c1.googledomains.com",
-                "ns-cloud-c2.googledomains.com"
-            }
-            self.assertEqual(names, expected_names, "Should parse real zone file format correctly")
-        finally:
-            os.remove(zone_file)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1716,6 +1716,113 @@ class Tests(unittest.TestCase):
                 resolver, actual_resolvers, "Should have the expected resolvers"
             )
 
+    def test_zone_file_input_names_only(self):
+        zone_content = """
+; Zone file for testing
+example.com.	3600	IN	A	192.0.2.1
+www.example.com.	3600	IN	CNAME	example.com.
+mail.example.com.	3600	IN	MX	10	mx.example.com.
+example.com.	3600	IN	NS	ns1.example.com.
+; Comment line should be ignored
+"""
+        zone_file = "test_zone_names_only.zone"
+        with open(zone_file, "w") as f:
+            f.write(zone_content)
+
+        try:
+            c = f"A --input-file={zone_file} --zone-file"
+            cmd = f"{self.ZDNS_EXECUTABLE} {c} {self.ADDITIONAL_FLAGS}"
+            o = subprocess.check_output(cmd, shell=True)
+            output_lines = o.decode("utf-8").strip().splitlines()
+
+            # Should get 3 unique domains: example.com, www.example.com, mail.example.com
+            names = set()
+            for line in output_lines:
+                result = json.loads(line)
+                names.add(result["name"])
+
+            expected_names = {"example.com", "www.example.com", "mail.example.com"}
+            self.assertEqual(names, expected_names, "Should extract all record names from zone file")
+        finally:
+            os.remove(zone_file)
+
+    def test_zone_file_input_with_targets(self):
+        zone_content = """
+example.com.	3600	IN	NS	ns1.example.com.
+example.com.	3600	IN	NS	ns2.example.com.
+www.example.com.	3600	IN	CNAME	example.com.
+mail.example.com.	3600	IN	MX	10	mx.example.com.
+_http._tcp.example.com.	3600	IN	SRV	10	5	80	server.example.com.
+"""
+        zone_file = "test_zone_with_targets.zone"
+        with open(zone_file, "w") as f:
+            f.write(zone_content)
+
+        try:
+            c = f"A --input-file={zone_file} --zone-file --include-targets"
+            cmd = f"{self.ZDNS_EXECUTABLE} {c} {self.ADDITIONAL_FLAGS}"
+            o = subprocess.check_output(cmd, shell=True)
+            output_lines = o.decode("utf-8").strip().splitlines()
+
+            # Should get both names and targets
+            names = set()
+            for line in output_lines:
+                result = json.loads(line)
+                names.add(result["name"])
+
+            expected_names = {
+                "example.com",
+                "www.example.com",
+                "mail.example.com",
+                "_http._tcp.example.com",
+                "ns1.example.com",
+                "ns2.example.com",
+                "mx.example.com",
+                "server.example.com"
+            }
+            self.assertEqual(names, expected_names, "Should extract both names and targets from zone file")
+        finally:
+            os.remove(zone_file)
+
+    def test_zone_file_real_format(self):
+        zone_content = """
+zdns-testing.com.	3600	IN	SOA	ns-cloud-c1.googledomains.com. cloud-dns-hostmaster.google.com. 2 21600 3600 259200 300
+zdns-testing.com.	3600	IN	NS	ns-cloud-c1.googledomains.com.
+zdns-testing.com.	3600	IN	NS	ns-cloud-c2.googledomains.com.
+zdns-testing.com.	300	IN	A	1.2.3.4
+www.zdns-testing.com.	300	IN	CNAME	zdns-testing.com.
+mx1.zdns-testing.com.	300	IN	A	1.2.3.4
+zdns-testing.com.	300	IN	MX	1	mx1.zdns-testing.com.
+zdns-testing.com.	900	IN	CAA	0	issue	"letsencrypt.org"
+; Comment line
+"""
+        zone_file = "test_zone_real_format.zone"
+        with open(zone_file, "w") as f:
+            f.write(zone_content)
+
+        try:
+            c = f"A --input-file={zone_file} --zone-file --include-targets"
+            cmd = f"{self.ZDNS_EXECUTABLE} {c} {self.ADDITIONAL_FLAGS}"
+            o = subprocess.check_output(cmd, shell=True)
+            output_lines = o.decode("utf-8").strip().splitlines()
+
+            names = set()
+            for line in output_lines:
+                result = json.loads(line)
+                names.add(result["name"])
+
+            # Should extract names and targets from NS, CNAME, MX records; SOA mname
+            expected_names = {
+                "zdns-testing.com",
+                "www.zdns-testing.com",
+                "mx1.zdns-testing.com",
+                "ns-cloud-c1.googledomains.com",
+                "ns-cloud-c2.googledomains.com"
+            }
+            self.assertEqual(names, expected_names, "Should parse real zone file format correctly")
+        finally:
+            os.remove(zone_file)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1761,7 +1761,7 @@ _http._tcp.example.com.	3600	IN	SRV	10	5	80	server.example.com.
             f.write(zone_content)
 
         try:
-            c = f"A --input-file={zone_file} --zone-file --include-targets"
+            c = f"A --input-file={zone_file} --zone-file --zone-file-include-targets"
             cmd = f"{self.ZDNS_EXECUTABLE} {c} {self.ADDITIONAL_FLAGS}"
             o = subprocess.check_output(cmd, shell=True)
             output_lines = o.decode("utf-8").strip().splitlines()

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1742,7 +1742,9 @@ example.com.	3600	IN	NS	ns1.example.com.
                 names.add(result["name"])
 
             expected_names = {"example.com", "www.example.com", "mail.example.com"}
-            self.assertEqual(names, expected_names, "Should extract all record names from zone file")
+            self.assertEqual(
+                names, expected_names, "Should extract all record names from zone file"
+            )
         finally:
             os.remove(zone_file)
 
@@ -1778,11 +1780,16 @@ _http._tcp.example.com.	3600	IN	SRV	10	5	80	server.example.com.
                 "ns1.example.com",
                 "ns2.example.com",
                 "mx.example.com",
-                "server.example.com"
+                "server.example.com",
             }
-            self.assertEqual(names, expected_names, "Should extract both names and targets from zone file")
+            self.assertEqual(
+                names,
+                expected_names,
+                "Should extract both names and targets from zone file",
+            )
         finally:
             os.remove(zone_file)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In reference to the issue I had created earlier: #568
- **src/cli/iohandlers/zonefile_handler.go** defines the parsing logic. I used the zone file for a less popular TLD (which I retrieved from ICANN's CZDS portal) as a reference. This could be more robust, but I think it should be fine for now.
- **src/cli/worker_manager.go** defines additional logic (e.g., a zone file can't also be an Alexa file, etc.);
- **src/cli/cli.go** the `InputOutputOptions` struct is expanded for `--zone-file` and `--include-targets`
- **testing/integration_tests.py** defines two tests for the parsing functions 

Resolves #568 