### PR TITLE
Fix broken integration test

### DIFF
--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1741,12 +1741,20 @@ class Tests(unittest.TestCase):
     def test_lookup_all_nameservers_multi_zone_iterative(self):
         """
         Test that --all-nameservers lookups work with domains whose nameservers have their nameservers in different zones
-        In this case, example.com has a/b.iana-servers.net as nameservers, which are in the .com zone, but whose nameservers
-        are dig -t NS iana-servers.com -> ns.icann.org, a/b/c.iana-servers.net. This means the .com nameservers will not
-        provide the IPs in the additional section.
+        In this case, tripadvisor.de has nameservers in .com, .net, .org, and .uk, which are of course NOT in the .de zone.
+        This means the nameservers will not provide the IPs in the additional section, and so we'll test that we still
+        resolve correctly by iteratively looking up the nameservers too.
+
+        Example (Note the lack of additionals)
+        $ dig -t A tripadvisor.de @a.nic.de
+        ...
+        AUTHORITY SECTION:
+        tripadvisor.de.		86400	IN	NS	ns-463.awsdns-57.com.
+        tripadvisor.de.		86400	IN	NS	ns-1014.awsdns-62.net.
+        tripadvisor.de.		86400	IN	NS	ns-1296.awsdns-34.org.
+        tripadvisor.de.		86400	IN	NS	ns-1710.awsdns-21.co.uk.
         """
-        # example.com has nameservers in .com, .org, and .net, we'll have to iteratively figure out their IP addresses too
-        c = "A example.com --all-nameservers --iterative --timeout=60"
+        c = "A tripadvisor.de --all-nameservers --iterative --timeout=60"
         cmd, res = self.run_zdns(c, "")
         self.assertSuccess(res, cmd, "A")
         # Check for layers
@@ -1756,25 +1764,15 @@ class Tests(unittest.TestCase):
             "Should have the root (.) layer",
         )
         self.assertIn(
-            "com",
+            "de",
             res["results"]["A"]["data"]["per_layer_responses"],
-            "Should have the .com layer",
+            "Should have the .de layer",
         )
         self.assertIn(
-            "example.com",
+            "tripadvisor.de",
             res["results"]["A"]["data"]["per_layer_responses"],
-            "Should have the example.com layer",
+            "Should have the tripadvisor.de layer",
         )
-        self.check_for_existance_of_root_and_com_nses(res)
-        # check for the example.com nameservers
-        actual_example_nses = []
-        for entry in res["results"]["A"]["data"]["per_layer_responses"]["example.com"]:
-            actual_example_nses.append(entry["nameserver"])
-        expected_example_nses = ["a.iana-servers.net", "b.iana-servers.net"]
-        for ns in expected_example_nses:
-            self.assertIn(
-                ns, actual_example_nses, "Should have the example.com nameservers"
-            )
 
     def test_lookup_all_nameservers_external_lookup(self):
         """


### PR DESCRIPTION
It seems like `example.com` updated their nameservers to use Cloudflare.

```shell
dig -t NS example.com @hera.ns.cloudflare.com                                                                                                                                                                                 ...
;; ANSWER SECTION:
example.com.            86400   IN      NS      elliott.ns.cloudflare.com.
example.com.            86400   IN      NS      hera.ns.cloudflare.com.
```

This breaks the integration test where I wanted to test resolving domains whose nameservers were in a different zone as themselves.

`tripadvisor.de` seems to be a good alternative. Using AWS's DNS, their nameservers sit across 4 zones. I remove explicit checks for what those nameservers are, since I'd imagine that could change with these being cloud DNS providers and I don't want our tests to be brittle.

```shell
$ dig -t A tripadvisor.de @a.nic.de

;; AUTHORITY SECTION:
tripadvisor.de.		86400	IN	NS	ns-1710.awsdns-21.co.uk.
tripadvisor.de.		86400	IN	NS	ns-1014.awsdns-62.net.
tripadvisor.de.		86400	IN	NS	ns-463.awsdns-57.com.
tripadvisor.de.		86400	IN	NS	ns-1296.awsdns-34.org.
```