### PR TITLE
fix - fixes a regression where --local-addr was ignored when --name-servers provided

### DIFF
--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -272,6 +272,10 @@ func populateResolverConfig(gc *CLIConf) *zdns.ResolverConfig {
 	if err != nil {
 		log.Fatal("could not populate IP transport mode: ", err)
 	}
+	config, _, err = populateLocalAddresses(gc, config)
+	if err != nil {
+		log.Fatal("could not populate local addresses: ", err)
+	}
 	// This is used in extractAuthorities where we need to know whether to request A or AAAA records to continue iteration
 	// Must be set after populating IPTransportMode
 	if config.IPVersionMode == zdns.IPv4Only {
@@ -511,6 +515,8 @@ func useNameServerStringToPopulateNameServers(nameServers []string, config *zdns
 	return config, nil
 }
 
+// populateLocalAddresses takes the local addr string from the CLI and splits it into IPv4 and v6 local addrs
+// Idempotent - it is safe to call repeatedly
 func populateLocalAddresses(gc *CLIConf, config *zdns.ResolverConfig) (*zdns.ResolverConfig, bool, error) {
 	// Local Addresses are populated in this order:
 	// 1. If user provided local addresses, use those

--- a/src/cli/worker_manager_test.go
+++ b/src/cli/worker_manager_test.go
@@ -282,13 +282,17 @@ func TestPopulateResolverConfig(t *testing.T) {
 
 	t.Run("IPVersionMode from --4/--6 flags", func(t *testing.T) {
 		tests := []struct {
-			name                string
-			ipv4Only            bool
-			ipv6Only            bool
-			nameServers         []string
-			nameServersString   string
-			wantIPVersionMode   zdns.IPVersionMode
-			wantIterPref        zdns.IterationIPPreference
+			name              string
+			ipv4Only          bool
+			ipv6Only          bool
+			nameServers       []string
+			nameServersString string
+			wantIPVersionMode zdns.IPVersionMode
+			wantIterPref      zdns.IterationIPPreference
+			wantV4NSes        []string // IPs expected in External/RootNameServersV4; nil means don't check
+			wantV6NSes        []string // IPs expected in External/RootNameServersV6; nil means don't check
+			wantV4Empty       bool
+			wantV6Empty       bool
 		}{
 			{
 				name:              "--4 forces IPv4Only regardless of nameserver family",
@@ -297,6 +301,8 @@ func TestPopulateResolverConfig(t *testing.T) {
 				nameServersString: ipv4NS,
 				wantIPVersionMode: zdns.IPv4Only,
 				wantIterPref:      zdns.PreferIPv4,
+				wantV4NSes:        []string{ipv4NS},
+				wantV6Empty:       true,
 			},
 			{
 				name:              "--6 forces IPv6Only regardless of nameserver family",
@@ -305,6 +311,8 @@ func TestPopulateResolverConfig(t *testing.T) {
 				nameServersString: ipv6NS,
 				wantIPVersionMode: zdns.IPv6Only,
 				wantIterPref:      zdns.PreferIPv6,
+				wantV6NSes:        []string{ipv6NS},
+				wantV4Empty:       true,
 			},
 			{
 				name:              "--4 with mixed nameservers drops IPv6 nameservers",
@@ -313,6 +321,8 @@ func TestPopulateResolverConfig(t *testing.T) {
 				nameServersString: ipv4NS + "," + ipv6NS,
 				wantIPVersionMode: zdns.IPv4Only,
 				wantIterPref:      zdns.PreferIPv4,
+				wantV4NSes:        []string{ipv4NS},
+				wantV6Empty:       true,
 			},
 			{
 				name:              "--6 with mixed nameservers drops IPv4 nameservers",
@@ -321,6 +331,8 @@ func TestPopulateResolverConfig(t *testing.T) {
 				nameServersString: ipv4NS + "," + ipv6NS,
 				wantIPVersionMode: zdns.IPv6Only,
 				wantIterPref:      zdns.PreferIPv6,
+				wantV6NSes:        []string{ipv6NS},
+				wantV4Empty:       true,
 			},
 		}
 		for _, tt := range tests {
@@ -333,6 +345,20 @@ func TestPopulateResolverConfig(t *testing.T) {
 				config := populateResolverConfig(&gc)
 				assert.Equal(t, tt.wantIPVersionMode, config.IPVersionMode)
 				assert.Equal(t, tt.wantIterPref, config.IterationIPPreference)
+				if tt.wantV4Empty {
+					assert.Empty(t, config.ExternalNameServersV4, "ExternalNameServersV4 should be empty")
+					assert.Empty(t, config.RootNameServersV4, "RootNameServersV4 should be empty")
+				} else if tt.wantV4NSes != nil {
+					requireNSIPs(t, config.ExternalNameServersV4, tt.wantV4NSes, "ExternalNameServersV4")
+					requireNSIPs(t, config.RootNameServersV4, tt.wantV4NSes, "RootNameServersV4")
+				}
+				if tt.wantV6Empty {
+					assert.Empty(t, config.ExternalNameServersV6, "ExternalNameServersV6 should be empty")
+					assert.Empty(t, config.RootNameServersV6, "RootNameServersV6 should be empty")
+				} else if tt.wantV6NSes != nil {
+					requireNSIPs(t, config.ExternalNameServersV6, tt.wantV6NSes, "ExternalNameServersV6")
+					requireNSIPs(t, config.RootNameServersV6, tt.wantV6NSes, "RootNameServersV6")
+				}
 			})
 		}
 	})
@@ -435,9 +461,6 @@ func TestPopulateResolverConfig(t *testing.T) {
 	})
 
 	t.Run("local addresses populated when nameservers also provided", func(t *testing.T) {
-		// These cases expose the regression: populateIPTransportMode returns early when
-		// nameservers are given, bypassing the populateLocalAddresses call. LocalAddrsV4
-		// and LocalAddrsV6 are therefore never written into the ResolverConfig.
 		tests := []struct {
 			name              string
 			nameServers       []string

--- a/src/cli/worker_manager_test.go
+++ b/src/cli/worker_manager_test.go
@@ -16,8 +16,11 @@ package cli
 
 import (
 	"fmt"
+	"net"
+	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/zmap/zdns/v2/src/zdns"
@@ -216,5 +219,425 @@ func TestParseNormalInputLine(t *testing.T) {
 			require.Equal(t, test.expectedNS, ns)
 			require.Equal(t, test.expectedTriggers, triggers)
 		})
+	}
+}
+
+// writeTempResolvConf writes a resolv.conf-style file with the given nameservers and
+// returns its path. The file is cleaned up when the test ends.
+func writeTempResolvConf(t *testing.T, nameservers ...string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "resolv.conf")
+	require.NoError(t, err)
+	for _, ns := range nameservers {
+		_, err = fmt.Fprintf(f, "nameserver %s\n", ns)
+		require.NoError(t, err)
+	}
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+// baseConf returns a CLIConf with sensible non-zero defaults so populateResolverConfig
+// does not hit log.Fatal on missing required fields. Individual tests override specific
+// fields to exercise the behavior under test.
+func baseConf(t *testing.T) CLIConf {
+	t.Helper()
+	return CLIConf{
+		GeneralOptions: GeneralOptions{
+			Timeout:          20,
+			NetworkTimeout:   2,
+			IterationTimeout: 8,
+			Retries:          3,
+			MaxDepth:         10,
+			CacheSize:        100,
+		},
+		InputOutputOptions: InputOutputOptions{
+			// Provide a resolv.conf with a known IPv4 address so tests that do not
+			// supply name servers or local addresses get a deterministic IP mode.
+			DNSConfigFilePath: writeTempResolvConf(t, "1.1.1.1"),
+			Verbosity:         3,
+		},
+	}
+}
+
+// mustParseIP panics if the string is not a valid IP. Only used in test setup.
+func mustParseIP(s string) net.IP {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		panic("invalid IP in test: " + s)
+	}
+	return ip
+}
+
+func TestPopulateResolverConfig(t *testing.T) {
+	const (
+		ipv4NS  = "1.1.1.1"
+		ipv4NS2 = "8.8.8.8"
+		ipv6NS  = "2606:4700:4700::1111"
+		ipv6NS2 = "2001:4860:4860::8888"
+
+		localIPv4  = "192.168.1.5"
+		localIPv6  = "fd00::1"
+		localIPv42 = "10.0.0.1"
+	)
+
+	t.Run("IPVersionMode from --4/--6 flags", func(t *testing.T) {
+		tests := []struct {
+			name                string
+			ipv4Only            bool
+			ipv6Only            bool
+			nameServers         []string
+			nameServersString   string
+			wantIPVersionMode   zdns.IPVersionMode
+			wantIterPref        zdns.IterationIPPreference
+		}{
+			{
+				name:              "--4 forces IPv4Only regardless of nameserver family",
+				ipv4Only:          true,
+				nameServers:       []string{ipv4NS},
+				nameServersString: ipv4NS,
+				wantIPVersionMode: zdns.IPv4Only,
+				wantIterPref:      zdns.PreferIPv4,
+			},
+			{
+				name:              "--6 forces IPv6Only regardless of nameserver family",
+				ipv6Only:          true,
+				nameServers:       []string{ipv6NS},
+				nameServersString: ipv6NS,
+				wantIPVersionMode: zdns.IPv6Only,
+				wantIterPref:      zdns.PreferIPv6,
+			},
+			{
+				name:              "--4 with mixed nameservers drops IPv6 nameservers",
+				ipv4Only:          true,
+				nameServers:       []string{ipv4NS, ipv6NS},
+				nameServersString: ipv4NS + "," + ipv6NS,
+				wantIPVersionMode: zdns.IPv4Only,
+				wantIterPref:      zdns.PreferIPv4,
+			},
+			{
+				name:              "--6 with mixed nameservers drops IPv4 nameservers",
+				ipv6Only:          true,
+				nameServers:       []string{ipv4NS, ipv6NS},
+				nameServersString: ipv4NS + "," + ipv6NS,
+				wantIPVersionMode: zdns.IPv6Only,
+				wantIterPref:      zdns.PreferIPv6,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				gc := baseConf(t)
+				gc.IPv4TransportOnly = tt.ipv4Only
+				gc.IPv6TransportOnly = tt.ipv6Only
+				gc.NameServers = tt.nameServers
+				gc.NameServersString = tt.nameServersString
+				config := populateResolverConfig(&gc)
+				assert.Equal(t, tt.wantIPVersionMode, config.IPVersionMode)
+				assert.Equal(t, tt.wantIterPref, config.IterationIPPreference)
+			})
+		}
+	})
+
+	t.Run("IPVersionMode inferred from nameserver addresses", func(t *testing.T) {
+		tests := []struct {
+			name              string
+			nameServers       []string
+			nameServersString string
+			wantIPVersionMode zdns.IPVersionMode
+			wantIterPref      zdns.IterationIPPreference
+		}{
+			{
+				name:              "IPv4-only nameservers infer IPv4Only",
+				nameServers:       []string{ipv4NS, ipv4NS2},
+				nameServersString: ipv4NS + "," + ipv4NS2,
+				wantIPVersionMode: zdns.IPv4Only,
+				wantIterPref:      zdns.PreferIPv4,
+			},
+			{
+				name:              "IPv6-only nameservers infer IPv6Only",
+				nameServers:       []string{ipv6NS, ipv6NS2},
+				nameServersString: ipv6NS + "," + ipv6NS2,
+				wantIPVersionMode: zdns.IPv6Only,
+				wantIterPref:      zdns.PreferIPv6,
+			},
+			{
+				name:              "mixed IPv4 and IPv6 nameservers infer IPv4OrIPv6",
+				nameServers:       []string{ipv4NS, ipv6NS},
+				nameServersString: ipv4NS + "," + ipv6NS,
+				wantIPVersionMode: zdns.IPv4OrIPv6,
+				wantIterPref:      zdns.NoPreference,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				gc := baseConf(t)
+				gc.NameServers = tt.nameServers
+				gc.NameServersString = tt.nameServersString
+				config := populateResolverConfig(&gc)
+				assert.Equal(t, tt.wantIPVersionMode, config.IPVersionMode)
+				assert.Equal(t, tt.wantIterPref, config.IterationIPPreference)
+			})
+		}
+	})
+
+	t.Run("IPVersionMode inferred from local addresses when no nameservers provided", func(t *testing.T) {
+		tests := []struct {
+			name              string
+			localAddrs        []net.IP
+			wantIPVersionMode zdns.IPVersionMode
+			wantIterPref      zdns.IterationIPPreference
+			wantLocalAddrsV4  []net.IP
+			wantLocalAddrsV6  []net.IP
+		}{
+			{
+				name:              "IPv4 local addr infers IPv4Only and populates LocalAddrsV4",
+				localAddrs:        []net.IP{mustParseIP(localIPv4)},
+				wantIPVersionMode: zdns.IPv4Only,
+				wantIterPref:      zdns.PreferIPv4,
+				wantLocalAddrsV4:  []net.IP{mustParseIP(localIPv4)},
+				wantLocalAddrsV6:  []net.IP{},
+			},
+			{
+				name:              "IPv6 local addr infers IPv6Only and populates LocalAddrsV6",
+				localAddrs:        []net.IP{mustParseIP(localIPv6)},
+				wantIPVersionMode: zdns.IPv6Only,
+				wantIterPref:      zdns.PreferIPv6,
+				wantLocalAddrsV4:  []net.IP{},
+				wantLocalAddrsV6:  []net.IP{mustParseIP(localIPv6)},
+			},
+			{
+				name:              "mixed local addrs infer IPv4OrIPv6 and populate both lists",
+				localAddrs:        []net.IP{mustParseIP(localIPv4), mustParseIP(localIPv6)},
+				wantIPVersionMode: zdns.IPv4OrIPv6,
+				wantIterPref:      zdns.NoPreference,
+				wantLocalAddrsV4:  []net.IP{mustParseIP(localIPv4)},
+				wantLocalAddrsV6:  []net.IP{mustParseIP(localIPv6)},
+			},
+			{
+				name:              "multiple IPv4 local addrs all stored in LocalAddrsV4",
+				localAddrs:        []net.IP{mustParseIP(localIPv4), mustParseIP(localIPv42)},
+				wantIPVersionMode: zdns.IPv4Only,
+				wantIterPref:      zdns.PreferIPv4,
+				wantLocalAddrsV4:  []net.IP{mustParseIP(localIPv4), mustParseIP(localIPv42)},
+				wantLocalAddrsV6:  []net.IP{},
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				gc := baseConf(t)
+				gc.LocalAddrs = tt.localAddrs
+				config := populateResolverConfig(&gc)
+				assert.Equal(t, tt.wantIPVersionMode, config.IPVersionMode)
+				assert.Equal(t, tt.wantIterPref, config.IterationIPPreference)
+				assert.Equal(t, tt.wantLocalAddrsV4, config.LocalAddrsV4)
+				assert.Equal(t, tt.wantLocalAddrsV6, config.LocalAddrsV6)
+			})
+		}
+	})
+
+	t.Run("local addresses populated when nameservers also provided", func(t *testing.T) {
+		// These cases expose the regression: populateIPTransportMode returns early when
+		// nameservers are given, bypassing the populateLocalAddresses call. LocalAddrsV4
+		// and LocalAddrsV6 are therefore never written into the ResolverConfig.
+		tests := []struct {
+			name              string
+			nameServers       []string
+			nameServersString string
+			localAddrs        []net.IP
+			wantLocalAddrsV4  []net.IP
+			wantLocalAddrsV6  []net.IP
+		}{
+			{
+				name:              "IPv4 local addr is propagated when IPv4 nameservers are also set",
+				nameServers:       []string{ipv4NS},
+				nameServersString: ipv4NS,
+				localAddrs:        []net.IP{mustParseIP(localIPv4)},
+				wantLocalAddrsV4:  []net.IP{mustParseIP(localIPv4)},
+				wantLocalAddrsV6:  []net.IP{},
+			},
+			{
+				name:              "IPv6 local addr is propagated when IPv6 nameservers are also set",
+				nameServers:       []string{ipv6NS},
+				nameServersString: ipv6NS,
+				localAddrs:        []net.IP{mustParseIP(localIPv6)},
+				wantLocalAddrsV4:  []net.IP{},
+				wantLocalAddrsV6:  []net.IP{mustParseIP(localIPv6)},
+			},
+			{
+				name:              "mixed local addrs are propagated when mixed nameservers are also set",
+				nameServers:       []string{ipv4NS, ipv6NS},
+				nameServersString: ipv4NS + "," + ipv6NS,
+				localAddrs:        []net.IP{mustParseIP(localIPv4), mustParseIP(localIPv6)},
+				wantLocalAddrsV4:  []net.IP{mustParseIP(localIPv4)},
+				wantLocalAddrsV6:  []net.IP{mustParseIP(localIPv6)},
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				gc := baseConf(t)
+				gc.NameServers = tt.nameServers
+				gc.NameServersString = tt.nameServersString
+				gc.LocalAddrs = tt.localAddrs
+				config := populateResolverConfig(&gc)
+				// These assertions currently fail due to the regression in
+				// populateIPTransportMode: when nameservers are provided the function
+				// returns early, skipping the populateLocalAddresses call.
+				assert.Equal(t, tt.wantLocalAddrsV4, config.LocalAddrsV4, "LocalAddrsV4")
+				assert.Equal(t, tt.wantLocalAddrsV6, config.LocalAddrsV6, "LocalAddrsV6")
+			})
+		}
+	})
+
+	t.Run("IterationIPPreference with prefer flags", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			preferIPv4       bool
+			preferIPv6       bool
+			nameServers      []string
+			nameServersString string
+			wantIterPref     zdns.IterationIPPreference
+		}{
+			{
+				name:              "--prefer-ipv4-iteration with mixed nameservers sets PreferIPv4",
+				preferIPv4:        true,
+				nameServers:       []string{ipv4NS, ipv6NS},
+				nameServersString: ipv4NS + "," + ipv6NS,
+				wantIterPref:      zdns.PreferIPv4,
+			},
+			{
+				name:              "--prefer-ipv6-iteration with mixed nameservers sets PreferIPv6",
+				preferIPv6:        true,
+				nameServers:       []string{ipv4NS, ipv6NS},
+				nameServersString: ipv4NS + "," + ipv6NS,
+				wantIterPref:      zdns.PreferIPv6,
+			},
+			{
+				name:              "no preference flag with mixed nameservers sets NoPreference",
+				nameServers:       []string{ipv4NS, ipv6NS},
+				nameServersString: ipv4NS + "," + ipv6NS,
+				wantIterPref:      zdns.NoPreference,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				gc := baseConf(t)
+				gc.PreferIPv4Iteration = tt.preferIPv4
+				gc.PreferIPv6Iteration = tt.preferIPv6
+				gc.NameServers = tt.nameServers
+				gc.NameServersString = tt.nameServersString
+				config := populateResolverConfig(&gc)
+				assert.Equal(t, tt.wantIterPref, config.IterationIPPreference)
+			})
+		}
+	})
+
+	t.Run("nameserver lists populated correctly from user-provided nameservers", func(t *testing.T) {
+		tests := []struct {
+			name              string
+			ipv4Only          bool
+			ipv6Only          bool
+			nameServers       []string
+			nameServersString string
+			wantV4NSes        []string // expected ExternalNameServersV4 IPs
+			wantV6NSes        []string // expected ExternalNameServersV6 IPs
+			wantV4Empty       bool     // ExternalNameServersV4 should be empty
+			wantV6Empty       bool     // ExternalNameServersV6 should be empty
+		}{
+			{
+				name:              "IPv4 nameserver populates ExternalNameServersV4 and RootNameServersV4",
+				nameServers:       []string{ipv4NS},
+				nameServersString: ipv4NS,
+				wantV4NSes:        []string{ipv4NS},
+				wantV6Empty:       true,
+			},
+			{
+				name:              "IPv6 nameserver populates ExternalNameServersV6 and RootNameServersV6",
+				nameServers:       []string{ipv6NS},
+				nameServersString: ipv6NS,
+				wantV6NSes:        []string{ipv6NS},
+				wantV4Empty:       true,
+			},
+			{
+				name:              "mixed nameservers populate both V4 and V6 lists",
+				nameServers:       []string{ipv4NS, ipv6NS},
+				nameServersString: ipv4NS + "," + ipv6NS,
+				wantV4NSes:        []string{ipv4NS},
+				wantV6NSes:        []string{ipv6NS},
+			},
+			{
+				name:              "--4 drops IPv6 nameservers from ExternalNameServersV6",
+				ipv4Only:          true,
+				nameServers:       []string{ipv4NS, ipv6NS},
+				nameServersString: ipv4NS + "," + ipv6NS,
+				wantV4NSes:        []string{ipv4NS},
+				wantV6Empty:       true,
+			},
+			{
+				name:              "--6 drops IPv4 nameservers from ExternalNameServersV4",
+				ipv6Only:          true,
+				nameServers:       []string{ipv4NS, ipv6NS},
+				nameServersString: ipv4NS + "," + ipv6NS,
+				wantV6NSes:        []string{ipv6NS},
+				wantV4Empty:       true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				gc := baseConf(t)
+				gc.IPv4TransportOnly = tt.ipv4Only
+				gc.IPv6TransportOnly = tt.ipv6Only
+				gc.NameServers = tt.nameServers
+				gc.NameServersString = tt.nameServersString
+				config := populateResolverConfig(&gc)
+
+				if tt.wantV4Empty {
+					assert.Empty(t, config.ExternalNameServersV4, "ExternalNameServersV4 should be empty")
+					assert.Empty(t, config.RootNameServersV4, "RootNameServersV4 should be empty")
+				} else if tt.wantV4NSes != nil {
+					requireNSIPs(t, config.ExternalNameServersV4, tt.wantV4NSes, "ExternalNameServersV4")
+					requireNSIPs(t, config.RootNameServersV4, tt.wantV4NSes, "RootNameServersV4")
+				}
+
+				if tt.wantV6Empty {
+					assert.Empty(t, config.ExternalNameServersV6, "ExternalNameServersV6 should be empty")
+					assert.Empty(t, config.RootNameServersV6, "RootNameServersV6 should be empty")
+				} else if tt.wantV6NSes != nil {
+					requireNSIPs(t, config.ExternalNameServersV6, tt.wantV6NSes, "ExternalNameServersV6")
+					requireNSIPs(t, config.RootNameServersV6, tt.wantV6NSes, "RootNameServersV6")
+				}
+			})
+		}
+	})
+
+	t.Run("iterative resolution uses root servers when no nameservers provided", func(t *testing.T) {
+		gc := baseConf(t)
+		gc.IPv4TransportOnly = true // avoid resolv.conf dependency for IP mode detection
+		gc.IterativeResolution = true
+		config := populateResolverConfig(&gc)
+		assert.Equal(t, zdns.RootServersV4[:], config.ExternalNameServersV4)
+		assert.Equal(t, zdns.RootServersV4[:], config.RootNameServersV4)
+	})
+
+	t.Run("non-iterative resolution reads nameservers from resolv.conf when none provided", func(t *testing.T) {
+		confFile := writeTempResolvConf(t, ipv4NS)
+		gc := baseConf(t)
+		gc.DNSConfigFilePath = confFile
+		config := populateResolverConfig(&gc)
+		assert.Equal(t, zdns.IPv4Only, config.IPVersionMode)
+		requireNSIPs(t, config.ExternalNameServersV4, []string{ipv4NS}, "ExternalNameServersV4")
+		requireNSIPs(t, config.RootNameServersV4, []string{ipv4NS}, "RootNameServersV4")
+	})
+}
+
+// requireNSIPs asserts that the given nameserver list contains exactly the given IPs (order-independent).
+func requireNSIPs(t *testing.T, actual []zdns.NameServer, wantIPs []string, label string) {
+	t.Helper()
+	require.Len(t, actual, len(wantIPs), "%s: expected %d nameserver(s), got %d", label, len(wantIPs), len(actual))
+	actualIPs := make(map[string]struct{}, len(actual))
+	for _, ns := range actual {
+		actualIPs[ns.IP.String()] = struct{}{}
+	}
+	for _, ip := range wantIPs {
+		_, ok := actualIPs[ip]
+		assert.True(t, ok, "%s: expected IP %s not found in actual list", label, ip)
 	}
 }

--- a/src/cli/worker_manager_test.go
+++ b/src/cli/worker_manager_test.go
@@ -512,12 +512,12 @@ func TestPopulateResolverConfig(t *testing.T) {
 
 	t.Run("IterationIPPreference with prefer flags", func(t *testing.T) {
 		tests := []struct {
-			name             string
-			preferIPv4       bool
-			preferIPv6       bool
-			nameServers      []string
+			name              string
+			preferIPv4        bool
+			preferIPv6        bool
+			nameServers       []string
 			nameServersString string
-			wantIterPref     zdns.IterationIPPreference
+			wantIterPref      zdns.IterationIPPreference
 		}{
 			{
 				name:              "--prefer-ipv4-iteration with mixed nameservers sets PreferIPv4",


### PR DESCRIPTION
While testing #607, I realized that I had introduced a regression in behavior in #604 where if a user provides `--name-servers`, we ignored their `--local-addr` preferences.

The root cause was I moved `populateLocalAddresses()` within `populateIPTransportMode()` since what IP version a local address is is one of the criteria we use to decide on IPv4/IPv6 behavior.

However, there was a path that exited `populateIPTransportMode()` early (if the user provided `--name-servers`, hence the bug), resulting in the local address being ignored.

## Solution
Since `populateLocalAddresses()` is idempotent and has no side-effects, we call it again after `populateIPTransportMode`. This ensures the local addresses are set.

## Prevention
There is quite a bit of logic within `populateResolverConfig` in the `cli/worker_manager.go` to set everything up correctly and inform the user early if they provide a set of CLI flags that wouldn't work to try to provide a better UX. It's easy to make mistakes when refactoring even when you yourself wrote the code. 😄 

This PR adds a suite of tests for `populateResolverConfig` that would have flagged the above regression. Hopefully they'll both prevent regressions moving forward and flag other possible ones.