### PR TITLE
Add --authenticated-data flag to set AD bit in queries

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -68,6 +68,7 @@ type GeneralOptions struct {
 
 // QueryOptions affect the fields of the actual DNS queries. Applicable to all modules.
 type QueryOptions struct {
+	AuthenticatedData  bool   `long:"authenticated-data" description:"Sends DNS packets with the AD bit set"`
 	CheckingDisabled   bool   `long:"checking-disabled" description:"Sends DNS packets with the CD bit set"`
 	ClassString        string `long:"class" default:"INET" description:"DNS class to query. Options: INET, CSNET, CHAOS, HESIOD, NONE, ANY."`
 	ClientSubnetString string `long:"client-subnet" description:"Client subnet in CIDR format for EDNS0."`

--- a/src/cli/worker_manager.go
+++ b/src/cli/worker_manager.go
@@ -245,6 +245,7 @@ func populateResolverConfig(gc *CLIConf) *zdns.ResolverConfig {
 	config.Retries = gc.Retries
 	config.MaxDepth = gc.MaxDepth
 	config.CheckingDisabledBit = gc.CheckingDisabled
+	config.AuthenticatedDataBit = gc.AuthenticatedData
 	config.ShouldRecycleSockets = !gc.DisableRecycleSockets
 
 	config.ShouldValidateDNSSEC = gc.ValidateDNSSEC

--- a/src/zdns/lookup.go
+++ b/src/zdns/lookup.go
@@ -893,21 +893,21 @@ func (r *Resolver) cachedLookup(ctx context.Context, q Question, nameServer *Nam
 	var status Status
 	if r.dnsOverHTTPSEnabled {
 		r.verboseLog(depth, "****WIRE LOOKUP*** ", DoHProtocol, " ", dns.TypeToString[q.Type], " ", q.Name, " ", nameServer)
-		result, rawResp, status, err = doDoHLookup(lookupCtx, connInfo.httpsClient, q, nameServer, requestIteration, r.ednsOptions, r.dnsSecEnabled, r.checkingDisabledBit)
+		result, rawResp, status, err = doDoHLookup(lookupCtx, connInfo.httpsClient, q, nameServer, requestIteration, r.ednsOptions, r.dnsSecEnabled, r.checkingDisabledBit, r.authenticatedDataBit)
 	} else if r.dnsOverTLSEnabled {
 		r.verboseLog(depth, "****WIRE LOOKUP*** ", DoTProtocol, " ", dns.TypeToString[q.Type], " ", q.Name, " ", nameServer)
-		result, rawResp, status, err = doDoTLookup(lookupCtx, connInfo, q, nameServer, r.rootCAs, r.verifyServerCert, requestIteration, r.ednsOptions, r.dnsSecEnabled, r.checkingDisabledBit)
+		result, rawResp, status, err = doDoTLookup(lookupCtx, connInfo, q, nameServer, r.rootCAs, r.verifyServerCert, requestIteration, r.ednsOptions, r.dnsSecEnabled, r.checkingDisabledBit, r.authenticatedDataBit)
 	} else if connInfo.udpClient != nil {
 		r.verboseLog(depth, "****WIRE LOOKUP*** ", UDPProtocol, " ", dns.TypeToString[q.Type], " ", q.Name, " ", nameServer)
-		result, rawResp, status, err = wireLookupUDP(lookupCtx, connInfo, q, nameServer, r.ednsOptions, requestIteration, r.dnsSecEnabled, r.checkingDisabledBit)
+		result, rawResp, status, err = wireLookupUDP(lookupCtx, connInfo, q, nameServer, r.ednsOptions, requestIteration, r.dnsSecEnabled, r.checkingDisabledBit, r.authenticatedDataBit)
 		if status == StatusTruncated && connInfo.tcpClient != nil {
 			// result truncated, try again with TCP
 			r.verboseLog(depth, "****WIRE LOOKUP*** ", TCPProtocol, " ", dns.TypeToString[q.Type], " ", q.Name, " ", nameServer)
-			result, rawResp, status, err = wireLookupTCP(lookupCtx, connInfo, q, nameServer, r.ednsOptions, requestIteration, r.dnsSecEnabled, r.checkingDisabledBit)
+			result, rawResp, status, err = wireLookupTCP(lookupCtx, connInfo, q, nameServer, r.ednsOptions, requestIteration, r.dnsSecEnabled, r.checkingDisabledBit, r.authenticatedDataBit)
 		}
 	} else if connInfo.tcpClient != nil {
 		r.verboseLog(depth, "****WIRE LOOKUP*** ", TCPProtocol, " ", dns.TypeToString[q.Type], " ", q.Name, " ", nameServer)
-		result, rawResp, status, err = wireLookupTCP(lookupCtx, connInfo, q, nameServer, r.ednsOptions, requestIteration, r.dnsSecEnabled, r.checkingDisabledBit)
+		result, rawResp, status, err = wireLookupTCP(lookupCtx, connInfo, q, nameServer, r.ednsOptions, requestIteration, r.dnsSecEnabled, r.checkingDisabledBit, r.authenticatedDataBit)
 	} else {
 		return &SingleQueryResult{}, false, StatusError, trace, errors.New("no connection info for nameserver")
 	}
@@ -943,7 +943,7 @@ func (r *Resolver) cachedLookup(ctx context.Context, q Question, nameServer *Nam
 	return result, isCached, status, trace, err
 }
 
-func doDoTLookup(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, rootCAs *x509.CertPool, shouldVerifyServerCert, recursive bool, ednsOptions []dns.EDNS0, dnssec bool, checkingDisabled bool) (*SingleQueryResult, *dns.Msg, Status, error) {
+func doDoTLookup(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, rootCAs *x509.CertPool, shouldVerifyServerCert, recursive bool, ednsOptions []dns.EDNS0, dnssec, checkingDisabled, authenticatedData bool) (*SingleQueryResult, *dns.Msg, Status, error) {
 	if util.HasCtxExpired(ctx) {
 		return nil, nil, StatusTimeout, errors.New("context expired")
 	}
@@ -952,6 +952,7 @@ func doDoTLookup(ctx context.Context, connInfo *ConnectionInfo, q Question, name
 	m.Question[0].Qclass = q.Class
 	m.RecursionDesired = recursive
 	m.CheckingDisabled = checkingDisabled
+	m.AuthenticatedData = authenticatedData
 	m.Id = 12345
 
 	m.SetEdns0(1232, dnssec)
@@ -1037,12 +1038,13 @@ func doDoTLookup(ctx context.Context, connInfo *ConnectionInfo, q Question, name
 	return constructSingleQueryResultFromDNSMsg(&res, responseMsg)
 }
 
-func doDoHLookup(ctx context.Context, httpClient *http.Client, q Question, nameServer *NameServer, recursive bool, ednsOptions []dns.EDNS0, dnssec bool, checkingDisabled bool) (*SingleQueryResult, *dns.Msg, Status, error) {
+func doDoHLookup(ctx context.Context, httpClient *http.Client, q Question, nameServer *NameServer, recursive bool, ednsOptions []dns.EDNS0, dnssec, checkingDisabled, authenticatedData bool) (*SingleQueryResult, *dns.Msg, Status, error) {
 	m := new(dns.Msg)
 	m.SetQuestion(dotName(q.Name), q.Type)
 	m.Question[0].Qclass = q.Class
 	m.RecursionDesired = recursive
 	m.CheckingDisabled = checkingDisabled
+	m.AuthenticatedData = authenticatedData
 
 	m.SetEdns0(1232, dnssec)
 	if ednsOpt := m.IsEdns0(); ednsOpt != nil {
@@ -1109,7 +1111,7 @@ func doDoHLookup(ctx context.Context, httpClient *http.Client, q Question, nameS
 }
 
 // wireLookupTCP performs a DNS lookup on-the-wire over TCP with the given parameters
-func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, ednsOptions []dns.EDNS0, recursive, dnssec, checkingDisabled bool) (*SingleQueryResult, *dns.Msg, Status, error) {
+func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, ednsOptions []dns.EDNS0, recursive, dnssec, checkingDisabled, authenticatedData bool) (*SingleQueryResult, *dns.Msg, Status, error) {
 	res := SingleQueryResult{Answers: []any{}, Authorities: []any{}, Additionals: []any{}}
 	res.Resolver = nameServer.String()
 
@@ -1118,6 +1120,7 @@ func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, na
 	m.Question[0].Qclass = q.Class
 	m.RecursionDesired = recursive
 	m.CheckingDisabled = checkingDisabled
+	m.AuthenticatedData = authenticatedData
 
 	m.SetEdns0(1232, dnssec)
 	if ednsOpt := m.IsEdns0(); ednsOpt != nil {
@@ -1169,7 +1172,7 @@ func wireLookupTCP(ctx context.Context, connInfo *ConnectionInfo, q Question, na
 }
 
 // wireLookupUDP performs a DNS lookup on-the-wire over UDP with the given parameters
-func wireLookupUDP(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, ednsOptions []dns.EDNS0, recursive, dnssec, checkingDisabled bool) (*SingleQueryResult, *dns.Msg, Status, error) {
+func wireLookupUDP(ctx context.Context, connInfo *ConnectionInfo, q Question, nameServer *NameServer, ednsOptions []dns.EDNS0, recursive, dnssec, checkingDisabled, authenticatedData bool) (*SingleQueryResult, *dns.Msg, Status, error) {
 	res := SingleQueryResult{Answers: []any{}, Authorities: []any{}, Additionals: []any{}}
 	res.Resolver = nameServer.String()
 	res.Protocol = "udp"
@@ -1179,6 +1182,7 @@ func wireLookupUDP(ctx context.Context, connInfo *ConnectionInfo, q Question, na
 	m.Question[0].Qclass = q.Class
 	m.RecursionDesired = recursive
 	m.CheckingDisabled = checkingDisabled
+	m.AuthenticatedData = authenticatedData
 
 	m.SetEdns0(1232, dnssec)
 	if ednsOpt := m.IsEdns0(); ednsOpt != nil {

--- a/src/zdns/resolver.go
+++ b/src/zdns/resolver.go
@@ -47,6 +47,7 @@ const (
 	defaultRetries               = 1
 	defaultMaxDepth              = 10
 	defaultCheckingDisabledBit   = false // Sends DNS packets with the CD bit set
+	defaultAuthenticatedDataBit  = false // Sends DNS packets with the AD bit set
 	defaultNameServerModeEnabled = false // Treats input as nameservers to query with a static query rather than queries to send to a static name server
 	defaultFollowCNAMEs          = true  // Follow CNAMEs/DNAMEs in iterative queries
 	defaultCacheSize             = 10000
@@ -104,6 +105,7 @@ type ResolverConfig struct {
 	HTTPSClientIPv6      *http.Client   // for DoH, per docs should be shared amongst requests
 	EdnsOptions          []dns.EDNS0
 	CheckingDisabledBit  bool
+	AuthenticatedDataBit bool
 }
 
 // Validate checks if the ResolverConfig is valid, returns an error describing the issue if it is not.
@@ -261,6 +263,7 @@ func NewResolverConfig() *ResolverConfig {
 		DNSSecEnabled:        defaultDNSSECEnabled,
 		ShouldValidateDNSSEC: defaultShouldValidateDNSSEC,
 		CheckingDisabledBit:  defaultCheckingDisabledBit,
+		AuthenticatedDataBit: defaultAuthenticatedDataBit,
 	}
 }
 
@@ -338,13 +341,14 @@ type Resolver struct {
 	shouldValidateDNSSEC bool             // whether to validate DNSSEC
 	validator            *dNSSECValidator // DNSSEC validator for the current lookup
 
-	dnsOverHTTPSEnabled bool           // whether to use DNS over HTTPS for External Lookups, n/a to Iterative Lookups
-	dnsOverTLSEnabled   bool           // whether to use DNS over TLS for External Lookups, n/a to Iterative Lookups
-	rootCAs             *x509.CertPool // Root CAs for DoT/DoH Server Verification
-	verifyServerCert    bool           // Verify server certificates for DoT/DoH
-	ednsOptions         []dns.EDNS0
-	checkingDisabledBit bool
-	isClosed            bool // true if the resolver has been closed, lookup will panic if called after Close
+	dnsOverHTTPSEnabled  bool           // whether to use DNS over HTTPS for External Lookups, n/a to Iterative Lookups
+	dnsOverTLSEnabled    bool           // whether to use DNS over TLS for External Lookups, n/a to Iterative Lookups
+	rootCAs              *x509.CertPool // Root CAs for DoT/DoH Server Verification
+	verifyServerCert     bool           // Verify server certificates for DoT/DoH
+	ednsOptions          []dns.EDNS0
+	checkingDisabledBit  bool
+	authenticatedDataBit bool
+	isClosed             bool // true if the resolver has been closed, lookup will panic if called after Close
 }
 
 // InitResolver creates a new Resolver struct using the ResolverConfig. The Resolver is used to perform DNS lookups.
@@ -394,6 +398,7 @@ func InitResolver(config *ResolverConfig) (*Resolver, error) {
 		shouldValidateDNSSEC: config.ShouldValidateDNSSEC,
 		ednsOptions:          config.EdnsOptions,
 		checkingDisabledBit:  config.CheckingDisabledBit,
+		authenticatedDataBit: config.AuthenticatedDataBit,
 	}
 	log.SetLevel(r.logLevel)
 	// Deep copy local address so Resolver is independent of the config

--- a/testing/integration_tests.py
+++ b/testing/integration_tests.py
@@ -1398,7 +1398,7 @@ class Tests(unittest.TestCase):
 
     def test_edns0_ede_2_cd(self):
         name = "dnssec-failed.org"
-        # using Cloudflare Public DNS (8.8.8.8) that implements EDE, checking disabled resulting in NOERROR
+        # using Google Public DNS (8.8.8.8) that implements EDE, checking disabled resulting in NOERROR
         c = f"A --name-servers=8.8.8.8:53 --checking-disabled"
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd, "A")
@@ -1424,6 +1424,20 @@ class Tests(unittest.TestCase):
         name = "dnssec-failed.org"
         cmd, res = self.run_zdns(c, name)
         self.assertSuccess(res, cmd, "A")
+
+    def test_ad_bit_not_set(self):
+        c = "MX --name-servers=8.8.8.8:53 --include-fields=flags"
+        name = "pm.me"
+        cmd, res = self.run_zdns(c, name)
+        res = res["results"]["MX"]
+        self.assertFalse(res["data"]["flags"]["authenticated"])
+
+    def test_ad_bit_set(self):
+        c = "MX --name-servers=8.8.8.8:53 --authenticated-data --include-fields=flags"
+        name = "pm.me"
+        cmd, res = self.run_zdns(c, name)
+        res = res["results"]["MX"]
+        self.assertTrue(res["data"]["flags"]["authenticated"])
 
     def test_dnssec_validation_secure(self):
         # checks if dnssec validation is performed


### PR DESCRIPTION
I'm looking to add support for setting the AD bit in queries. This is helpful when you have a secure channel to a trusted DNSSEC-validating recursive resolver and you'd like to see if response is secure.

Here's that behavior in dig, using Cloudflare's DNSSEC-validationg recursive resolver Protonmail's DNSSEC signed MX record:

        $ dig @1.1.1.1 MX pm.me
        ...snip...
        ;; flags: qr rd ra ad; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1
        ...snip...
        pm.me.                  1200    IN      MX      5 mail.protonmail.ch.
        pm.me.                  1200    IN      MX      10 mailsec.protonmail.ch.
        ...snip...

Note that "ad" is listed in flags.

A zmap query does not set the AD bit, however.

        $ ./zdns --name-servers 1.1.1.1 --include-fields=flags MX pm.me | jq .results.MX.data.flags.authenticated
        00h:00m:00s; Scan Complete; 1 names scanned; 8.61 names/sec; 100.0% success rate; NOERROR: 1
        false

This pull request adds the `--authenticated-data` flag, allowing the AD bit to be set.

        $ ./zdns --name-servers 1.1.1.1 --include-fields=flags --authenticated-data MX pm.me | jq .results.MX.data.flags.authenticated
        00h:00m:00s; Scan Complete; 1 names scanned; 9.03 names/sec; 100.0% success rate; NOERROR: 1
        true

It may be worth changing zmap to set the AD bit by default, matching dig's behavior. But I have not made that change here and I don't personally have a preference.