### PR TITLE
Add input triggers to allow running names through a subset of the modules with the Multiple module

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,11 +233,26 @@ The input format is:
 
 An example `input.csv` file:
 ```
-example.com,,A
-google.com,,A,CNAME
-example.com,1.1.1.1,AAAA
+example.com,,a-trigger
+google.com,,a-trigger,cname-trigger
+example.com,1.1.1.1,aaaa-trigger
 yahoo.com
 apnews.com,1.1.1.1
+```
+
+And corresponding `multiple.ini`:
+```
+; Specify Global Options here
+[Application Options]
+iterative=true
+prefer-ipv6-iteration="true"
+; List out modules and their respective module-specific options here. A module can only be listed once
+[A]
+trigger = "a-trigger"
+[AAAA]
+trigger = "aaaa-trigger"
+[CNAME]
+trigger = "cname-trigger"
 ```
 
 This will lookup:
@@ -247,20 +262,6 @@ This will lookup:
 - `yahoo.com` with all modules specified and using default nameservers
 - `apnews.com` with all modules specified and using Cloudflare's 1.1.1.1 resolver
 
-A corresponding `multiple.ini` file would be provided:
-```
-; Specify Global Options here
-[Application Options]
-iterative=true
-prefer-ipv6-iteration="true"
-; List out modules and their respective module-specific options here. A module can only be listed once
-[A]
-trigger = "A"
-[AAAA]
-trigger = "AAAA"
-[CNAME]
-trigger = "CNAME"
-```
 
 Running the command:
 ```shell

--- a/README.md
+++ b/README.md
@@ -212,6 +212,49 @@ $ echo "google.com,1.1.1.1\nfacebook.com,8.8.8.8" | zdns A
 {"name":"facebook.com","results":{"A":{"data":{"additionals":[...],"answers":[...],"protocol":"udp","resolver":"8.8.8.8:53"},"duration":0.061365459,"status":"NOERROR","timestamp":"2024-09-13T09:51:34-04:00"}}}
 ````
 
+### Per-Module Triggers
+ZDNS also supports passing in per-input-line "triggers" that map input lines to specific modules. With these, you can specify that 
+certain domains be looked up with specific modules.
+
+The input format is:
+`domain_name,name_server,trigger,trigger_2,etc`, where nameServer can be empty to use the default nameservers and 1+ triggers can be specified.
+
+An example `input.csv` file:
+```
+example.com,,A
+google.com,,A,CNAME
+example.com,1.1.1.1,AAAA
+yahoo.com
+apnews.com,1.1.1.1
+```
+
+This will lookup:
+- `example.com` with the A module using default nameservers
+- `google.com` with the A + CNAME modules using default nameservers
+- `example.com` with the AAAA module using Cloudflare's 1.1.1.1 resolver
+- `yahoo.com` with all modules specified and using default nameservers
+- `apnews.com` with all modules specified and using Cloudflare's 1.1.1.1 resolver
+
+A corresponding `multiple.ini` file would be provided:
+```
+; Specify Global Options here
+[Application Options]
+iterative=true
+prefer-ipv6-iteration="true"
+; List out modules and their respective module-specific options here. A module can only be listed once
+[A]
+trigger = "A"
+[AAAA]
+trigger = "AAAA"
+[CNAME]
+trigger = "CNAME"
+```
+
+Running the command:
+```shell
+zdns MULTIPLE --multi-config-file="./multiple.ini" --input-file="input.csv"
+```
+
 Local Recursion
 ---------------
 

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -251,6 +251,17 @@ For Example:
 zdns A google.com --name-servers=1.1.1.1,8.8.8.8
 echo "google.com,1.0.0.1" | zdns A
 
+Input Formats
+The input format is new-line delimited with optional nameserver and trigger(s) specified.
+name,[nameserver],[trigger1],[trigger2],...
+
+For example
+
+example.com                           # queries example.com using default nameservers
+example.com,1.1.1.1                   # queries example.com using 1.1.1.1
+example.com,,cname-trigger            # queries example.com using default nameservers, triggers on cname-trigger
+example.com,,cname-trigger,a-trigger  # queries example.com using default nameservers, triggers on both cname-trigger and a-trigger
+
 For more information, see the README
 `
 

--- a/src/cli/modules.go
+++ b/src/cli/modules.go
@@ -133,11 +133,12 @@ func RegisterLookupModule(name string, lm LookupModule) {
 	moduleToLookupModule[name] = lm
 	_, err := parser.AddCommand(name, "", lm.GetDescription(), lm)
 	if err != nil {
-		log.Fatalf("could not add command: %v", err)
+		log.Fatalf("could not add command (%s): %v", name, err)
 	}
 }
 
 type BasicLookupModule struct {
+	Trigger              string `long:"trigger" description:"invoke only on targets with specified tag. Useful for multiple module"`
 	IsIterative          bool
 	LookupAllNameServers bool
 	DNSType              uint16

--- a/src/cli/modules.go
+++ b/src/cli/modules.go
@@ -29,6 +29,7 @@ type LookupModule interface {
 	Lookup(ctx context.Context, resolver *zdns.Resolver, lookupName string, nameServer *zdns.NameServer) (any, zdns.Trace, zdns.Status, error)
 	Help() string                 // needed to satisfy the ZCommander interface in ZFlags.
 	GetDescription() string       // needed to add a command to the parser, printed to the user. Printed to the user when they run the help command for a given module
+	GetTrigger() string           // get the trigger tag for this module, if any
 	Validate(args []string) error // needed to satisfy the ZCommander interface in ZFlags
 	NewFlags() any                // needed to satisfy the ZModule interface in ZFlags
 }
@@ -168,6 +169,10 @@ func (lm *BasicLookupModule) Help() string {
 
 func (lm *BasicLookupModule) GetDescription() string {
 	return lm.Description
+}
+
+func (lm *BasicLookupModule) GetTrigger() string {
+	return lm.Trigger
 }
 
 func (lm *BasicLookupModule) Validate(args []string) error {

--- a/src/cli/multiple.ini
+++ b/src/cli/multiple.ini
@@ -3,9 +3,8 @@
 iterative=true
 prefer-ipv6-iteration="true"
 ; List out modules and their respective module-specific options here. A module can only be listed once
-[ALOOKUP]
-ipv4-lookup = true
-; You can use default values and just list modules if you don't need to specify any options
 [A]
+trigger = "A"
 [AAAA]
+trigger = "AAAA"
 [CNAME]

--- a/src/cli/multiple.ini
+++ b/src/cli/multiple.ini
@@ -3,8 +3,11 @@
 iterative=true
 prefer-ipv6-iteration="true"
 ; List out modules and their respective module-specific options here. A module can only be listed once
+[ALOOKUP]
+ipv4-lookup = true
 [A]
 trigger = "A"
 [AAAA]
 trigger = "AAAA"
+; You can use default values and just list modules if you don't need to specify any options
 [CNAME]

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -765,7 +765,7 @@ func parseMetadataInputLine(line string) (string, string) {
 	return s[0], s[1]
 }
 
-func parseNormalInputLine(line string) (string, string) {
+func parseNormalInputLine(line string) (name string, nameserver string) {
 	r := csv.NewReader(strings.NewReader(line))
 	s, err := r.Read()
 	if err != nil || len(s) == 0 {

--- a/src/cli/worker_manager_test.go
+++ b/src/cli/worker_manager_test.go
@@ -163,3 +163,58 @@ func TestRemoveDomainsFromNameServersString(t *testing.T) {
 		})
 	}
 }
+
+func TestParseNormalInputLine(t *testing.T) {
+	tests := []struct {
+		input            string
+		expectedDomain   string
+		expectedNS       string
+		expectedTriggers []string
+	}{
+		{
+			input:            "example.com",
+			expectedDomain:   "example.com",
+			expectedNS:       "",
+			expectedTriggers: []string{},
+		},
+		{
+			input:            "example.com,1.1.1.1",
+			expectedDomain:   "example.com",
+			expectedNS:       "1.1.1.1",
+			expectedTriggers: []string{},
+		},
+		{
+			// spaces after commas
+			input:            "example.com, 1.1.1.1",
+			expectedDomain:   "example.com",
+			expectedNS:       "1.1.1.1",
+			expectedTriggers: []string{},
+		},
+		{
+			input:            "example.com, 1.1.1.1, trigger1",
+			expectedDomain:   "example.com",
+			expectedNS:       "1.1.1.1",
+			expectedTriggers: []string{"trigger1"},
+		},
+		{
+			input:            "example.com,, trigger1",
+			expectedDomain:   "example.com",
+			expectedNS:       "",
+			expectedTriggers: []string{"trigger1"},
+		},
+		{
+			input:            "example.com,,,",
+			expectedDomain:   "example.com",
+			expectedNS:       "",
+			expectedTriggers: []string{"", ""},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			domain, ns, triggers := parseNormalInputLine(test.input)
+			require.Equal(t, test.expectedDomain, domain)
+			require.Equal(t, test.expectedNS, ns)
+			require.Equal(t, test.expectedTriggers, triggers)
+		})
+	}
+}

--- a/src/modules/alookup/a_lookup.go
+++ b/src/modules/alookup/a_lookup.go
@@ -73,3 +73,7 @@ func (aMod *ALookupModule) NewFlags() any {
 func (aMod *ALookupModule) GetDescription() string {
 	return "alookup will get the information that is typically desired, instead of just the information that exists in a single record. Specifically, alookup acts similar to nslookup and will follow CNAME records."
 }
+
+func (aMod *ALookupModule) GetTrigger() string {
+	return aMod.baseModule.Trigger
+}

--- a/src/modules/axfr/axfr.go
+++ b/src/modules/axfr/axfr.go
@@ -157,6 +157,10 @@ func (axfrMod *AxfrLookupModule) GetDescription() string {
 	return ""
 }
 
+func (axfrMod *AxfrLookupModule) GetTrigger() string {
+	return axfrMod.Trigger
+}
+
 // CLIInit initializes the AxfrLookupModule with the given parameters, used to call AXFR from the command line
 func (axfrMod *AxfrLookupModule) CLIInit(gc *cli.CLIConf, rc *zdns.ResolverConfig) error {
 	if gc == nil {

--- a/src/modules/axfr/axfr_test.go
+++ b/src/modules/axfr/axfr_test.go
@@ -121,7 +121,7 @@ func InitTest() (*AxfrLookupModule, *zdns.Resolver) {
 	if err != nil {
 		panic("failed to initialize resolver: " + err.Error())
 	}
-	axfrMod.NSModule.WithTestingLookup(mockNSLookup)
+	axfrMod.nsModule.WithTestingLookup(mockNSLookup)
 	return axfrMod, resolver
 }
 

--- a/src/modules/bindversion/bindversion.go
+++ b/src/modules/bindversion/bindversion.go
@@ -74,6 +74,10 @@ func (bindVersionMod *BindVersionLookupModule) GetDescription() string {
 	return ""
 }
 
+func (bindVersionMod *BindVersionLookupModule) GetTrigger() string {
+	return bindVersionMod.Trigger
+}
+
 func (bindVersionMod *BindVersionLookupModule) Validate(args []string) error {
 	return nil
 }

--- a/src/modules/dmarc/dmarc.go
+++ b/src/modules/dmarc/dmarc.go
@@ -75,6 +75,10 @@ func (dmarcMod *DmarcLookupModule) GetDescription() string {
 	return ""
 }
 
+func (dmarcMod *DmarcLookupModule) GetTrigger() string {
+	return dmarcMod.Trigger
+}
+
 func (dmarcMod *DmarcLookupModule) NewFlags() any {
 	return dmarcMod
 }

--- a/src/modules/mxlookup/mx_lookup.go
+++ b/src/modules/mxlookup/mx_lookup.go
@@ -130,6 +130,10 @@ func (mxMod *MXLookupModule) GetDescription() string {
 	return "MXLOOKUP will additionally do an A lookup for the IP addresses that correspond with an exchange record."
 }
 
+func (mxMod *MXLookupModule) GetTrigger() string {
+	return mxMod.Trigger
+}
+
 func (mxMod *MXLookupModule) NewFlags() any {
 	return mxMod
 }

--- a/src/modules/nslookup/ns_lookup.go
+++ b/src/modules/nslookup/ns_lookup.go
@@ -93,6 +93,10 @@ func (nsMod *NSLookupModule) GetDescription() string {
 	return "Run a more exhaustive ns lookup, will additionally do an A/AAAA lookup for the IP addresses that correspond with name server records."
 }
 
+func (nsMod *NSLookupModule) GetTrigger() string {
+	return nsMod.Trigger
+}
+
 func (nsMod *NSLookupModule) NewFlags() any {
 	return nsMod
 }

--- a/src/modules/spf/spf.go
+++ b/src/modules/spf/spf.go
@@ -78,6 +78,10 @@ func (spfMod *SpfLookupModule) GetDescription() string {
 	return ""
 }
 
+func (spfMod *SpfLookupModule) GetTrigger() string {
+	return spfMod.Trigger
+}
+
 func (spfMod *SpfLookupModule) NewFlags() any {
 	return spfMod
 }

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -888,6 +888,13 @@ class Tests(unittest.TestCase):
                 for mod in ["A", "AAAA"]:
                     self.assertSuccess(res, cmd, mod)
                     self.assertEqual(res["results"][mod]["data"]["resolver"], "1.1.1.1:53")
+            with self.subTest(name="nameserver and trigger without using MULTIPLE module"):
+                name = "zdns-testing.com,1.1.1.1,A,AAAA"
+                c = "A --trigger A"
+                cmd, res = self.run_zdns(c, name)
+                for mod in ["A"]:
+                    self.assertSuccess(res, cmd, mod)
+                    self.assertEqual(res["results"][mod]["data"]["resolver"], "1.1.1.1:53")
 
     def test_cname(self):
         c = "CNAME"

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import json
 import unittest
+import tempfile
 import datetime
 from dateutil import parser
 from ipaddress import ip_address
@@ -831,6 +832,62 @@ class Tests(unittest.TestCase):
         # delete file
         cmd = f"rm {file_name}"
         subprocess.check_output(cmd, shell=True)
+
+    def test_per_module_triggers(self):
+        """Integration test for per-module triggers feature."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create multiple.ini
+            multi_config_path = os.path.join(tmpdir, "multiple.ini")
+            with open(multi_config_path, "w") as f:
+                f.write("""
+                        [Application Options]
+                        iterative=false
+                        prefer-ipv6-iteration="true"
+
+                        [A]
+                        trigger = "A"
+                        [AAAA]
+                        trigger = "AAAA"
+                        [CNAME]
+                        trigger = "CNAME"
+                    """)
+            # ---- Subtests for each domain ----
+            with self.subTest(name="using multiple modules and no trigger"):
+                name = "zdns-testing.com"
+                c = "MULTIPLE -c " + multi_config_path
+                cmd, res = self.run_zdns(c, name)
+                for mod in ["A", "AAAA", "CNAME"]:
+                    self.assertSuccess(res, cmd, mod)
+            with self.subTest(name="Single Trigger"):
+                name = "zdns-testing.com,,A"
+                c = "MULTIPLE -c " + multi_config_path
+                cmd, res = self.run_zdns(c, name)
+                self.assertSuccess(res, cmd, "A")
+                self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd, "A")
+                self.assertEqual(len(res["results"]), 1)
+
+            with self.subTest(name="Multiple Triggers"):
+                name = "zdns-testing.com,,A,CNAME"
+                c = "MULTIPLE -c " + multi_config_path
+                cmd, res = self.run_zdns(c, name)
+                self.assertSuccess(res, cmd, "A")
+                self.assertSuccess(res, cmd, "CNAME")
+                self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd, "A")
+                self.assertEqual(len(res["results"]), 2)
+            with self.subTest(name="nameserver specified and using multiple modules and no trigger"):
+                name = "zdns-testing.com,1.1.1.1"
+                c = "MULTIPLE -c " + multi_config_path
+                cmd, res = self.run_zdns(c, name)
+                for mod in ["A", "AAAA", "CNAME"]:
+                    self.assertSuccess(res, cmd, mod)
+                    self.assertEqual(res["results"][mod]["data"]["resolver"], "1.1.1.1:53")
+            with self.subTest(name="nameserver and trigger"):
+                name = "zdns-testing.com,1.1.1.1,A,AAAA"
+                c = "MULTIPLE -c " + multi_config_path
+                cmd, res = self.run_zdns(c, name)
+                for mod in ["A", "AAAA"]:
+                    self.assertSuccess(res, cmd, mod)
+                    self.assertEqual(res["results"][mod]["data"]["resolver"], "1.1.1.1:53")
 
     def test_cname(self):
         c = "CNAME"

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -839,7 +839,8 @@ class Tests(unittest.TestCase):
             # Create multiple.ini
             multi_config_path = os.path.join(tmpdir, "multiple.ini")
             with open(multi_config_path, "w") as f:
-                f.write("""
+                f.write(
+                    """
                         [Application Options]
                         iterative=false
                         prefer-ipv6-iteration="true"
@@ -850,7 +851,8 @@ class Tests(unittest.TestCase):
                         trigger = "AAAA"
                         [CNAME]
                         trigger = "CNAME"
-                    """)
+                    """
+                )
             # ---- Subtests for each domain ----
             with self.subTest(name="using multiple modules and no trigger"):
                 name = "zdns-testing.com"
@@ -874,27 +876,37 @@ class Tests(unittest.TestCase):
                 self.assertSuccess(res, cmd, "CNAME")
                 self.assertEqualAnswers(res, self.ROOT_A_ANSWERS, cmd, "A")
                 self.assertEqual(len(res["results"]), 2)
-            with self.subTest(name="nameserver specified and using multiple modules and no trigger"):
+            with self.subTest(
+                name="nameserver specified and using multiple modules and no trigger"
+            ):
                 name = "zdns-testing.com,1.1.1.1"
                 c = "MULTIPLE -c " + multi_config_path
                 cmd, res = self.run_zdns(c, name)
                 for mod in ["A", "AAAA", "CNAME"]:
                     self.assertSuccess(res, cmd, mod)
-                    self.assertEqual(res["results"][mod]["data"]["resolver"], "1.1.1.1:53")
+                    self.assertEqual(
+                        res["results"][mod]["data"]["resolver"], "1.1.1.1:53"
+                    )
             with self.subTest(name="nameserver and trigger"):
                 name = "zdns-testing.com,1.1.1.1,A,AAAA"
                 c = "MULTIPLE -c " + multi_config_path
                 cmd, res = self.run_zdns(c, name)
                 for mod in ["A", "AAAA"]:
                     self.assertSuccess(res, cmd, mod)
-                    self.assertEqual(res["results"][mod]["data"]["resolver"], "1.1.1.1:53")
-            with self.subTest(name="nameserver and trigger without using MULTIPLE module"):
+                    self.assertEqual(
+                        res["results"][mod]["data"]["resolver"], "1.1.1.1:53"
+                    )
+            with self.subTest(
+                name="nameserver and trigger without using MULTIPLE module"
+            ):
                 name = "zdns-testing.com,1.1.1.1,A,AAAA"
                 c = "A --trigger A"
                 cmd, res = self.run_zdns(c, name)
                 for mod in ["A"]:
                     self.assertSuccess(res, cmd, mod)
-                    self.assertEqual(res["results"][mod]["data"]["resolver"], "1.1.1.1:53")
+                    self.assertEqual(
+                        res["results"][mod]["data"]["resolver"], "1.1.1.1:53"
+                    )
 
     def test_cname(self):
         c = "CNAME"


### PR DESCRIPTION
Adds ZGrab style triggers to ZDNS so users can query specific names with specific modules as they see fit.

## Input Format
This expands the acceptable new-line delimited input format for ZDNS to include
- `name`
- `name`,`nameserver`
- `name`,`nameserver`,`trigger`
- `name`,`nameserver`,`trigger`,`second-trigger`, etc

## Examples
An example `input.csv` file:
```
example.com,,a-trigger
google.com,,a-trigger,cname-trigger
example.com,1.1.1.1,aaaa-trigger
yahoo.com
apnews.com,1.1.1.1
```

And corresponding `multiple.ini`:
```
; Specify Global Options here
[Application Options]
iterative=true
prefer-ipv6-iteration="true"
; List out modules and their respective module-specific options here. A module can only be listed once
[A]
trigger = "a-trigger"
[AAAA]
trigger = "aaaa-trigger"
[CNAME]
trigger = "cname-trigger"
```

This will lookup:
- `example.com` with the A module using default nameservers
- `google.com` with the A + CNAME modules using default nameservers
- `example.com` with the AAAA module using Cloudflare's 1.1.1.1 resolver
- `yahoo.com` with all modules specified and using default nameservers
- `apnews.com` with all modules specified and using Cloudflare's 1.1.1.1 resolver

## Related Issues
Resolves #571 