### PR TITLE
Fixes panic if user provides IPs and we find a loopback IP during iteration

### DIFF
--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -272,6 +272,10 @@ func populateResolverConfig(gc *CLIConf) *zdns.ResolverConfig {
 	if err != nil {
 		log.Fatal("could not populate IP transport mode: ", err)
 	}
+	config, _, err = populateLocalAddresses(gc, config)
+	if err != nil {
+		log.Fatal("could not populate local addresses: ", err)
+	}
 	// This is used in extractAuthorities where we need to know whether to request A or AAAA records to continue iteration
 	// Must be set after populating IPTransportMode
 	if config.IPVersionMode == zdns.IPv4Only {
@@ -373,7 +377,7 @@ func populateIPTransportMode(gc *CLIConf, config *zdns.ResolverConfig) (*zdns.Re
 		log.Infof("user didn't prescribe a specific IP version mode (IPv4/v6), but did provide nameservers. Inferred IP mode - %s", config.IPVersionMode.String())
 		return config, nil
 	}
-	// Check local addressed if provided
+	// Check local addresses if provided
 	var didSet bool
 	config, didSet, err = populateLocalAddresses(gc, config)
 	if err != nil {
@@ -511,6 +515,8 @@ func useNameServerStringToPopulateNameServers(nameServers []string, config *zdns
 	return config, nil
 }
 
+// populateLocalAddresses populates the LocalAddrsV4 and LocalAddrsV6 fields of the ResolverConfig based on the provided CLI arguments.
+// It is idempotent, safe to call multiple times
 func populateLocalAddresses(gc *CLIConf, config *zdns.ResolverConfig) (*zdns.ResolverConfig, bool, error) {
 	// Local Addresses are populated in this order:
 	// 1. If user provided local addresses, use those

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -512,7 +512,6 @@ func useNameServerStringToPopulateNameServers(nameServers []string, config *zdns
 }
 
 // populateLocalAddresses populates the LocalAddrsV4 and LocalAddrsV6 fields of the ResolverConfig based on the provided CLI arguments.
-// It is idempotent, safe to call multiple times
 func populateLocalAddresses(gc *CLIConf, config *zdns.ResolverConfig) (*zdns.ResolverConfig, bool, error) {
 	// Local Addresses are populated in this order:
 	// 1. If user provided local addresses, use those

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -272,10 +272,6 @@ func populateResolverConfig(gc *CLIConf) *zdns.ResolverConfig {
 	if err != nil {
 		log.Fatal("could not populate IP transport mode: ", err)
 	}
-	config, _, err = populateLocalAddresses(gc, config)
-	if err != nil {
-		log.Fatal("could not populate local addresses: ", err)
-	}
 	// This is used in extractAuthorities where we need to know whether to request A or AAAA records to continue iteration
 	// Must be set after populating IPTransportMode
 	if config.IPVersionMode == zdns.IPv4Only {

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -1321,9 +1321,6 @@ func (r *Resolver) iterateOnAuthorities(ctx context.Context, qWithMeta *Question
 
 	// If we get here, all authorities failed
 	r.verboseLog(depth+2, "--> No more authorities to try for name ", qWithMeta.Q.Name, ", terminating")
-	if err != nil {
-		return &SingleQueryResult{}, trace, StatusServFail, fmt.Errorf("no valid nameservers found or all lookups failed, last error: %w", err)
-	}
 	return &SingleQueryResult{}, trace, StatusServFail, errors.New("no valid nameservers found or all lookups failed")
 }
 

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -1265,7 +1265,6 @@ func (r *Resolver) iterateOnAuthorities(ctx context.Context, qWithMeta *Question
 		authorities[i], authorities[j] = authorities[j], authorities[i]
 	})
 
-	var err error
 	for _, elem := range authorities {
 		// Skip DNSSEC records
 		switch elem.(type) {
@@ -1290,8 +1289,7 @@ func (r *Resolver) iterateOnAuthorities(ctx context.Context, qWithMeta *Question
 		}
 
 		if nsStatus != StatusNoError {
-			var err error
-			newStatus, err := handleStatus(nsStatus, err)
+			newStatus, err := handleStatus(nsStatus, nil)
 			if err != nil {
 				r.verboseLog(depth+2, "--> Auth find failed for name ", qWithMeta.Q.Name, " with status: ", newStatus, " and error: ", err)
 			} else {
@@ -1301,9 +1299,7 @@ func (r *Resolver) iterateOnAuthorities(ctx context.Context, qWithMeta *Question
 		}
 
 		// Try iterative lookup immediately with this nameserver
-		var iterateResult *SingleQueryResult
-		var status Status
-		iterateResult, newTrace, status, err = r.iterativeLookup(ctx, qWithMeta, []NameServer{*ns}, depth+1, nextLayer, trace)
+		iterateResult, newTrace, status, err := r.iterativeLookup(ctx, qWithMeta, []NameServer{*ns}, depth+1, nextLayer, trace)
 		trace = newTrace
 
 		if status == StatusNoNeededGlue {

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -740,8 +740,12 @@ func (r *Resolver) cyclingLookup(ctx context.Context, qWithMeta *QuestionWithMet
 			r.verboseLog(depth+1, "Cycling lookup failed - rate limit exceeded and out of retries. Name: ", qWithMeta.Q.Name, ", Layer: ", layer, ", Nameserver: ", nameServer)
 			return result, isCached, status, trace, errors.New("cycling lookup failed - rate limit exceeded and out of retries")
 		} else if *qWithMeta.RetriesRemaining == 0 {
-			r.verboseLog(depth+1, "Cycling lookup failed - out of retries. Name: ", qWithMeta.Q.Name, ", Layer: ", layer, ", Nameserver: ", nameServer)
-			return result, isCached, status, trace, fmt.Errorf("cycling lookup failed - out of retries. Last error: %v", err)
+			if err != nil {
+				r.verboseLog(depth+1, "Cycling lookup failed - out of retries. Name: ", qWithMeta.Q.Name, ", Layer: ", layer, ", Nameserver: ", nameServer, ", Error: ", err)
+			} else {
+				r.verboseLog(depth+1, "Cycling lookup failed - out of retries. Name: ", qWithMeta.Q.Name, ", Layer: ", layer, ", Nameserver: ", nameServer)
+			}
+			return result, isCached, status, trace, fmt.Errorf("cycling lookup failed - out of retries. Last error: %w", err)
 		} else if util.HasCtxExpired(ctx) {
 			r.verboseLog(depth+1, "Cycling lookup failed - context expired. Name: ", qWithMeta.Q.Name, ", Layer: ", layer, ", Nameserver: ", nameServer)
 			return result, isCached, status, trace, errors.New("cycling lookup failed - context expired")
@@ -1261,6 +1265,7 @@ func (r *Resolver) iterateOnAuthorities(ctx context.Context, qWithMeta *Question
 		authorities[i], authorities[j] = authorities[j], authorities[i]
 	})
 
+	var err error
 	for _, elem := range authorities {
 		// Skip DNSSEC records
 		switch elem.(type) {
@@ -1296,7 +1301,9 @@ func (r *Resolver) iterateOnAuthorities(ctx context.Context, qWithMeta *Question
 		}
 
 		// Try iterative lookup immediately with this nameserver
-		iterateResult, newTrace, status, err := r.iterativeLookup(ctx, qWithMeta, []NameServer{*ns}, depth+1, nextLayer, trace)
+		var iterateResult *SingleQueryResult
+		var status Status
+		iterateResult, newTrace, status, err = r.iterativeLookup(ctx, qWithMeta, []NameServer{*ns}, depth+1, nextLayer, trace)
 		trace = newTrace
 
 		if status == StatusNoNeededGlue {
@@ -1314,6 +1321,9 @@ func (r *Resolver) iterateOnAuthorities(ctx context.Context, qWithMeta *Question
 
 	// If we get here, all authorities failed
 	r.verboseLog(depth+2, "--> No more authorities to try for name ", qWithMeta.Q.Name, ", terminating")
+	if err != nil {
+		return &SingleQueryResult{}, trace, StatusServFail, fmt.Errorf("no valid nameservers found or all lookups failed, last error: %w", err)
+	}
 	return &SingleQueryResult{}, trace, StatusServFail, errors.New("no valid nameservers found or all lookups failed")
 }
 

--- a/src/zdns/rate_limit.go
+++ b/src/zdns/rate_limit.go
@@ -22,8 +22,9 @@ import (
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/zmap/zdns/v2/src/internal/util"
 	"golang.org/x/time/rate"
+
+	"github.com/zmap/zdns/v2/src/internal/util"
 )
 
 const rateLimitTTL = time.Second * 15

--- a/src/zdns/rate_limit.go
+++ b/src/zdns/rate_limit.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/zmap/zdns/v2/src/internal/util"
 	"golang.org/x/time/rate"
 )
 
@@ -101,6 +102,9 @@ func (l *PerIPPerNameNSRateLimiter) getReservations(ns NameServer) (perIPReserva
 }
 
 func (l *PerIPPerNameNSRateLimiter) wait(ctx context.Context, ns NameServer) error {
+	if util.HasCtxExpired(ctx) {
+		return errors.New("context has already expired before waiting on rate limiter")
+	}
 
 	ipReservation, nameReservation, err := l.getReservations(ns)
 	if err != nil {

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -446,16 +446,16 @@ func InitResolver(config *ResolverConfig) (*Resolver, error) {
 func (r *Resolver) getConnectionInfo(nameServer *NameServer) (*ConnectionInfo, error) {
 	// what local addresses should we use?
 	isNSIPv6 := util.IsIPv6(&nameServer.IP)
-	isLoopback := nameServer.IP.IsLoopback()
+	isNSLoopback := nameServer.IP.IsLoopback()
 	// check if we have a pre-existing udpConn info
 	var existingConnInfo *ConnectionInfo
-	if isNSIPv6 && isLoopback && r.connInfoIPv6Loopback != nil {
+	if isNSIPv6 && isNSLoopback && r.connInfoIPv6Loopback != nil {
 		existingConnInfo = r.connInfoIPv6Loopback
-	} else if isNSIPv6 && !isLoopback && r.connInfoIPv6Internet != nil {
+	} else if isNSIPv6 && !isNSLoopback && r.connInfoIPv6Internet != nil {
 		existingConnInfo = r.connInfoIPv6Internet
-	} else if !isNSIPv6 && isLoopback && r.connInfoIPv4Loopback != nil {
+	} else if !isNSIPv6 && isNSLoopback && r.connInfoIPv4Loopback != nil {
 		existingConnInfo = r.connInfoIPv4Loopback
-	} else if !isNSIPv6 && !isLoopback && r.connInfoIPv4Internet != nil {
+	} else if !isNSIPv6 && !isNSLoopback && r.connInfoIPv4Internet != nil {
 		// must be IPv4 non-loopback
 		existingConnInfo = r.connInfoIPv4Internet
 	}
@@ -490,7 +490,7 @@ func (r *Resolver) getConnectionInfo(nameServer *NameServer) (*ConnectionInfo, e
 	})
 	var localAddr *net.IP
 	for _, ip := range userIPs {
-		if isLoopback == ip.IsLoopback() {
+		if isNSLoopback == ip.IsLoopback() {
 			localAddr = &ip
 			break
 		}
@@ -498,10 +498,10 @@ func (r *Resolver) getConnectionInfo(nameServer *NameServer) (*ConnectionInfo, e
 
 	if localAddr == nil {
 		// none of the user-supplied IPs match the conditions, we need to select one
-		if isLoopback && isNSIPv6 {
+		if isNSLoopback && isNSIPv6 {
 			ip := net.ParseIP(DefaultLoopbackIPv6Addr)
 			localAddr = &ip
-		} else if isLoopback {
+		} else if isNSLoopback {
 			ip := net.ParseIP(DefaultLoopbackIPv4Addr)
 			localAddr = &ip
 		} else {
@@ -519,21 +519,22 @@ func (r *Resolver) getConnectionInfo(nameServer *NameServer) (*ConnectionInfo, e
 
 			// cleanup socket
 			if err = conn.Close(); err != nil {
-				log.Error("unable to close test connection to Google public DNS: ", err)
+				log.Error("unable to close test connection to nameserver: ", err)
 			}
 		}
 		if localAddr != nil {
 			if (len(r.userPreferredIPv4LocalAddrs) > 0 && localAddr.To4() != nil) || (len(r.userPreferredIPv6LocalAddrs) > 0 && util.IsIPv6(localAddr)) {
 				// the user provided a local addr. explicitly that won't work, error
-				log.Fatalf("none of the user-supplied local addresses (%v) could connect to name server %s", userIPs, nameServer.String())
-			} else {
-				// user didn't explicitly provide a local addr, this is just a default. Info level so as not to alarm the user
-				log.Infof("none of the default local addresses could connect to name server %s, using local address %s", nameServer.String(), localAddr.String())
+				// In rare cases, a NS for a name can point at a local address. While obviously not resolveable, we shouldn't kill the ZDNS process.
+				// Return an error and move on
+				return nil, fmt.Errorf("none of the user-supplied local addresses (%v) could connect to name server %s", userIPs, nameServer.String())
 			}
+			// user didn't explicitly provide a local addr, this is just a default. Info level so as not to alarm the user
+			log.Infof("none of the default local addresses could connect to name server %s, using local address %s", nameServer.String(), localAddr.String())
 		}
 	}
 	if localAddr == nil {
-		return nil, errors.New("unable to find local address for connection")
+		return nil, fmt.Errorf("unable to find local address for connection to nameserver %s", nameServer.String())
 	}
 	connInfo := &ConnectionInfo{
 		localAddr: *localAddr,
@@ -627,11 +628,11 @@ func (r *Resolver) getConnectionInfo(nameServer *NameServer) (*ConnectionInfo, e
 		}
 	}
 	// save the connection info for future use
-	if isNSIPv6 && isLoopback {
+	if isNSIPv6 && isNSLoopback {
 		r.connInfoIPv6Loopback = connInfo
 	} else if isNSIPv6 {
 		r.connInfoIPv6Internet = connInfo
-	} else if isLoopback {
+	} else if isNSLoopback {
 		r.connInfoIPv4Loopback = connInfo
 	} else {
 		r.connInfoIPv4Internet = connInfo


### PR DESCRIPTION
See problem description and root cause in #593, copied below for convenience

Changes
- downgrades the error from `log.Fatal` to an error for that lookup if user provides local address and we can't connect to the nameserver because it's "loopback-ness" doesn't match

## Testing
Using the domain the opener provided:

On `main`: (well, I checked out a few commits ago since the regression discussed in #608 caused `--local-addr` to be ignored
```shell
⋊> ~/zdns on f4205b5  echo "snowplowingandremoval.com" | ./zdns NS --retries=0 --name-servers="192.41.162.30" --iterative --retries=0 --local-addr=192.168.0.203                                                                                              17:08:27
FATA[0000] none of the user-supplied local addresses ([192.168.0.203]) could connect to name server 127.0.0.1:53 
(venv) ⋊> ~/zdns on f4205b5  
```

This fix
```shell
 ⋊> ~/zdns on phillip/593-no-local-addresses-can-connect ◦ echo "snowplowingandremoval.com" | ./zdns NS --retries=0 --name-servers="192.41.162.30" --iterative --retries=0 --local-addr=XXXX                                                       ...
{"name":"snowplowingandremoval.com","results":{"NS":{"data":{"protocol":"","resolver":""},"duration":9.658489917,"error":"no valid nameservers found or all lookups failed","status":"SERVFAIL","timestamp":"2026-05-28T17:06:21+12:00"}}}
00h:00m:10s; 1 names scanned; 0.10 names/sec; 0.0% success rate; SERVFAIL: 1
00h:00m:10s; Scan Complete; 1 names scanned; 0.09 names/sec; 0.0% success rate; SERVFAIL: 1
(venv) ⋊> ~/zdns on phillip/593-no-local-addresses-can-connect ◦ 
```


## Resolved Issues
Closes #593 

## Root Cause

Hey @cpack299, apologies for the delay in getting back to you on this.

I'm able to reproduce and have a pretty good idea what's going on here. 

### Root Cause
So as your non-`--iterative` mode shows, `snowplowingandremoval.com` has 2 NS servers

```shell
⋊> ~/zdns on main ◦ dig -t NS snowplowingandremoval.com @192.41.162.30                                                                                                                                                                    ...

;; AUTHORITY SECTION:
snowplowingandremoval.com. 172800 IN	NS	ns1.squareserver.net.deleted.gandi.net.
snowplowingandremoval.com. 172800 IN	NS	ns2.squareserver.net.deleted.gandi.net.
```

The issue arrises because both of these nameservers resolve to _local_ IP addresses.
```shell
⋊> ~/◦ dig -t A ns1.squareserver.net.deleted.gandi.net                                                                                                                                                                       ...
;; ANSWER SECTION:
ns1.squareserver.net.deleted.gandi.net.	85846 IN A 127.0.0.1


⋊> ~/ ◦ dig -t A ns2.squareserver.net.deleted.gandi.net                                                                                                                                                                      
...
;; ANSWER SECTION:
ns2.squareserver.net.deleted.gandi.net.	85832 IN A 127.0.0.1
```

When resolving any query in `--iterative`, once we find the nameservers from the `.com` authoritative servers, we query the nameservers (`ns1./ns2.squareserver.net.deleted.gandi.net`) directly for what the nameservers for this name are.

And since you provided a local address to ZDNS, it complains it can't reach that local address.

I added that `FATAL: none of the user-supplied local addresses ([10.134.52.42]) could connect to name server 127.0.0.1:53` to defend against users' supplying nameservers and local IPs that couldn't reach each other in which case we should abort and let them try a different configuration. However, obviously in this case the mismatch came from the resolution directly and aborting leads to a horrible UX as you pointed out.

`dig` will timeout when resolving this with `+trace`, Cloudflare returns a `SERVFAIL` and Google a `REFUSED`. 

```shell
⋊> ~/zdns on main ◦ dig "snowplowingandremoval.com" @1.1.1.1                                                                                                                                                                              ...
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 44416
...
```
```shell
⋊> ~/zdns on main ◦ dig "snowplowingandremoval.com" @8.8.8.8                                                                                                                                                                    ...
;; ->>HEADER<<- opcode: QUERY, status: REFUSED, id: 50408
```
```shell
⋊> ~/zdns on main ◦ dig -t NS snowplowingandremoval.com +trace                                                                                                                                                                            ...
;; Received 1185 bytes from 199.7.91.13#53(d.root-servers.net) in 21 ms

snowplowingandremoval.com. 172800 IN	NS	ns1.squareserver.net.deleted.gandi.net.
snowplowingandremoval.com. 172800 IN	NS	ns2.squareserver.net.deleted.gandi.net.
...

;; connection timed out; no servers could be reached
```

### Proposed Fix
We should just do validation of the `--local-addr` and `--nameservers` at startup and if we run into an issue like this, we should just abort with an error.
I'll also take a quick look for any other `log.Fatal` since those should really only happen at startup.
