### PR TITLE
[svcb.dohpath] add dohpath extraction when running SVCB queries

### DIFF
--- a/src/zdns/answers.go
+++ b/src/zdns/answers.go
@@ -576,6 +576,8 @@ func makeSVCBAnswer(cAns *dns.SVCB) SVCBAnswer {
 				params[ikv.Key().String()] = kv.ECH
 			case *dns.SVCBIPv6Hint:
 				params[ikv.Key().String()] = kv.Hint
+			case *dns.SVCBDoHPath:
+				params[ikv.Key().String()] = kv.Template
 			case *dns.SVCBLocal: //SVCBLocal is the default case for unknown keys
 				params[ikv.Key().String()] = kv.Data
 			default: //should not happen


### PR DESCRIPTION
When querying SVCB records with ZDNS, it is necessary to also extract the DoH path if given in the reply.
That allows the user to get the right endpoint for a DoH query (especially useful when a non standard endpoint is used).

The SVCBDoHPath is already present in the dns module, it was just not used during evaluation.